### PR TITLE
feat(batch): add COMPLETED_WITH_WARNINGS status and endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,7 @@ aws --endpoint-url=http://localhost:4566 s3 mb s3://dataforge-uploads
 ### DTO Records (Added 2025-10-09 - FR-001, FR-002, FR-003)
 All endpoints now return structured DTO records instead of Map<String, Object>:
 
-- **BatchResponseDto**: id, batchId, siteId, status, s3Path, uploadedFilesCount, totalSize, hasErrors, startedAt, completedAt
+- **BatchResponseDto**: id, batchId, siteId, status (IN_PROGRESS, COMPLETED, COMPLETED_WITH_WARNINGS, FAILED, CANCELLED, NOT_COMPLETED), s3Path, uploadedFilesCount, totalSize, hasErrors, startedAt, completedAt
 - **ErrorLogResponseDto**: id, batchId, severity, message, source, metadata, occurredAt
 - **FileUploadResponseDto**: id, batchId, filename, s3Key, fileSize, checksum, uploadedAt
 - **AccountResponseDto**: id, email, name, isActive, createdAt, maxConcurrentBatches

--- a/frontend/src/entities/batch/model/types.ts
+++ b/frontend/src/entities/batch/model/types.ts
@@ -14,6 +14,7 @@
 export type BatchStatus =
   | 'IN_PROGRESS'
   | 'COMPLETED'
+  | 'COMPLETED_WITH_WARNINGS'
   | 'NOT_COMPLETED'
   | 'FAILED'
   | 'CANCELLED';

