### PR TITLE
hotfix(ci): Use GitHub Container Registry instead of Docker Hub

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -172,6 +172,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, build]
     if: needs.setup.outputs.run_full_pipeline == 'true'
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout code
@@ -180,19 +183,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ secrets.DOCKER_USERNAME }}/data-forge-middleware
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr


### PR DESCRIPTION
## Problem
Docker build job was failing because Docker Hub credentials (DOCKER_USERNAME, DOCKER_PASSWORD) are not configured in GitHub Secrets.

## Solution
Replace Docker Hub with GitHub Container Registry (ghcr.io) which uses built-in GITHUB_TOKEN for authentication.

## Changes
- ✅ Replace `docker/login-action` Docker Hub credentials with GitHub Container Registry
- ✅ Use `github.actor` and `GITHUB_TOKEN` for authentication
- ✅ Update image path: `${{ secrets.DOCKER_USERNAME }}/data-forge-middleware` → `ghcr.io/${{ github.repository }}`
- ✅ Add `packages: write` permission to docker-build job

## Testing
- Workflow will automatically run on this branch
- Docker images will be published to `ghcr.io/quantum-soft-dev/data-forge-middleware`

## Impact
- No Docker Hub secrets required
- Images stored in GitHub Packages (same platform as code)
- Automatic authentication using workflow token

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)