--- a/frontend/src/features/upload-history/ui/BatchDetailView.tsx
+++ b/frontend/src/features/upload-history/ui/BatchDetailView.tsx
@@ -141,12 +141,14 @@ export function BatchDetailView({
             className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${
               batch.status === 'COMPLETED'
                 ? 'bg-green-100 text-green-800'
+                : batch.status === 'COMPLETED_WITH_WARNINGS'
+                ? 'bg-yellow-100 text-yellow-800'
                 : batch.status === 'IN_PROGRESS'
                 ? 'bg-blue-100 text-blue-800'
                 : 'bg-red-100 text-red-800'
             }`}
           >
-            {batch.status}
+            {batch.status === 'COMPLETED_WITH_WARNINGS' ? 'Completed (Warnings)' : batch.status}
           </span>
         </div>
 

--- a/frontend/src/features/upload-history/ui/BatchListView.tsx
+++ b/frontend/src/features/upload-history/ui/BatchListView.tsx
@@ -112,6 +112,7 @@ export function BatchListView({
         >
           <option value="all">All Status</option>
           <option value="COMPLETED">Completed</option>
+          <option value="COMPLETED_WITH_WARNINGS">Completed with Warnings</option>
           <option value="IN_PROGRESS">In Progress</option>
           <option value="FAILED">Failed</option>
         </select>
@@ -191,12 +192,14 @@ export function BatchListView({
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
                         batch.status === 'COMPLETED'
                           ? 'bg-green-100 text-green-800'
+                          : batch.status === 'COMPLETED_WITH_WARNINGS'
+                          ? 'bg-yellow-100 text-yellow-800'
                           : batch.status === 'IN_PROGRESS'
                           ? 'bg-blue-100 text-blue-800'
                           : 'bg-red-100 text-red-800'
                       }`}
                     >
-                      {batch.status}
+                      {batch.status === 'COMPLETED_WITH_WARNINGS' ? 'Completed (Warnings)' : batch.status}
                     </span>
                   </div>
                   <div className="mt-0.5 text-xs text-gray-500">

--- a/specs/001-technical-specification-data/contracts/batch-api.md
+++ b/specs/001-technical-specification-data/contracts/batch-api.md
@@ -186,6 +186,62 @@
 
 ---
 
+## POST /api/v1/batch/{batchId}/complete-with-warnings
+
+**Summary**: Mark batch as completed but with non-critical warnings
+
+**Request**:
+- **Headers**:
+  - `Authorization: Bearer {jwt_token}` (required)
+- **Path Parameters**:
+  - `batchId` (UUID, required): Batch identifier
+- **Body**: None
+
+**Responses**:
+
+### 200 OK - Batch completed with warnings
+```json
+{
+  "batchId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "status": "COMPLETED_WITH_WARNINGS",
+  "completedAt": "2025-10-06T10:45:00Z",
+  "uploadedFilesCount": 15,
+  "totalSize": 45678900,
+  "hasErrors": false
+}
+```
+
+### 400 Bad Request - Batch already completed
+```json
+{
+  "timestamp": "2025-10-06T10:30:00Z",
+  "status": 400,
+  "error": "Bad Request",
+  "message": "Batch is already completed",
+  "path": "/api/v1/batch/{batchId}/complete-with-warnings"
+}
+```
+
+### 401 Unauthorized - Batch does not belong to site
+```json
+{
+  "timestamp": "2025-10-06T10:30:00Z",
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Batch does not belong to this site",
+  "path": "/api/v1/batch/{batchId}/complete-with-warnings"
+}
+```
+
+**Business Rules**:
+- Batch must be in IN_PROGRESS status
+- Batch must belong to authenticated site
+- After completion, no more file uploads allowed
+- Transition to COMPLETED_WITH_WARNINGS status
+- `hasErrors` remains `false` (warnings ≠ errors)
+
+---
+
 ## POST /api/v1/batch/{batchId}/fail
 
 **Summary**: Mark batch as failed due to critical error
@@ -327,6 +383,35 @@
     responses:
       '200':
         description: Batch completed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchCompleteResponse'
+      '400':
+        $ref: '#/components/responses/BadRequest'
+      '401':
+        $ref: '#/components/responses/Unauthorized'
+      '404':
+        $ref: '#/components/responses/NotFound'
+
+/api/v1/batch/{batchId}/complete-with-warnings:
+  post:
+    summary: Complete batch with warnings
+    operationId: completeBatchWithWarnings
+    tags:
+      - Batch
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: batchId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '200':
+        description: Batch completed with warnings
         content:
           application/json:
             schema:

--- a/specs/001-technical-specification-data/data-model.md
+++ b/specs/001-technical-specification-data/data-model.md
@@ -134,18 +134,20 @@ CREATE INDEX idx_sites_is_active ON sites(is_active);
 **Enum: BatchStatus**
 - `IN_PROGRESS` - Active upload session (only one per site allowed)
 - `COMPLETED` - Successfully finished by client
+- `COMPLETED_WITH_WARNINGS` - Successfully finished but with non-critical warnings
 - `NOT_COMPLETED` - Expired via timeout without explicit completion
 - `FAILED` - Marked as failed by client due to critical error
 - `CANCELLED` - Cancelled by client
 
 **State Transitions** (enforced by domain logic):
 ```
-IN_PROGRESS → COMPLETED   (client calls /complete)
-IN_PROGRESS → FAILED      (client calls /fail)
-IN_PROGRESS → CANCELLED   (client calls /cancel)
-IN_PROGRESS → NOT_COMPLETED (timeout scheduler)
+IN_PROGRESS → COMPLETED               (client calls /complete)
+IN_PROGRESS → COMPLETED_WITH_WARNINGS (client calls /complete-with-warnings)
+IN_PROGRESS → FAILED                  (client calls /fail)
+IN_PROGRESS → CANCELLED               (client calls /cancel)
+IN_PROGRESS → NOT_COMPLETED           (timeout scheduler)
 ```
-- No transitions allowed FROM terminal states (COMPLETED, FAILED, CANCELLED, NOT_COMPLETED)
+- No transitions allowed FROM terminal states (COMPLETED, COMPLETED_WITH_WARNINGS, FAILED, CANCELLED, NOT_COMPLETED)
 - File uploads only allowed IN `IN_PROGRESS` status
 
 **Relationships**:
@@ -174,7 +176,7 @@ CREATE TABLE batches (
     started_at TIMESTAMP NOT NULL,
     completed_at TIMESTAMP,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT chk_batch_status CHECK (status IN ('IN_PROGRESS', 'COMPLETED', 'NOT_COMPLETED', 'FAILED', 'CANCELLED'))
+    CONSTRAINT chk_batch_status CHECK (status IN ('IN_PROGRESS', 'COMPLETED', 'COMPLETED_WITH_WARNINGS', 'NOT_COMPLETED', 'FAILED', 'CANCELLED'))
 );
 
 CREATE INDEX idx_batches_site_id ON batches(site_id);

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchLifecycleService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchLifecycleService.java
@@ -146,6 +146,35 @@ public class BatchLifecycleService {
     }
 
     /**
+     * Complete batch with warnings.
+     * <p>
+     * Marks batch as completed but with non-critical warnings.
+     * Validates batch is IN_PROGRESS before completion.
+     * </p>
+     *
+     * @param batchId batch identifier
+     * @return completed batch with warnings
+     * @throws BatchNotFoundException         if batch not found
+     * @throws InvalidBatchStatusException if batch is not IN_PROGRESS
+     */
+    public Batch completeBatchWithWarnings(UUID batchId) {
+        logger.info("Completing batch with warnings: batchId={}", batchId);
+
+        Batch batch = getBatch(batchId);
+        validateStatus(batch, BatchStatus.IN_PROGRESS, "complete with warnings");
+
+        batch.completeWithWarnings();
+        Batch saved = batchRepository.save(batch);
+
+        // Publish domain event (same as regular complete)
+        BatchCompletedEvent event = new BatchCompletedEvent(batchId, batch.getUploadedFilesCount(), batch.getTotalSize());
+        eventPublisher.publishEvent(event);
+
+        logger.info("Batch completed with warnings: batchId={}", batchId);
+        return saved;
+    }
+
+    /**
      * Fail batch with error.
      * <p>
      * Validates batch is IN_PROGRESS before failing.

--- a/src/main/java/com/bitbi/dfm/batch/domain/Batch.java
+++ b/src/main/java/com/bitbi/dfm/batch/domain/Batch.java
@@ -113,6 +113,12 @@ public class Batch {
         this.completedAt = LocalDateTime.now();
     }
 
+    public void completeWithWarnings() {
+        status.validateTransition(BatchStatus.COMPLETED_WITH_WARNINGS);
+        this.status = BatchStatus.COMPLETED_WITH_WARNINGS;
+        this.completedAt = LocalDateTime.now();
+    }
+
     public void fail() {
         status.validateTransition(BatchStatus.FAILED);
         this.status = BatchStatus.FAILED;

--- a/src/main/java/com/bitbi/dfm/batch/domain/BatchStatus.java
+++ b/src/main/java/com/bitbi/dfm/batch/domain/BatchStatus.java
@@ -8,13 +8,14 @@ package com.bitbi.dfm.batch.domain;
  *
  * <h3>State Transitions:</h3>
  * <pre>
- * IN_PROGRESS → COMPLETED     (client calls /complete)
- * IN_PROGRESS → FAILED         (client calls /fail)
- * IN_PROGRESS → CANCELLED      (client calls /cancel)
- * IN_PROGRESS → NOT_COMPLETED  (timeout scheduler)
+ * IN_PROGRESS → COMPLETED               (client calls /complete)
+ * IN_PROGRESS → COMPLETED_WITH_WARNINGS (client calls /complete-with-warnings)
+ * IN_PROGRESS → FAILED                  (client calls /fail)
+ * IN_PROGRESS → CANCELLED               (client calls /cancel)
+ * IN_PROGRESS → NOT_COMPLETED           (timeout scheduler)
  * </pre>
  *
- * <p>Terminal states (COMPLETED, FAILED, CANCELLED, NOT_COMPLETED) are immutable.</p>
+ * <p>Terminal states (COMPLETED, COMPLETED_WITH_WARNINGS, FAILED, CANCELLED, NOT_COMPLETED) are immutable.</p>
  *
  * @author Data Forge Team
  * @version 1.0.0
@@ -31,6 +32,12 @@ public enum BatchStatus {
      * Terminal state - no further uploads or transitions allowed.
      */
     COMPLETED,
+
+    /**
+     * Successfully finished but with non-critical warnings.
+     * Terminal state - files uploaded successfully but had issues.
+     */
+    COMPLETED_WITH_WARNINGS,
 
     /**
      * Expired via timeout without explicit completion.
@@ -100,6 +107,7 @@ public enum BatchStatus {
         // Explicit state machine validation for IN_PROGRESS
         if (this == IN_PROGRESS) {
             boolean isValidTransition = targetStatus == COMPLETED ||
+                                       targetStatus == COMPLETED_WITH_WARNINGS ||
                                        targetStatus == NOT_COMPLETED ||
                                        targetStatus == FAILED ||
                                        targetStatus == CANCELLED;
@@ -107,7 +115,7 @@ public enum BatchStatus {
             if (!isValidTransition) {
                 throw new IllegalStateException(
                         String.format("Invalid transition from %s to %s. " +
-                                     "Allowed: COMPLETED, NOT_COMPLETED, FAILED, CANCELLED",
+                                     "Allowed: COMPLETED, COMPLETED_WITH_WARNINGS, NOT_COMPLETED, FAILED, CANCELLED",
                                      this, targetStatus)
                 );
             }

--- a/src/main/java/com/bitbi/dfm/batch/presentation/BatchController.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/BatchController.java
@@ -140,6 +140,55 @@ public class BatchController {
     }
 
     /**
+     * Complete batch with warnings.
+     * <p>
+     * POST /api/v1/batch/{id}/complete-with-warnings
+     * </p>
+     *
+     * @param batchId batch identifier
+     * @return completed batch response with warnings status
+     */
+    @PostMapping("/{id}/complete-with-warnings")
+    public ResponseEntity<?> completeBatchWithWarnings(
+            @PathVariable("id") UUID batchId) {
+
+        try {
+            logger.info("Completing batch with warnings: batchId={}", batchId);
+
+            // Get batch first to verify ownership
+            Batch batch = batchLifecycleService.getBatch(batchId);
+
+            // Verify site ownership
+            authorizationHelper.verifySiteOwnership(batch.getSiteId());
+
+            batch = batchLifecycleService.completeBatchWithWarnings(batchId);
+
+            BatchResponseDto response = BatchResponseDto.fromEntity(batch);
+            return ResponseEntity.ok(response);
+
+        } catch (AuthorizationHelper.UnauthorizedException e) {
+            logger.warn("Unauthorized batch completion with warnings: batchId={}, {}", batchId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(createErrorResponse(HttpStatus.FORBIDDEN, e.getMessage()));
+
+        } catch (BatchLifecycleService.BatchNotFoundException e) {
+            logger.warn("Batch not found: {}", batchId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(createErrorResponse(HttpStatus.NOT_FOUND, "Batch not found"));
+
+        } catch (BatchLifecycleService.InvalidBatchStatusException e) {
+            logger.warn("Invalid batch status: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(createErrorResponse(HttpStatus.BAD_REQUEST, e.getMessage()));
+
+        } catch (Exception e) {
+            logger.error("Error completing batch with warnings: batchId={}", batchId, e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(createErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to complete batch with warnings"));
+        }
+    }
+
+    /**
      * Fail batch with error.
      * <p>
      * POST /api/v1/batch/{id}/fail

--- a/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchResponseDto.java
@@ -19,7 +19,7 @@ import java.util.UUID;
  * @param id Unique batch identifier
  * @param batchId Alias for id (backward compatibility)
  * @param siteId Site that owns this batch
- * @param status Current batch status (IN_PROGRESS, COMPLETED, FAILED, CANCELLED, NOT_COMPLETED)
+ * @param status Current batch status (IN_PROGRESS, COMPLETED, COMPLETED_WITH_WARNINGS, FAILED, CANCELLED, NOT_COMPLETED)
  * @param s3Path S3 path prefix for uploaded files
  * @param uploadedFilesCount Number of files uploaded to this batch
  * @param totalSize Total size of all uploaded files in bytes

--- a/src/main/java/com/bitbi/dfm/device/presentation/DeviceBatchController.java
+++ b/src/main/java/com/bitbi/dfm/device/presentation/DeviceBatchController.java
@@ -221,6 +221,91 @@ public class DeviceBatchController {
     }
 
     /**
+     * Complete batch with warnings.
+     * <p>
+     * Marks an IN_PROGRESS batch as COMPLETED_WITH_WARNINGS. Use this when the batch
+     * completes but with non-critical warnings (e.g., data quality issues that don't
+     * prevent processing).
+     * </p>
+     * <p>
+     * Key differences from regular completion:
+     * <ul>
+     *   <li>Status set to COMPLETED_WITH_WARNINGS instead of COMPLETED</li>
+     *   <li>hasErrors remains false (warnings ≠ errors)</li>
+     *   <li>Data is still considered valid for processing</li>
+     * </ul>
+     * </p>
+     *
+     * @param batchId Batch identifier (path variable)
+     * @return 200 OK with updated batch details, or error response
+     */
+    @PostMapping("/{id}/complete-with-warnings")
+    @Operation(
+            summary = "Complete batch with warnings",
+            description = "Marks an IN_PROGRESS batch as COMPLETED_WITH_WARNINGS. " +
+                    "Use this when the batch completes successfully but with non-critical warnings. " +
+                    "hasErrors remains false (warnings are not errors)."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Batch completed with warnings",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BatchResponseDto.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Bad Request - Invalid batch status transition",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Forbidden - Batch not owned by authenticated site",
+                    content = @Content(mediaType = "application/json")
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Not Found - Batch does not exist",
+                    content = @Content(mediaType = "application/json")
+            )
+    })
+    public ResponseEntity<?> completeBatchWithWarnings(@PathVariable("id") UUID batchId) {
+        try {
+            logger.info("Device API: Completing batch with warnings - batchId={}", batchId);
+
+            // Get batch first to verify ownership
+            Batch batch = batchLifecycleService.getBatch(batchId);
+
+            // Verify site ownership via JWT claims
+            authorizationHelper.verifySiteOwnership(batch.getSiteId());
+
+            // Delegate to service layer
+            batch = batchLifecycleService.completeBatchWithWarnings(batchId);
+
+            BatchResponseDto response = BatchResponseDto.fromEntity(batch);
+            return ResponseEntity.ok(response);
+
+        } catch (AuthorizationHelper.UnauthorizedException e) {
+            logger.warn("Device API: Unauthorized batch completion with warnings - batchId={}, {}", batchId, e.getMessage());
+            return DeviceControllerHelper.handleUnauthorizedException(e);
+
+        } catch (BatchLifecycleService.BatchNotFoundException e) {
+            logger.warn("Device API: Batch not found - batchId={}", batchId);
+            return DeviceControllerHelper.handleBatchNotFoundException(e);
+
+        } catch (BatchLifecycleService.InvalidBatchStatusException e) {
+            logger.warn("Device API: Invalid batch status - {}", e.getMessage());
+            return DeviceControllerHelper.handleInvalidBatchStatusException(e);
+
+        } catch (Exception e) {
+            logger.error("Device API: Error completing batch with warnings - batchId={}", batchId, e);
+            return DeviceControllerHelper.handleInternalServerError("Failed to complete batch with warnings");
+        }
+    }
+
+    /**
      * Fail batch due to error.
      * <p>
      * Marks an IN_PROGRESS batch as FAILED. Use this when an unrecoverable error

--- a/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
+++ b/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
@@ -75,6 +75,17 @@ public final class ApiRoutes {
     public static final String DEVICE_BATCHES_COMPLETE = DEVICE_BATCHES + "/{id}/complete";
 
     /**
+     * Complete batch with warnings endpoint.
+     * <p>
+     * Method: POST<br>
+     * Path Variable: {id} - Batch ID<br>
+     * Authentication: Custom JWT<br>
+     * Returns: BatchResponseDto with COMPLETED_WITH_WARNINGS status
+     * </p>
+     */
+    public static final String DEVICE_BATCHES_COMPLETE_WITH_WARNINGS = DEVICE_BATCHES + "/{id}/complete-with-warnings";
+
+    /**
      * Mark batch as failed endpoint.
      * <p>
      * Method: POST<br>

--- a/src/main/resources/db/migration/V7__add_completed_with_warnings_status.sql
+++ b/src/main/resources/db/migration/V7__add_completed_with_warnings_status.sql
@@ -1,0 +1,16 @@
+-- Migration: V7__add_completed_with_warnings_status.sql
+-- Description: Add COMPLETED_WITH_WARNINGS status to batches table
+-- Author: Data Forge Team
+-- Date: 2025-12-15
+
+-- Drop existing constraint
+ALTER TABLE batches
+DROP CONSTRAINT chk_batch_status;
+
+-- Add updated constraint with new status
+ALTER TABLE batches
+ADD CONSTRAINT chk_batch_status
+CHECK (status IN ('IN_PROGRESS', 'COMPLETED', 'COMPLETED_WITH_WARNINGS', 'NOT_COMPLETED', 'FAILED', 'CANCELLED'));
+
+-- Update column comment
+COMMENT ON COLUMN batches.status IS 'Lifecycle state (IN_PROGRESS, COMPLETED, COMPLETED_WITH_WARNINGS, NOT_COMPLETED, FAILED, CANCELLED)';

--- a/src/test/java/com/bitbi/dfm/batch/domain/BatchStatusTest.java
+++ b/src/test/java/com/bitbi/dfm/batch/domain/BatchStatusTest.java
@@ -26,6 +26,16 @@ class BatchStatusTest {
     }
 
     @Test
+    @DisplayName("Should allow valid transition from IN_PROGRESS to COMPLETED_WITH_WARNINGS")
+    void shouldAllowTransitionToCompletedWithWarnings() {
+        // Given
+        BatchStatus status = BatchStatus.IN_PROGRESS;
+
+        // When/Then - should not throw
+        status.validateTransition(BatchStatus.COMPLETED_WITH_WARNINGS);
+    }
+
+    @Test
     @DisplayName("Should allow valid transition from IN_PROGRESS to NOT_COMPLETED")
     void shouldAllowTransitionToNotCompleted() {
         // Given
@@ -116,10 +126,23 @@ class BatchStatusTest {
     }
 
     @Test
+    @DisplayName("Should reject transition from COMPLETED_WITH_WARNINGS to any state")
+    void shouldRejectTransitionFromCompletedWithWarnings() {
+        // Given
+        BatchStatus status = BatchStatus.COMPLETED_WITH_WARNINGS;
+
+        // When/Then
+        assertThatThrownBy(() -> status.validateTransition(BatchStatus.IN_PROGRESS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Cannot transition from terminal status COMPLETED_WITH_WARNINGS");
+    }
+
+    @Test
     @DisplayName("Should correctly identify terminal states")
     void shouldIdentifyTerminalStates() {
         // Terminal states
         assertThat(BatchStatus.COMPLETED.isTerminal()).isTrue();
+        assertThat(BatchStatus.COMPLETED_WITH_WARNINGS.isTerminal()).isTrue();
         assertThat(BatchStatus.FAILED.isTerminal()).isTrue();
         assertThat(BatchStatus.CANCELLED.isTerminal()).isTrue();
         assertThat(BatchStatus.NOT_COMPLETED.isTerminal()).isTrue();
@@ -136,6 +159,7 @@ class BatchStatusTest {
 
         // Reject uploads in terminal states
         assertThat(BatchStatus.COMPLETED.allowsFileUpload()).isFalse();
+        assertThat(BatchStatus.COMPLETED_WITH_WARNINGS.allowsFileUpload()).isFalse();
         assertThat(BatchStatus.FAILED.allowsFileUpload()).isFalse();
         assertThat(BatchStatus.CANCELLED.allowsFileUpload()).isFalse();
         assertThat(BatchStatus.NOT_COMPLETED.allowsFileUpload()).isFalse();

--- a/src/test/java/com/bitbi/dfm/device/presentation/DeviceBatchContractTest.java
+++ b/src/test/java/com/bitbi/dfm/device/presentation/DeviceBatchContractTest.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * <ul>
  *   <li>POST /api/v1/device/batches/start - Start new batch</li>
  *   <li>POST /api/v1/device/batches/{id}/complete - Complete batch</li>
+ *   <li>POST /api/v1/device/batches/{id}/complete-with-warnings - Complete batch with warnings</li>
  *   <li>POST /api/v1/device/batches/{id}/fail - Fail batch</li>
  *   <li>POST /api/v1/device/batches/{id}/cancel - Cancel batch</li>
  *   <li>GET /api/v1/device/batches/{id} - Get batch details</li>
@@ -262,6 +263,51 @@ class DeviceBatchContractTest extends BaseIntegrationTest {
         String completedBatchId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"; // COMPLETED batch
 
         mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_COMPLETE, completedBatchId)
+                        .header("Authorization", "Bearer " + jwtToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"));
+    }
+
+    /**
+     * TC23: Complete batch with warnings should return 200 OK with COMPLETED_WITH_WARNINGS status.
+     * <p>
+     * <b>Given</b>: An IN_PROGRESS batch owned by the authenticated site<br>
+     * <b>When</b>: POST /api/v1/device/batches/{id}/complete-with-warnings<br>
+     * <b>Then</b>: 200 OK with batch status=COMPLETED_WITH_WARNINGS, hasErrors=false
+     * </p>
+     */
+    @Test
+    @DisplayName("TC23: Should complete batch with warnings and return COMPLETED_WITH_WARNINGS status")
+    void shouldCompleteBatchWithWarningsAndReturnCorrectStatus() throws Exception {
+        String batchId = "b1c2d3e4-f5a6-7890-bcde-f12345678903"; // IN_PROGRESS batch from test data
+
+        mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_COMPLETE_WITH_WARNINGS, batchId)
+                        .header("Authorization", "Bearer " + jwtToken)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(batchId))
+                .andExpect(jsonPath("$.status").value("COMPLETED_WITH_WARNINGS"))
+                .andExpect(jsonPath("$.hasErrors").value(false))
+                .andExpect(jsonPath("$.completedAt").exists());
+    }
+
+    /**
+     * TC24: Complete already completed batch with warnings should return 400 Bad Request.
+     * <p>
+     * <b>Given</b>: A batch that is already COMPLETED<br>
+     * <b>When</b>: POST /api/v1/device/batches/{id}/complete-with-warnings<br>
+     * <b>Then</b>: 400 Bad Request (invalid status transition)
+     * </p>
+     */
+    @Test
+    @DisplayName("TC24: Should return 400 when completing with warnings on already completed batch")
+    void shouldReturn400WhenCompletingWithWarningsOnAlreadyCompletedBatch() throws Exception {
+        String completedBatchId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"; // COMPLETED batch
+
+        mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_COMPLETE_WITH_WARNINGS, completedBatchId)
                         .header("Authorization", "Bearer " + jwtToken)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())

--- a/src/test/java/com/bitbi/dfm/integration/BatchCompletionIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/BatchCompletionIntegrationTest.java
@@ -102,4 +102,66 @@ class BatchCompletionIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.id").exists())
                 .andExpect(jsonPath("$.batchId").exists());
     }
+
+    @Test
+    @DisplayName("Should complete batch with warnings and transition to COMPLETED_WITH_WARNINGS status")
+    void shouldCompleteBatchWithWarningsAndTransitionToCorrectStatus() throws Exception {
+        // Given: Batch with uploaded files
+        // When: POST /api/v1/device/batches/{id}/complete-with-warnings
+        mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_COMPLETE_WITH_WARNINGS, IN_PROGRESS_MOCK_BATCH_ID)
+                        .header("Authorization", generateTestToken()))
+
+                // Then: Batch completed with warnings (200 OK with BatchResponseDto)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.batchId").value(IN_PROGRESS_MOCK_BATCH_ID))
+                .andExpect(jsonPath("$.status").value("COMPLETED_WITH_WARNINGS"))
+                .andExpect(jsonPath("$.hasErrors").value(false))
+                .andExpect(jsonPath("$.completedAt").exists())
+                .andExpect(jsonPath("$.uploadedFilesCount").isNumber())
+                .andExpect(jsonPath("$.totalSize").isNumber());
+    }
+
+    @Test
+    @DisplayName("Should prevent file upload after batch completed with warnings")
+    void shouldPreventFileUploadAfterBatchCompletedWithWarnings() throws Exception {
+        // Given: Batch completed with warnings
+        mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_COMPLETE_WITH_WARNINGS, IN_PROGRESS_MOCK_BATCH_ID)
+                        .header("Authorization", generateTestToken()))
+                .andExpect(status().isOk());
+
+        // When: Attempt to upload file
+        MockMultipartFile file = new MockMultipartFile(
+                "files", "late-file.csv.gz", "application/gzip",
+                "late content".getBytes()
+        );
+
+        mockMvc.perform(multipart(ApiRoutes.DEVICE_FILES_UPLOAD, IN_PROGRESS_MOCK_BATCH_ID)
+                        .file(file)
+                        .header("Authorization", generateTestToken()))
+
+                // Then: 409 Conflict (batch is already completed with warnings)
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.status").value(409))
+                .andExpect(jsonPath("$.error").value("Conflict"))
+                .andExpect(jsonPath("$.message").value("Cannot upload files to batch with status: COMPLETED_WITH_WARNINGS"));
+    }
+
+    @Test
+    @DisplayName("Should allow new batch after completion with warnings")
+    void shouldAllowNewBatchAfterCompletionWithWarnings() throws Exception {
+        // Given: Previous batch completed with warnings
+        mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_COMPLETE_WITH_WARNINGS, IN_PROGRESS_MOCK_BATCH_ID)
+                        .header("Authorization", generateTestToken()))
+                .andExpect(status().isOk());
+
+        // When: Start new batch
+        mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_START)
+                        .header("Authorization", generateTestToken()))
+
+                // Then: Success (201 Created with BatchResponseDto)
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").exists())
+                .andExpect(jsonPath("$.batchId").exists());
+    }
 }


### PR DESCRIPTION
## Summary
- Add new terminal batch status `COMPLETED_WITH_WARNINGS` for batches that complete successfully but with non-critical warnings
- Add `POST /api/v1/batch/{id}/complete-with-warnings` endpoint
- Update documentation (data-model.md, batch-api.md, CLAUDE.md)

## Key Behavior
- `hasErrors` remains `false` (warnings ≠ errors)
- Terminal state (no further transitions allowed)
- Publishes `BatchCompletedEvent` like regular complete

## New State Machine
```
IN_PROGRESS → COMPLETED | COMPLETED_WITH_WARNINGS | FAILED | CANCELLED | NOT_COMPLETED
```

## API
```
POST /api/v1/batch/{id}/complete-with-warnings
Authorization: Bearer <JWT>

Response 200:
{
  "status": "COMPLETED_WITH_WARNINGS",
  "hasErrors": false,
  ...
}
```

## Test plan
- [x] Unit tests pass (`BatchStatusTest`, `BatchTest`)
- [x] Compilation successful
- [ ] Manual API testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)