### PR TITLE
feat(plugin): SQL generation for Bit BI + My Plugins dashboard widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -654,9 +654,91 @@ auth0:
 - [ ] Multi-part upload for large files (>5GB)
 
 <!-- MANUAL ADDITIONS START -->
+
+### My Plugins Dashboard Widget (Added 2025-12-22)
+
+**Feature**: User-facing plugin management widget on the Dashboard allowing users to view, activate, and deactivate plugins.
+
+#### User Capabilities
+- View list of activated plugins with status (active/inactive)
+- View available plugins that can be activated
+- Activate new plugins with required configuration (e.g., tenantId for Bit BI)
+- Deactivate plugins that are no longer needed
+- See last used timestamp for each plugin
+
+#### Frontend Structure (Feature-Sliced Design)
+```
+frontend/src/
+├── features/my-plugins/
+│   ├── api/
+│   │   ├── myPluginsApi.ts           # API client functions
+│   │   ├── myPluginsQueries.ts       # useAccountPluginsQuery, useAvailablePluginsQuery
+│   │   ├── myPluginsMutations.ts     # useActivatePluginMutation, useDeactivatePluginMutation
+│   │   └── __tests__/                # 14 tests
+│   ├── model/
+│   │   └── types.ts                  # AccountPluginSummary, ActivatePluginRequest, etc.
+│   ├── ui/
+│   │   ├── PluginCard.tsx            # Individual plugin card with status and actions
+│   │   ├── PluginList.tsx            # Grid of plugin cards with loading/error states
+│   │   ├── PluginActivationDialog.tsx # Dialog for plugin activation with form
+│   │   └── __tests__/                # 44 tests
+│   └── index.ts
+├── widgets/my-plugins/
+│   ├── MyPluginsWidget.tsx           # Container widget for Dashboard
+│   ├── index.ts
+│   └── __tests__/                    # 10 tests
+└── pages/dashboard/
+    └── DashboardPage.tsx             # Integrates MyPluginsWidget
+```
+
+#### API Endpoints Used
+| Operation | Endpoint | Method |
+|-----------|----------|--------|
+| List user's plugins | `GET /api/v1/account/plugins` | Query |
+| List available plugins | `GET /api/v1/admin/plugins` | Query |
+| Activate plugin | `POST /api/v1/plugins/{pluginId}/activate` | Mutation |
+| Deactivate plugin | `DELETE /api/v1/plugins/{pluginId}/deactivate` | Mutation |
+
+#### API Routes (Frontend)
+```typescript
+// frontend/src/shared/api/apiRoutes.ts
+export const ACCOUNT_PLUGINS = `${ADMIN_API_BASE}/account/plugins`;
+export const PLUGINS = `${ADMIN_API_BASE}/plugins`;
+export const PLUGINS_ACTIVATE = (pluginId: string) => `${PLUGINS}/${pluginId}/activate`;
+export const PLUGINS_DEACTIVATE = (pluginId: string) => `${PLUGINS}/${pluginId}/deactivate`;
+```
+
+#### Query Keys (TanStack Query)
+```typescript
+// frontend/src/entities/plugin/api/keys.ts
+pluginKeys = {
+  // ... existing keys ...
+  accountPlugins: () => [...pluginKeys.all, 'account'] as const,
+  accountPluginList: (includeInactive: boolean) =>
+    [...pluginKeys.accountPlugins(), { includeInactive }] as const,
+}
+```
+
+#### Test Coverage
+- **API layer**: 14 tests (queries + mutations)
+- **UI components**: 44 tests (PluginCard, PluginList, PluginActivationDialog)
+- **Widget**: 10 tests (MyPluginsWidget integration)
+- **Total**: 68 tests
+
+#### Plugin-Specific Configuration
+Bit BI plugin requires `tenantId` in the pluginData:
+```typescript
+interface BitBiPluginData {
+  tenantId: string;
+}
+```
+
+The PluginActivationDialog detects the plugin type and shows appropriate form fields.
+
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
 - 001-plugin-sql-generation: Added Java 21 (LTS) with Spring Boot 3.5.6 + Spring Boot 3.5.6, Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (ApplicationEventPublisher), Hypersistence Utils (JSONB), Apache Commons CSV 1.12.0, java-diff-utils 4.12, ICU4J 76.1
 - 013-plugin-system: Added Admin UI for plugin administration at `/admin/plugins` with registered plugins list and audit logs with filtering
 - 013-plugin-system: Added Java 21 (LTS) with Spring Boot 3.5.6 + Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (`ApplicationEventPublisher`), Hypersistence Utils (JSONB types), json-schema-validator (1.5.4)
+- 013-plugin-system: Added My Plugins Dashboard widget for user-facing plugin management with activation/deactivation capabilities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-02
 - Java 21 (LTS) with Spring Boot 3.5.6 + Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (`ApplicationEventPublisher`), Hypersistence Utils (JSONB types) (013-plugin-system)
 - PostgreSQL 16 (new tables: `plugin_configs`, `account_plugins`, `plugin_audit_logs` - partitioned) (013-plugin-system)
 - Java 21 (LTS) with Spring Boot 3.5.6 + Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (`ApplicationEventPublisher`), Hypersistence Utils (JSONB types), json-schema-validator (1.5.4) (013-plugin-system)
+- Java 21 (LTS) with Spring Boot 3.5.6 + Spring Boot 3.5.6, Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (ApplicationEventPublisher), Hypersistence Utils (JSONB), Apache Commons CSV 1.12.0, java-diff-utils 4.12, ICU4J 76.1 (001-plugin-sql-generation)
+- PostgreSQL 16 (new table: `plugin_sql_generations`), AWS S3 (SQL file storage at `plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql`) (001-plugin-sql-generation)
 
 ### Backend Stack
 - **Java 21** (LTS) with modern language features
@@ -655,6 +657,6 @@ auth0:
 <!-- MANUAL ADDITIONS END -->
 
 ## Recent Changes
+- 001-plugin-sql-generation: Added Java 21 (LTS) with Spring Boot 3.5.6 + Spring Boot 3.5.6, Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (ApplicationEventPublisher), Hypersistence Utils (JSONB), Apache Commons CSV 1.12.0, java-diff-utils 4.12, ICU4J 76.1
 - 013-plugin-system: Added Admin UI for plugin administration at `/admin/plugins` with registered plugins list and audit logs with filtering
 - 013-plugin-system: Added Java 21 (LTS) with Spring Boot 3.5.6 + Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (`ApplicationEventPublisher`), Hypersistence Utils (JSONB types), json-schema-validator (1.5.4)
-- 013-plugin-system: Added Java 21 (LTS) with Spring Boot 3.5.6 + Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (`ApplicationEventPublisher`), Hypersistence Utils (JSONB types)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,8 @@ dependencies {
     implementation("com.networknt:json-schema-validator:1.5.4")
     // Rate limiting for Plugin API
     implementation("com.bucket4j:bucket4j-core:8.10.1")
+    // Caffeine cache for rate limiter (prevents memory leak)
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,8 @@ dependencies {
     // Plugin System Dependencies
     // JSON Schema validation for plugin data
     implementation("com.networknt:json-schema-validator:1.5.4")
+    // Rate limiting for Plugin API
+    implementation("com.bucket4j:bucket4j-core:8.10.1")
 
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,6 @@ repositories {
     mavenCentral()
 }
 
-extra["testcontainersVersion"] = "1.20.2"
 extra["awsSdkVersion"] = "2.28.11"
 
 dependencies {
@@ -101,12 +100,13 @@ dependencies {
     // Test Dependencies
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
-    testImplementation(platform("org.testcontainers:testcontainers-bom:${property("testcontainersVersion")}"))
-    testImplementation("org.testcontainers:testcontainers")
-    testImplementation("org.testcontainers:junit-jupiter")
-    testImplementation("org.testcontainers:postgresql")
-    testImplementation("org.testcontainers:localstack")
+    // Testcontainers 2.0.3 for Docker Desktop 29.x compatibility
+    testImplementation("org.testcontainers:testcontainers:2.0.3")
+    testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.3")
+    testImplementation("org.testcontainers:testcontainers-postgresql:2.0.3")
+    testImplementation("org.testcontainers:testcontainers-localstack:2.0.3")
     testImplementation("org.awaitility:awaitility:4.2.2")
+    // Docker 29.x compatibility handled by Testcontainers 2.0.2+
 }
 
 

--- a/docs/plugin-system-functinal.md
+++ b/docs/plugin-system-functinal.md
@@ -1,0 +1,533 @@
+# Plugin SQL Generation Extension (PRD-013b)
+
+**Feature Branch**: `013-plugin-system`
+**Created**: 2025-12-22
+**Status**: Draft
+**Extends**: PRD-013 (Plugin System & Bit BI OAuth Integration)
+
+## Overview
+
+Расширение плагин-системы (PRD-013) для автоматической генерации SQL файлов на основе различий между последовательными загрузками батчей.
+
+### Ключевые возможности:
+1. Автоматическая генерация diff при завершении загрузки батча
+2. Создание PostgreSQL SQL файлов на основе результатов diff
+3. Plugin API endpoints для получения SQL изменений по сайту и дате
+
+---
+
+## User Stories
+
+### User Story 1 - Автоматическая генерация Diff (Priority: P1)
+
+После завершения загрузки батча для аккаунта с активированным плагином Bit BI система автоматически сравнивает все файлы текущего батча с предыдущим батчем того же сайта.
+
+**Acceptance Scenarios:**
+
+1. **Given** аккаунт с активированным плагином Bit BI, **When** батч загрузка завершается (`BATCH_COMPLETED`), **Then** система автоматически запускает diff по всем файлам с предыдущим батчем того же сайта.
+
+2. **Given** это первый батч для сайта, **When** батч загрузка завершается, **Then** генерируются INSERT запросы для всех строк всех файлов.
+
+3. **Given** предыдущий батч существует, **When** diff выполняется, **Then** результат содержит добавленные, измененные и удаленные строки.
+
+---
+
+### User Story 2 - Генерация SQL файлов (Priority: P1)
+
+На основе результатов diff генерируются PostgreSQL SQL файлы с INSERT, UPDATE и DELETE запросами.
+
+**SQL Generation Rules:**
+
+| Тип изменения | SQL Statement | WHERE Clause |
+|---------------|---------------|--------------|
+| Строка добавлена | `INSERT INTO` | N/A |
+| Строка изменена | `UPDATE` | По всем неизмененным полям |
+| Строка удалена | `DELETE` | По всем полям |
+
+**Acceptance Scenarios:**
+
+1. **Given** diff показывает добавленную строку, **When** SQL генерируется, **Then** создается `INSERT INTO {table} (...) VALUES (...)`.
+
+2. **Given** diff показывает измененную строку, **When** SQL генерируется, **Then** создается `UPDATE {table} SET changed_col=new_val WHERE unchanged_col1=val1 AND unchanged_col2=val2`.
+
+3. **Given** diff показывает удаленную строку, **When** SQL генерируется, **Then** создается `DELETE FROM {table} WHERE col1=val1 AND col2=val2 AND ...` (все поля).
+
+4. **Given** любой SQL запрос, **When** он генерируется, **Then** после него добавляется комментарий `--- END OF COMMAND "{filename}:{line_number}" ---`.
+
+---
+
+### User Story 3 - Получение SQL изменений через API (Priority: P1)
+
+Bit BI пользователь с Plugin API Key может получить все SQL изменения для сайта после указанной даты.
+
+**Endpoint:** `GET /api/v1/plugins/bit-bi/sql-changes`
+
+**Acceptance Scenarios:**
+
+1. **Given** валидный Plugin API Key, **When** запрос `GET /sql-changes?siteId=X&since=2025-01-01T00:00:00Z`, **Then** возвращаются все SQL изменения для сайта X после указанной даты.
+
+2. **Given** невалидный API Key, **When** запрос выполняется, **Then** возвращается 401 Unauthorized.
+
+3. **Given** siteId не принадлежит аккаунту, **When** запрос выполняется, **Then** возвращается 403 Forbidden.
+
+4. **Given** нет изменений после указанной даты, **When** запрос выполняется, **Then** возвращается пустой ответ (200 OK с пустым body).
+
+---
+
+### User Story 4 - Список доступных сайтов (Priority: P2)
+
+Bit BI пользователь может получить список сайтов доступных для его аккаунта.
+
+**Endpoint:** `GET /api/v1/plugins/bit-bi/sites`
+
+**Acceptance Scenarios:**
+
+1. **Given** валидный Plugin API Key, **When** запрос `GET /sites`, **Then** возвращается список всех сайтов аккаунта с id, name, domain.
+
+---
+
+### User Story 5 - Хранение SQL файлов в S3 (Priority: P2)
+
+Сгенерированные SQL файлы сохраняются в AWS S3 со структурированными путями.
+
+**Acceptance Scenarios:**
+
+1. **Given** SQL файл сгенерирован, **When** сохраняется в S3, **Then** путь: `plugins/bit-bi/{accountId}/{siteName}/{source_datetime}-{comparison_datetime}.sql`.
+
+2. **Given** файл успешно сохранен, **When** запрашивается через API, **Then** содержимое загружается из S3 и возвращается клиенту.
+
+---
+
+## Functional Requirements
+
+### SQL Generation
+
+- **FR-019**: Система ДОЛЖНА автоматически запускать diff при событии `BATCH_COMPLETED` для аккаунтов с активированным Bit BI плагином
+- **FR-020**: Система ДОЛЖНА генерировать `INSERT INTO` для добавленных строк
+- **FR-021**: Система ДОЛЖНА генерировать `UPDATE` для измененных строк с WHERE по неизмененным полям
+- **FR-022**: Система ДОЛЖНА генерировать `DELETE FROM` для удаленных строк с WHERE по всем полям
+- **FR-023**: Система ДОЛЖНА обрабатывать NULL значения согласно правилам типов DBF
+- **FR-024**: Система ДОЛЖНА сохранять SQL файлы в S3 по пути `plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql`
+- **FR-025**: Система ДОЛЖНА добавлять комментарий `--- END OF COMMAND "{filename}:{line_number}" ---` после каждого SQL выражения
+
+### Plugin API
+
+- **FR-026**: ~~Система ДОЛЖНА генерировать Plugin API Key при активации плагина~~ (УЖЕ РЕАЛИЗОВАНО - используется существующий `account_plugins.plugin_data` JSONB)
+- **FR-027**: Система ДОЛЖНА предоставлять endpoint `GET /sql-changes` с фильтрами siteId и since
+- **FR-028**: Система ДОЛЖНА предоставлять endpoint `GET /sites` для списка сайтов аккаунта
+- **FR-029**: Система ДОЛЖНА валидировать API Key и проверять принадлежность siteId к аккаунту
+
+### Existing Infrastructure (PRD-013)
+
+Следующие компоненты УЖЕ РЕАЛИЗОВАНЫ и будут использоваться:
+
+- `account_plugins` таблица с `plugin_data` (JSONB) для хранения apiKey
+- `PluginActivationService` для управления активацией
+- `PluginEventDispatcher` для обработки событий `BATCH_COMPLETED`
+- `BitBiPlugin` класс для обработки событий
+- JSON Schema валидация для plugin_data
+- Audit logging в `plugin_audit_logs`
+
+---
+
+## Technical Specification
+
+### API Endpoints
+
+#### GET /api/v1/plugins/bit-bi/sql-changes
+
+Получить SQL изменения для сайта после указанной даты.
+
+```http
+GET /api/v1/plugins/bit-bi/sql-changes?siteId={uuid}&since={datetime}
+Authorization: Bearer plk_xxxxxxxxxxxxx
+```
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| siteId | UUID | Yes | ID сайта |
+| since | ISO 8601 DateTime | Yes | Вернуть изменения после этой даты |
+
+**Response:** `200 OK`
+```
+Content-Type: text/plain; charset=utf-8
+
+INSERT INTO users (name, email, age) VALUES ('John', 'john@example.com', 30);
+--- END OF COMMAND "users.csv:1" ---
+UPDATE products SET price = 99.99 WHERE name = 'Widget' AND category = 'Tools';
+--- END OF COMMAND "products.csv:42" ---
+DELETE FROM orders WHERE id = 123 AND customer_id = 456 AND amount = 100.00;
+--- END OF COMMAND "orders.csv:15" ---
+```
+
+**Error Responses:**
+- `401 Unauthorized` - Invalid or missing API key
+- `403 Forbidden` - Site does not belong to account
+- `400 Bad Request` - Missing required parameters
+
+---
+
+#### GET /api/v1/plugins/bit-bi/sites
+
+Получить список доступных сайтов.
+
+```http
+GET /api/v1/plugins/bit-bi/sites
+Authorization: Bearer plk_xxxxxxxxxxxxx
+```
+
+**Response:** `200 OK`
+```json
+{
+  "sites": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "Main Store",
+      "domain": "main-store.com"
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440001",
+      "name": "Warehouse",
+      "domain": "warehouse.local"
+    }
+  ]
+}
+```
+
+---
+
+### Plugin API Key
+
+**Format:** `plk_` + 32 символа (alphanumeric)
+
+**Generation:** При активации плагина через POST /api/v1/plugins/bit-bi/activate
+
+**Storage:** В существующем `account_plugins.plugin_data` (JSONB) - расширение текущей схемы:
+
+```json
+{
+  "tenantId": "bit-bi-tenant-123",
+  "apiKey": "plk_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6",
+  "apiKeyCreatedAt": "2025-01-01T00:00:00Z"
+}
+```
+
+**Обновление JSON Schema (BitBiPlugin):**
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["tenantId"],
+  "properties": {
+    "tenantId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-zA-Z0-9-_]+$"
+    },
+    "apiKey": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 64,
+      "pattern": "^plk_[a-zA-Z0-9]+$"
+    },
+    "apiKeyCreatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+**Security:**
+- API Key привязан к Account (не к Site)
+- Дает доступ ко всем сайтам аккаунта
+- Endpoint проверяет принадлежность siteId к аккаунту
+
+---
+
+### SQL Statement Format
+
+#### Table Naming
+- Имя файла без расширения = имя таблицы
+- `users.csv` -> `users`
+- `product_catalog.csv` -> `product_catalog`
+
+#### Row Identification
+- Все поля вместе = составной ключ
+- Нет отдельного Primary Key
+
+#### Comment Format
+```sql
+{SQL_STATEMENT};
+--- END OF COMMAND "{filename}:{line_number}" ---
+```
+
+**Example:**
+```sql
+INSERT INTO users (name, email, phone) VALUES ('Alice', 'alice@test.com', '+1234567890');
+--- END OF COMMAND "users.csv:1" ---
+
+UPDATE customers SET balance = 150.00 WHERE name = 'Bob' AND email = 'bob@test.com' AND created_at = '2025-01-01';
+--- END OF COMMAND "customers.csv:42" ---
+
+DELETE FROM products WHERE sku = 'ABC123' AND name = 'Widget' AND price = 19.99 AND category = 'Tools';
+--- END OF COMMAND "products.csv:15" ---
+```
+
+---
+
+### NULL Handling (DBF Types)
+
+| DBF Type | Empty String -> NULL | Example |
+|----------|---------------------|---------|
+| Character (C) | Yes | `''` -> `NULL` |
+| Numeric (N) | Yes | `''` -> `NULL` |
+| Logical (L) | Yes | `''` -> `NULL` |
+| Date (D) | Yes | `''` -> `NULL` |
+| Float (F) | Yes | `''` -> `NULL` |
+| DateTime (T) | Yes | `''` -> `NULL` |
+| Integer (I) | **No** | Всегда числовое значение |
+| Currency (Y) | **No** | Всегда числовое значение |
+
+**SQL Examples:**
+```sql
+-- Character field with empty string
+INSERT INTO users (name, phone) VALUES ('John', NULL);
+
+-- Integer field (never NULL)
+INSERT INTO products (name, quantity) VALUES ('Widget', 0);
+
+-- Multiple NULLs
+UPDATE customers SET phone = NULL, address = NULL WHERE id = 123;
+```
+
+---
+
+### Event Flow
+
+```
+1. BatchLifecycleService.completeBatch()
+   +-- publishEvent(BatchCompletedEvent)
+
+2. BatchEventListener.onBatchCompleted()
+   +-- PluginEventDispatcher.dispatch(BATCH_COMPLETED)
+
+3. BitBiPlugin.execute(event, accountPlugin)
+   |-- Find previous batch for same site
+   |-- If no previous batch -> Generate INSERT for all rows
+   +-- If previous batch exists:
+       |-- CsvFieldDiffService.compare(currentFiles, previousFiles)
+       |-- SqlGenerationService.generate(diffResults)
+       +-- S3 upload to plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
+
+4. GET /sql-changes request
+   |-- Validate API Key -> find AccountPlugin
+   |-- Verify siteId belongs to account
+   |-- Find all SQL files for site after 'since' date
+   +-- Stream/concatenate files and return
+```
+
+---
+
+## Database Changes
+
+### New Table: plugin_sql_generations
+
+```sql
+CREATE TABLE plugin_sql_generations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_plugin_id UUID NOT NULL REFERENCES account_plugins(id),
+    site_id UUID NOT NULL REFERENCES sites(id),
+    source_batch_id UUID NOT NULL REFERENCES batches(id),
+    comparison_batch_id UUID REFERENCES batches(id), -- NULL for first batch
+    s3_key VARCHAR(500) NOT NULL,
+    file_size_bytes BIGINT NOT NULL,
+    statement_count INTEGER NOT NULL,
+    generated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_account_plugin FOREIGN KEY (account_plugin_id)
+        REFERENCES account_plugins(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_plugin_sql_generations_site_date
+    ON plugin_sql_generations(site_id, generated_at DESC);
+
+CREATE INDEX idx_plugin_sql_generations_account_plugin
+    ON plugin_sql_generations(account_plugin_id);
+```
+
+### Index for API Key Lookup
+
+```sql
+CREATE INDEX idx_account_plugins_api_key
+    ON account_plugins USING GIN ((plugin_data->'apiKey'));
+```
+
+---
+
+## S3 File Structure
+
+```
+s3://dataforge-uploads/
++-- plugins/
+    +-- bit-bi/
+        +-- {accountId}/
+            +-- {siteName}/
+                |-- 2025-01-15T10-30-00Z--2025-01-14T09-00-00Z.sql
+                |-- 2025-01-16T14-45-00Z--2025-01-15T10-30-00Z.sql
+                +-- 2025-01-17T08-00-00Z--first-batch.sql
+```
+
+**Naming Convention:**
+- `{source_datetime}--{comparison_datetime}.sql`
+- `{source_datetime}--first-batch.sql` (для первого батча)
+- DateTime format: `YYYY-MM-DDTHH-mm-ssZ` (ISO 8601 без двоеточий)
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Первый батч для сайта | Все INSERT (comparison_batch_id = NULL) |
+| Пустой diff (файлы идентичны) | SQL файл не создается |
+| Бинарные файлы | Пропускаются (только CSV/текст) |
+| Кодировка файлов | Auto-detect (ICU4J): UTF-8, Windows-1252, ISO-8859-1 |
+| Батч без файлов | SQL файл не создается |
+| Плагин деактивирован | События не обрабатываются |
+| Site удален | SQL файлы остаются в S3 для audit |
+
+---
+
+## Success Criteria
+
+- **SC-009**: SQL генерация завершается в течение 60 секунд для батча с 100 файлами
+- **SC-010**: GET /sql-changes возвращает ответ в течение 2 секунд
+- **SC-011**: 100% точность SQL генерации (все добавления/изменения/удаления отражены)
+- **SC-012**: API Key валидация выполняется за <50ms
+- **SC-013**: Audit trail сохраняет все API вызовы и генерации
+
+---
+
+## Out of Scope
+
+- Web UI для просмотра SQL файлов (используйте API)
+- Поддержка других SQL диалектов (только PostgreSQL)
+- Ручной запуск diff (только автоматический при BATCH_COMPLETED)
+- Редактирование сгенерированных SQL файлов
+- Повторная генерация (regenerate) для существующих батчей
+
+---
+
+## Development Methodology: TDD (Test-Driven Development)
+
+Разработка данной функциональности ДОЛЖНА вестись по методологии TDD.
+
+### TDD Workflow
+
+```
+1. RED    - Написать failing test
+2. GREEN  - Написать минимальный код для прохождения теста
+3. REFACTOR - Улучшить код без изменения поведения
+```
+
+### Test Pyramid
+
+| Layer | Technology | Coverage | Purpose |
+|-------|------------|----------|---------|
+| Unit | JUnit 5 + Mockito | 80%+ | Business logic, validation |
+| Contract | MockMvc + @WebMvcTest | All endpoints | API contracts |
+| Integration | Testcontainers (PostgreSQL, LocalStack S3) | Critical paths | E2E flows |
+
+### Required Tests BEFORE Implementation
+
+#### 1. SQL Generation Tests
+```java
+// Unit: SqlGenerationServiceTest
+- shouldGenerateInsertForNewRow()
+- shouldGenerateUpdateForModifiedRow()
+- shouldGenerateDeleteForRemovedRow()
+- shouldUseAllFieldsInDeleteWhere()
+- shouldUseUnchangedFieldsInUpdateWhere()
+- shouldHandleNullValuesPerDbfType()
+- shouldAddEndOfCommandComment()
+```
+
+#### 2. Diff Service Tests
+```java
+// Unit: CsvFieldDiffServiceTest
+- shouldDetectAddedRows()
+- shouldDetectRemovedRows()
+- shouldDetectModifiedRows()
+- shouldIdentifyChangedFields()
+- shouldHandleFirstBatchAsAllInserts()
+```
+
+#### 3. Plugin API Tests
+```java
+// Contract: BitBiPluginApiContractTest
+- shouldReturnSqlChangesForValidApiKey()
+- shouldReturn401ForInvalidApiKey()
+- shouldReturn403ForSiteNotBelongingToAccount()
+- shouldReturnEmptyForNoChanges()
+- shouldReturnSiteListForValidApiKey()
+
+// Integration: BitBiPluginApiIntegrationTest
+- shouldFetchSqlChangesFromS3()
+- shouldFilterBySinceDate()
+- shouldCombineMultipleSqlFiles()
+```
+
+#### 4. Event Handler Tests
+```java
+// Unit: BitBiPluginTest
+- shouldTriggerDiffOnBatchCompleted()
+- shouldFindPreviousBatchForSameSite()
+- shouldGenerateSqlAndUploadToS3()
+- shouldSkipIfNoPreviousBatch()
+```
+
+### Test Data Fixtures
+
+```java
+// src/test/resources/fixtures/
+├── csv/
+│   ├── users_v1.csv         // Initial batch
+│   ├── users_v2.csv         // With changes
+│   └── products_empty.csv   // Edge case
+├── expected-sql/
+│   ├── users_insert.sql
+│   ├── users_update.sql
+│   └── users_delete.sql
+└── plugin-data/
+    └── valid_bit_bi_config.json
+```
+
+### Test Execution Order
+
+1. **Unit tests** - Run first, fastest feedback
+2. **Contract tests** - Verify API shape
+3. **Integration tests** - Verify E2E with real DB/S3
+
+### CI/CD Gate
+
+- All tests MUST pass before merge
+- Code coverage >= 80% for new code
+- No skipped tests allowed
+
+---
+
+## Security Considerations
+
+1. **API Key Storage**: Хранится хешированным в plugin_data (bcrypt)
+2. **Key Rotation**: Возможность regenerate через отдельный endpoint (future)
+3. **Rate Limiting**: 100 requests/minute per API Key
+4. **Audit Logging**: Все API вызовы логируются в plugin_audit_logs
+5. **Site Isolation**: Строгая проверка принадлежности siteId к аккаунту
+
+---
+
+*Document generated: 2025-12-22*

--- a/frontend/src/entities/plugin/api/keys.ts
+++ b/frontend/src/entities/plugin/api/keys.ts
@@ -16,4 +16,8 @@ export const pluginKeys = {
     [...pluginKeys.auditLogs(), filters] as const,
   auditLogByPlugin: (pluginId: string, page: number, size: number) =>
     [...pluginKeys.auditLogs(), 'plugin', pluginId, { page, size }] as const,
+  // Account plugins (user-facing)
+  accountPlugins: () => [...pluginKeys.all, 'account'] as const,
+  accountPluginList: (includeInactive: boolean) =>
+    [...pluginKeys.accountPlugins(), { includeInactive }] as const,
 }

--- a/frontend/src/features/my-plugins/api/__tests__/myPluginsMutations.test.tsx
+++ b/frontend/src/features/my-plugins/api/__tests__/myPluginsMutations.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Tests for my-plugins mutation hooks
+ *
+ * Tests plugin activation and deactivation mutations.
+ *
+ * Feature: My Plugins Dashboard Widget
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode } from 'react'
+import { useActivatePluginMutation, useDeactivatePluginMutation } from '../myPluginsMutations'
+import * as api from '../myPluginsApi'
+import type { PluginActivationResponse } from '../../model/types'
+
+// Mock the API
+vi.mock('../myPluginsApi', () => ({
+  activatePlugin: vi.fn(),
+  deactivatePlugin: vi.fn(),
+}))
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { toast } from 'sonner'
+
+describe('myPluginsMutations', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    vi.clearAllMocks()
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  describe('useActivatePluginMutation', () => {
+    const mockResponse: PluginActivationResponse = {
+      pluginId: 'bit-bi',
+      pluginName: 'Bit BI',
+      accountId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      isActive: true,
+      activatedAt: '2025-12-22T10:00:00Z',
+      lastUsedAt: null,
+    }
+
+    it('should activate plugin with POST request', async () => {
+      vi.mocked(api.activatePlugin).mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useActivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate({
+          pluginId: 'bit-bi',
+          request: { pluginData: { tenantId: 'test-tenant' } },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(api.activatePlugin).toHaveBeenCalledWith('bit-bi', {
+        pluginData: { tenantId: 'test-tenant' },
+      })
+    })
+
+    it('should invalidate query cache on success', async () => {
+      vi.mocked(api.activatePlugin).mockResolvedValue(mockResponse)
+
+      // Set up some cached data
+      queryClient.setQueryData(['plugins', 'account'], { content: [] })
+
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useActivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate({
+          pluginId: 'bit-bi',
+          request: { pluginData: { tenantId: 'test-tenant' } },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['plugins', 'account'],
+      })
+    })
+
+    it('should show success toast on activation', async () => {
+      vi.mocked(api.activatePlugin).mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useActivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate({
+          pluginId: 'bit-bi',
+          request: { pluginData: { tenantId: 'test-tenant' } },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(toast.success).toHaveBeenCalledWith('Plugin activated', {
+        description: 'Bit BI has been activated successfully.',
+      })
+    })
+
+    it('should show error toast on failure', async () => {
+      const mockError = new Error('Validation failed: tenantId is required')
+      vi.mocked(api.activatePlugin).mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useActivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate({
+          pluginId: 'bit-bi',
+          request: { pluginData: {} },
+        })
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(toast.error).toHaveBeenCalledWith('Failed to activate plugin', {
+        description: 'Validation failed: tenantId is required',
+      })
+    })
+  })
+
+  describe('useDeactivatePluginMutation', () => {
+    it('should deactivate plugin with DELETE request', async () => {
+      vi.mocked(api.deactivatePlugin).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useDeactivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate('bit-bi')
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(api.deactivatePlugin).toHaveBeenCalledWith('bit-bi')
+    })
+
+    it('should invalidate query cache on success', async () => {
+      vi.mocked(api.deactivatePlugin).mockResolvedValue(undefined)
+
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries')
+
+      const { result } = renderHook(() => useDeactivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate('bit-bi')
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['plugins', 'account'],
+      })
+    })
+
+    it('should show success toast on deactivation', async () => {
+      vi.mocked(api.deactivatePlugin).mockResolvedValue(undefined)
+
+      const { result } = renderHook(() => useDeactivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate('bit-bi')
+      })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(toast.success).toHaveBeenCalledWith('Plugin deactivated', {
+        description: 'Plugin bit-bi has been deactivated successfully.',
+      })
+    })
+
+    it('should show error toast on failure', async () => {
+      const mockError = new Error('Plugin not found')
+      vi.mocked(api.deactivatePlugin).mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useDeactivatePluginMutation(), { wrapper })
+
+      act(() => {
+        result.current.mutate('unknown-plugin')
+      })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(toast.error).toHaveBeenCalledWith('Failed to deactivate plugin', {
+        description: 'Plugin not found',
+      })
+    })
+  })
+})

--- a/frontend/src/features/my-plugins/api/__tests__/myPluginsQueries.test.tsx
+++ b/frontend/src/features/my-plugins/api/__tests__/myPluginsQueries.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for my-plugins query hooks
+ *
+ * Tests account plugins queries and available plugins queries.
+ *
+ * Feature: My Plugins Dashboard Widget
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactNode } from 'react'
+import { useAccountPluginsQuery, useAvailablePluginsQuery } from '../myPluginsQueries'
+import * as api from '../myPluginsApi'
+import type { AccountPluginListResponse, AvailablePlugin } from '../../model/types'
+
+// Mock the API
+vi.mock('../myPluginsApi', () => ({
+  fetchAccountPlugins: vi.fn(),
+  fetchAvailablePlugins: vi.fn(),
+}))
+
+describe('myPluginsQueries', () => {
+  let queryClient: QueryClient
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    vi.clearAllMocks()
+  })
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+
+  describe('useAccountPluginsQuery', () => {
+    const mockResponse: AccountPluginListResponse = {
+      content: [
+        {
+          pluginId: 'bit-bi',
+          pluginName: 'Bit BI',
+          isActive: true,
+          activatedAt: '2025-12-01T10:00:00Z',
+          deactivatedAt: null,
+          lastUsedAt: '2025-12-20T15:30:00Z',
+        },
+      ],
+      page: 0,
+      size: 20,
+      totalElements: 1,
+      totalPages: 1,
+    }
+
+    it('should fetch account plugins successfully', async () => {
+      vi.mocked(api.fetchAccountPlugins).mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useAccountPluginsQuery(false), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data).toEqual(mockResponse)
+      expect(api.fetchAccountPlugins).toHaveBeenCalledWith({ includeInactive: false })
+    })
+
+    it('should fetch account plugins with includeInactive=true', async () => {
+      vi.mocked(api.fetchAccountPlugins).mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useAccountPluginsQuery(true), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(api.fetchAccountPlugins).toHaveBeenCalledWith({ includeInactive: true })
+    })
+
+    it('should handle API error', async () => {
+      const mockError = new Error('Failed to fetch plugins')
+      vi.mocked(api.fetchAccountPlugins).mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useAccountPluginsQuery(false), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(result.current.error).toBe(mockError)
+    })
+
+    it('should have correct query key for cache invalidation', async () => {
+      vi.mocked(api.fetchAccountPlugins).mockResolvedValue(mockResponse)
+
+      const { result } = renderHook(() => useAccountPluginsQuery(false), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      // Verify query is cached with correct key
+      const cachedData = queryClient.getQueryData(['plugins', 'account', { includeInactive: false }])
+      expect(cachedData).toEqual(mockResponse)
+    })
+  })
+
+  describe('useAvailablePluginsQuery', () => {
+    const mockPlugins: AvailablePlugin[] = [
+      {
+        pluginId: 'bit-bi',
+        displayName: 'Bit BI',
+        version: '1.0.0',
+        isEnabled: true,
+      },
+      {
+        pluginId: 'analytics',
+        displayName: 'Analytics',
+        version: '2.0.0',
+        isEnabled: false,
+      },
+    ]
+
+    it('should fetch available plugins successfully', async () => {
+      vi.mocked(api.fetchAvailablePlugins).mockResolvedValue(mockPlugins)
+
+      const { result } = renderHook(() => useAvailablePluginsQuery(), { wrapper })
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+      expect(result.current.data).toEqual(mockPlugins)
+      expect(api.fetchAvailablePlugins).toHaveBeenCalled()
+    })
+
+    it('should handle API error', async () => {
+      const mockError = new Error('Failed to fetch available plugins')
+      vi.mocked(api.fetchAvailablePlugins).mockRejectedValue(mockError)
+
+      const { result } = renderHook(() => useAvailablePluginsQuery(), { wrapper })
+
+      await waitFor(() => expect(result.current.isError).toBe(true))
+
+      expect(result.current.error).toBe(mockError)
+    })
+  })
+})

--- a/frontend/src/features/my-plugins/api/myPluginsApi.ts
+++ b/frontend/src/features/my-plugins/api/myPluginsApi.ts
@@ -1,0 +1,96 @@
+/**
+ * My Plugins API Client
+ *
+ * API client functions for user-facing plugin management.
+ * Uses Axios instance with Auth0 authentication.
+ */
+
+import { apiClient } from '@/shared/api/client'
+import {
+  ACCOUNT_PLUGINS,
+  ADMIN_PLUGINS,
+  PLUGINS_ACTIVATE,
+  PLUGINS_DEACTIVATE,
+} from '@/shared/api/apiRoutes'
+import type {
+  AccountPluginListResponse,
+  AccountPluginsFilters,
+  ActivatePluginRequest,
+  PluginActivationResponse,
+  AvailablePlugin,
+} from '../model/types'
+import type { PluginConfig } from '@/entities/plugin/model/types'
+
+/**
+ * Fetch account's plugin integrations
+ */
+export async function fetchAccountPlugins(
+  filters: AccountPluginsFilters = {}
+): Promise<AccountPluginListResponse> {
+  const params = new URLSearchParams()
+
+  if (filters.page !== undefined) {
+    params.append('page', String(filters.page))
+  }
+  if (filters.size !== undefined) {
+    params.append('size', String(filters.size))
+  }
+  if (filters.includeInactive !== undefined) {
+    params.append('includeInactive', String(filters.includeInactive))
+  }
+
+  const queryString = params.toString()
+  const url = queryString ? `${ACCOUNT_PLUGINS}?${queryString}` : ACCOUNT_PLUGINS
+
+  const response = await apiClient.get<AccountPluginListResponse>(url)
+  return response.data
+}
+
+/**
+ * Fetch all available plugins (admin endpoint, returns all registered plugins)
+ * Used to show available plugins that user can activate.
+ */
+export async function fetchAvailablePlugins(): Promise<AvailablePlugin[]> {
+  const response = await apiClient.get<PluginConfig[]>(ADMIN_PLUGINS)
+  // Map PluginConfig to AvailablePlugin (subset of fields for user view)
+  return response.data.map((config) => ({
+    pluginId: config.pluginId,
+    displayName: config.displayName,
+    version: config.version,
+    isEnabled: config.isEnabled,
+  }))
+}
+
+/**
+ * Activate a plugin for the current account
+ *
+ * @param pluginId - Plugin identifier (e.g., "bit-bi")
+ * @param request - Activation request with plugin-specific data
+ * @returns PluginActivationResponseDto
+ */
+export async function activatePlugin(
+  pluginId: string,
+  request: ActivatePluginRequest
+): Promise<PluginActivationResponse> {
+  const response = await apiClient.post<PluginActivationResponse>(
+    PLUGINS_ACTIVATE(pluginId),
+    request
+  )
+  return response.data
+}
+
+/**
+ * Deactivate a plugin for the current account
+ *
+ * @param pluginId - Plugin identifier (e.g., "bit-bi")
+ */
+export async function deactivatePlugin(pluginId: string): Promise<void> {
+  await apiClient.delete(PLUGINS_DEACTIVATE(pluginId))
+}
+
+export const myPluginsApi = {
+  fetchAccountPlugins,
+  fetchAvailablePlugins,
+  activatePlugin,
+  deactivatePlugin,
+}

--- a/frontend/src/features/my-plugins/api/myPluginsMutations.ts
+++ b/frontend/src/features/my-plugins/api/myPluginsMutations.ts
@@ -1,0 +1,69 @@
+/**
+ * TanStack Query hooks for plugin activation/deactivation.
+ *
+ * @module features/my-plugins/api/myPluginsMutations
+ */
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import { pluginKeys } from '@/entities/plugin/api/keys'
+import { activatePlugin, deactivatePlugin } from './myPluginsApi'
+import type { ActivatePluginRequest, PluginActivationResponse } from '../model/types'
+
+/**
+ * Hook to activate a plugin for the current account.
+ * Automatically invalidates account plugins queries on success.
+ */
+export function useActivatePluginMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      pluginId,
+      request,
+    }: {
+      pluginId: string
+      request: ActivatePluginRequest
+    }) => activatePlugin(pluginId, request),
+    onSuccess: (data: PluginActivationResponse) => {
+      // Invalidate all account plugin queries to refetch fresh data
+      queryClient.invalidateQueries({ queryKey: pluginKeys.accountPlugins() })
+      // Show success toast
+      toast.success('Plugin activated', {
+        description: `${data.pluginName} has been activated successfully.`,
+      })
+    },
+    onError: (error: Error) => {
+      // Show error toast
+      toast.error('Failed to activate plugin', {
+        description: error.message,
+      })
+    },
+  })
+}
+
+/**
+ * Hook to deactivate a plugin for the current account.
+ * Automatically invalidates account plugins queries on success.
+ */
+export function useDeactivatePluginMutation() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (pluginId: string) => deactivatePlugin(pluginId),
+    onSuccess: (_, pluginId) => {
+      // Invalidate all account plugin queries to refetch fresh data
+      queryClient.invalidateQueries({ queryKey: pluginKeys.accountPlugins() })
+      // Show success toast
+      toast.success('Plugin deactivated', {
+        description: `Plugin ${pluginId} has been deactivated successfully.`,
+      })
+    },
+    onError: (error: Error) => {
+      // Show error toast
+      toast.error('Failed to deactivate plugin', {
+        description: error.message,
+      })
+    },
+  })
+}

--- a/frontend/src/features/my-plugins/api/myPluginsQueries.ts
+++ b/frontend/src/features/my-plugins/api/myPluginsQueries.ts
@@ -1,0 +1,37 @@
+/**
+ * TanStack Query hooks for user-facing plugin management.
+ *
+ * @module features/my-plugins/api/myPluginsQueries
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { pluginKeys } from '@/entities/plugin/api/keys'
+import { fetchAccountPlugins, fetchAvailablePlugins } from './myPluginsApi'
+
+/**
+ * Hook to fetch account's plugin integrations.
+ *
+ * @param includeInactive - Whether to include deactivated plugins
+ * @returns Query result with paginated list of account plugins
+ */
+export function useAccountPluginsQuery(includeInactive: boolean = false) {
+  return useQuery({
+    queryKey: pluginKeys.accountPluginList(includeInactive),
+    queryFn: () => fetchAccountPlugins({ includeInactive }),
+    staleTime: 30000, // 30 seconds - balance between freshness and performance
+  })
+}
+
+/**
+ * Hook to fetch all available plugins for activation.
+ * Returns list of plugins registered in the system that user can activate.
+ *
+ * @returns Query result with list of available plugins
+ */
+export function useAvailablePluginsQuery() {
+  return useQuery({
+    queryKey: pluginKeys.list(),
+    queryFn: () => fetchAvailablePlugins(),
+    staleTime: 60000, // 1 minute - available plugins rarely change
+  })
+}

--- a/frontend/src/features/my-plugins/index.ts
+++ b/frontend/src/features/my-plugins/index.ts
@@ -1,0 +1,42 @@
+/**
+ * My Plugins Feature - Barrel Export
+ *
+ * Exports types, API functions, and hooks for user-facing plugin management.
+ */
+
+// Types
+export type {
+  AccountPluginSummary,
+  AccountPluginListResponse,
+  ActivatePluginRequest,
+  PluginActivationResponse,
+  AccountPluginsFilters,
+  AvailablePlugin,
+  BitBiPluginData,
+} from './model/types'
+
+// API Functions
+export {
+  myPluginsApi,
+  fetchAccountPlugins,
+  fetchAvailablePlugins,
+  activatePlugin,
+  deactivatePlugin,
+} from './api/myPluginsApi'
+
+// Query Hooks
+export {
+  useAccountPluginsQuery,
+  useAvailablePluginsQuery,
+} from './api/myPluginsQueries'
+
+// Mutation Hooks
+export {
+  useActivatePluginMutation,
+  useDeactivatePluginMutation,
+} from './api/myPluginsMutations'
+
+// UI Components
+export { PluginCard } from './ui/PluginCard'
+export { PluginList } from './ui/PluginList'
+export { PluginActivationDialog } from './ui/PluginActivationDialog'

--- a/frontend/src/features/my-plugins/model/types.ts
+++ b/frontend/src/features/my-plugins/model/types.ts
@@ -1,0 +1,110 @@
+/**
+ * My Plugins Feature Types
+ *
+ * Types for displaying and managing user's plugin integrations on the Dashboard.
+ * Maps to backend DTOs: AccountPluginSummaryDto, AccountPluginListResponseDto,
+ * ActivatePluginRequestDto, PluginActivationResponseDto.
+ */
+
+/**
+ * Summary of an account's plugin integration.
+ * Maps to AccountPluginSummaryDto.java
+ *
+ * Security: Plugin-specific data (tenantId, etc.) is NOT exposed.
+ * Only metadata (name, activation date, last used) is returned.
+ */
+export interface AccountPluginSummary {
+  /** Unique plugin identifier (e.g., "bit-bi") */
+  pluginId: string
+  /** Human-readable plugin name (e.g., "Bit BI") */
+  pluginName: string
+  /** Current activation status */
+  isActive: boolean
+  /** When the plugin was first activated (ISO 8601) */
+  activatedAt: string
+  /** When the plugin was deactivated, null if active (ISO 8601) */
+  deactivatedAt: string | null
+  /** When the plugin last received an event, null if never used (ISO 8601) */
+  lastUsedAt: string | null
+}
+
+/**
+ * Paginated response for account plugins list.
+ * Maps to AccountPluginListResponseDto.java
+ */
+export interface AccountPluginListResponse {
+  /** List of plugin summaries for the current page */
+  content: AccountPluginSummary[]
+  /** Current page number (0-indexed) */
+  page: number
+  /** Page size */
+  size: number
+  /** Total number of elements across all pages */
+  totalElements: number
+  /** Total number of pages */
+  totalPages: number
+}
+
+/**
+ * Request DTO for plugin activation.
+ * Maps to ActivatePluginRequestDto.java
+ */
+export interface ActivatePluginRequest {
+  /** Plugin-specific data (validated against plugin's JSON Schema) */
+  pluginData: Record<string, unknown>
+}
+
+/**
+ * Response DTO for plugin activation operations.
+ * Maps to PluginActivationResponseDto.java
+ */
+export interface PluginActivationResponse {
+  /** Plugin identifier */
+  pluginId: string
+  /** Human-readable plugin name */
+  pluginName: string
+  /** Account ID */
+  accountId: string
+  /** Current activation status */
+  isActive: boolean
+  /** When the plugin was activated (ISO 8601) */
+  activatedAt: string
+  /** When the plugin was last used, null if never (ISO 8601) */
+  lastUsedAt: string | null
+}
+
+/**
+ * Query filters for listing account plugins.
+ */
+export interface AccountPluginsFilters {
+  /** Page number (0-indexed) */
+  page?: number
+  /** Page size (1-100) */
+  size?: number
+  /** Include deactivated plugins */
+  includeInactive?: boolean
+}
+
+/**
+ * Available plugin for activation.
+ * Maps to PluginConfig entity (subset of fields shown to users).
+ */
+export interface AvailablePlugin {
+  /** Unique plugin identifier */
+  pluginId: string
+  /** Human-readable plugin name */
+  displayName: string
+  /** Plugin version */
+  version: string
+  /** Whether the plugin is globally enabled */
+  isEnabled: boolean
+}
+
+/**
+ * Plugin activation form data for Bit BI plugin.
+ * Specific to the bit-bi plugin's schema requirements.
+ */
+export interface BitBiPluginData {
+  /** Tenant ID for Bit BI connection */
+  tenantId: string
+}

--- a/frontend/src/features/my-plugins/ui/PluginActivationDialog.tsx
+++ b/frontend/src/features/my-plugins/ui/PluginActivationDialog.tsx
@@ -1,0 +1,137 @@
+/**
+ * PluginActivationDialog Component
+ *
+ * Dialog for activating a plugin with required configuration fields.
+ * Currently supports Bit BI plugin with tenantId field.
+ */
+
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/ui/dialog'
+import { Button } from '@/shared/ui/ui/button'
+import { Input } from '@/shared/ui/ui/input'
+import { Label } from '@/shared/ui/ui/label'
+import type { AvailablePlugin, ActivatePluginRequest } from '../model/types'
+
+export interface PluginActivationDialogProps {
+  /** Whether the dialog is open */
+  open: boolean
+  /** Plugin to activate */
+  plugin: AvailablePlugin | null
+  /** Callback when dialog is closed (without activation) */
+  onClose: () => void
+  /** Callback when plugin is activated with data */
+  onSubmit: (pluginId: string, request: ActivatePluginRequest) => void
+  /** Whether activation is in progress */
+  isLoading?: boolean
+}
+
+/**
+ * Dialog for plugin activation with configuration form.
+ *
+ * For bit-bi plugin, shows tenantId field.
+ * For other plugins, shows a generic activation confirmation.
+ */
+export function PluginActivationDialog({
+  open,
+  plugin,
+  onClose,
+  onSubmit,
+  isLoading = false,
+}: PluginActivationDialogProps) {
+  const [tenantId, setTenantId] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const isBitBi = plugin?.pluginId === 'bit-bi'
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!plugin) return
+
+    // Validate required fields for bit-bi
+    if (isBitBi && !tenantId.trim()) {
+      setError('Tenant ID is required')
+      return
+    }
+
+    const pluginData: Record<string, unknown> = isBitBi
+      ? { tenantId: tenantId.trim() }
+      : {}
+
+    onSubmit(plugin.pluginId, { pluginData })
+  }
+
+  const handleClose = () => {
+    setTenantId('')
+    setError(null)
+    onClose()
+  }
+
+  if (!plugin) return null
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Activate {plugin.displayName}</DialogTitle>
+          <DialogDescription>
+            {isBitBi
+              ? 'Enter your Bit BI tenant ID to connect your account.'
+              : `Activate ${plugin.displayName} for your account.`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit}>
+          {isBitBi && (
+            <div className="space-y-4 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="tenantId">
+                  Tenant ID <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="tenantId"
+                  value={tenantId}
+                  onChange={(e) => {
+                    setTenantId(e.target.value)
+                    if (error) setError(null)
+                  }}
+                  placeholder="Enter your Bit BI tenant ID"
+                  disabled={isLoading}
+                  aria-invalid={!!error}
+                  aria-describedby={error ? 'tenantId-error' : undefined}
+                />
+                {error && (
+                  <p id="tenantId-error" className="text-sm text-red-500">
+                    {error}
+                  </p>
+                )}
+              </div>
+            </div>
+          )}
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading ? 'Activating...' : 'Activate'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/my-plugins/ui/PluginCard.tsx
+++ b/frontend/src/features/my-plugins/ui/PluginCard.tsx
@@ -1,0 +1,125 @@
+/**
+ * PluginCard Component
+ *
+ * Displays a single plugin card with activation status and actions.
+ * Used in the My Plugins widget on the Dashboard.
+ */
+
+import { formatDistanceToNow } from 'date-fns'
+import { Plug, Clock, Calendar, Check, X } from 'lucide-react'
+import { Button } from '@/shared/ui/ui/button'
+import { Badge } from '@/shared/ui/ui/badge'
+import type { AccountPluginSummary, AvailablePlugin } from '../model/types'
+
+interface PluginCardProps {
+  /** Plugin summary for activated plugins */
+  plugin?: AccountPluginSummary
+  /** Available plugin for unactivated plugins */
+  availablePlugin?: AvailablePlugin
+  /** Whether the plugin is currently activated for this account */
+  isActivated?: boolean
+  /** Callback when activate button is clicked */
+  onActivate?: (pluginId: string) => void
+  /** Callback when deactivate button is clicked */
+  onDeactivate?: (pluginId: string) => void
+  /** Whether an operation is pending */
+  isPending?: boolean
+}
+
+export function PluginCard({
+  plugin,
+  availablePlugin,
+  isActivated = false,
+  onActivate,
+  onDeactivate,
+  isPending = false,
+}: PluginCardProps) {
+  const pluginId = plugin?.pluginId || availablePlugin?.pluginId || ''
+  const pluginName = plugin?.pluginName || availablePlugin?.displayName || ''
+  const isActive = plugin?.isActive ?? isActivated
+  const version = availablePlugin?.version
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className={`flex h-10 w-10 items-center justify-center rounded-lg ${
+            isActive ? 'bg-green-50' : 'bg-gray-100'
+          }`}>
+            <Plug className={`h-5 w-5 ${isActive ? 'text-green-600' : 'text-gray-400'}`} />
+          </div>
+          <div>
+            <h3 className="text-sm font-medium text-gray-900">{pluginName}</h3>
+            {version && (
+              <p className="text-xs text-gray-500">v{version}</p>
+            )}
+          </div>
+        </div>
+        <Badge
+          variant={isActive ? 'default' : 'secondary'}
+          className={isActive ? 'bg-green-100 text-green-800 hover:bg-green-100' : ''}
+        >
+          {isActive ? (
+            <span className="flex items-center gap-1">
+              <Check className="h-3 w-3" />
+              Active
+            </span>
+          ) : (
+            <span className="flex items-center gap-1">
+              <X className="h-3 w-3" />
+              Inactive
+            </span>
+          )}
+        </Badge>
+      </div>
+
+      {/* Metadata */}
+      <div className="mt-4 space-y-2">
+        {plugin?.activatedAt && (
+          <div className="flex items-center gap-2 text-xs text-gray-500">
+            <Calendar className="h-3.5 w-3.5" />
+            <span>
+              Activated{' '}
+              {formatDistanceToNow(new Date(plugin.activatedAt), { addSuffix: true })}
+            </span>
+          </div>
+        )}
+        {plugin?.lastUsedAt && (
+          <div className="flex items-center gap-2 text-xs text-gray-500">
+            <Clock className="h-3.5 w-3.5" />
+            <span>
+              Last used{' '}
+              {formatDistanceToNow(new Date(plugin.lastUsedAt), { addSuffix: true })}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="mt-4">
+        {isActive ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full text-red-600 hover:bg-red-50 hover:text-red-700"
+            onClick={() => onDeactivate?.(pluginId)}
+            disabled={isPending}
+          >
+            {isPending ? 'Deactivating...' : 'Deactivate'}
+          </Button>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full text-green-600 hover:bg-green-50 hover:text-green-700"
+            onClick={() => onActivate?.(pluginId)}
+            disabled={isPending}
+          >
+            {isPending ? 'Activating...' : 'Activate'}
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/my-plugins/ui/PluginList.tsx
+++ b/frontend/src/features/my-plugins/ui/PluginList.tsx
@@ -1,0 +1,104 @@
+/**
+ * PluginList Component
+ *
+ * Displays a list of plugin cards with loading and empty states.
+ * Used in the My Plugins widget on the Dashboard.
+ */
+
+import { Plug, Loader2 } from 'lucide-react'
+import { PluginCard } from './PluginCard'
+import type { AccountPluginSummary, AvailablePlugin } from '../model/types'
+
+interface PluginListProps {
+  /** List of activated plugins */
+  plugins: AccountPluginSummary[]
+  /** List of available plugins (for showing unactivated ones) */
+  availablePlugins?: AvailablePlugin[]
+  /** Whether the data is loading */
+  isLoading?: boolean
+  /** Error message to display */
+  error?: Error | null
+  /** IDs of plugins currently being processed */
+  pendingPluginIds?: Set<string>
+  /** Callback when activate button is clicked */
+  onActivate?: (pluginId: string) => void
+  /** Callback when deactivate button is clicked */
+  onDeactivate?: (pluginId: string) => void
+}
+
+export function PluginList({
+  plugins,
+  availablePlugins = [],
+  isLoading = false,
+  error = null,
+  pendingPluginIds = new Set(),
+  onActivate,
+  onDeactivate,
+}: PluginListProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+        <span className="ml-3 text-sm text-gray-500">Loading plugins...</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-center">
+        <p className="text-sm text-red-600">
+          Failed to load plugins: {error.message}
+        </p>
+      </div>
+    )
+  }
+
+  // Merge activated plugins with available plugins
+  const activatedPluginIds = new Set(plugins.map((p) => p.pluginId))
+
+  // Get unactivated available plugins
+  const unactivatedPlugins = availablePlugins.filter(
+    (p) => !activatedPluginIds.has(p.pluginId) && p.isEnabled
+  )
+
+  const hasPlugins = plugins.length > 0 || unactivatedPlugins.length > 0
+
+  if (!hasPlugins) {
+    return (
+      <div className="rounded-lg border border-gray-200 bg-gray-50 p-8 text-center">
+        <Plug className="mx-auto h-12 w-12 text-gray-400" />
+        <p className="mt-4 text-sm text-gray-500">No plugins available</p>
+        <p className="text-xs text-gray-400">
+          Plugins will appear here when they become available.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {/* Activated plugins first */}
+      {plugins.map((plugin) => (
+        <PluginCard
+          key={plugin.pluginId}
+          plugin={plugin}
+          isPending={pendingPluginIds.has(plugin.pluginId)}
+          onActivate={onActivate}
+          onDeactivate={onDeactivate}
+        />
+      ))}
+      {/* Then unactivated available plugins */}
+      {unactivatedPlugins.map((plugin) => (
+        <PluginCard
+          key={plugin.pluginId}
+          availablePlugin={plugin}
+          isActivated={false}
+          isPending={pendingPluginIds.has(plugin.pluginId)}
+          onActivate={onActivate}
+          onDeactivate={onDeactivate}
+        />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/my-plugins/ui/__tests__/PluginActivationDialog.test.tsx
+++ b/frontend/src/features/my-plugins/ui/__tests__/PluginActivationDialog.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Tests for PluginActivationDialog Component
+ *
+ * Tests dialog rendering, form validation, and submission.
+ *
+ * Feature: My Plugins Dashboard Widget
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PluginActivationDialog } from '../PluginActivationDialog'
+import type { AvailablePlugin } from '../../model/types'
+
+describe('PluginActivationDialog', () => {
+  const mockBitBiPlugin: AvailablePlugin = {
+    pluginId: 'bit-bi',
+    displayName: 'Bit BI',
+    version: '1.0.0',
+    isEnabled: true,
+  }
+
+  const mockOtherPlugin: AvailablePlugin = {
+    pluginId: 'analytics',
+    displayName: 'Analytics',
+    version: '2.0.0',
+    isEnabled: true,
+  }
+
+  const defaultProps = {
+    open: true,
+    plugin: mockBitBiPlugin,
+    onClose: vi.fn(),
+    onSubmit: vi.fn(),
+  }
+
+  describe('Rendering', () => {
+    it('should render dialog when open is true', () => {
+      render(<PluginActivationDialog {...defaultProps} />)
+
+      expect(screen.getByText('Activate Bit BI')).toBeInTheDocument()
+    })
+
+    it('should not render dialog when open is false', () => {
+      render(<PluginActivationDialog {...defaultProps} open={false} />)
+
+      expect(screen.queryByText('Activate Bit BI')).not.toBeInTheDocument()
+    })
+
+    it('should not render when plugin is null', () => {
+      render(<PluginActivationDialog {...defaultProps} plugin={null} />)
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Bit BI Plugin Form', () => {
+    it('should show tenantId field for bit-bi plugin', () => {
+      render(<PluginActivationDialog {...defaultProps} />)
+
+      expect(screen.getByLabelText(/tenant id/i)).toBeInTheDocument()
+    })
+
+    it('should show description about Bit BI tenant ID', () => {
+      render(<PluginActivationDialog {...defaultProps} />)
+
+      expect(screen.getByText(/enter your bit bi tenant id/i)).toBeInTheDocument()
+    })
+
+    it('should validate tenantId is required', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+
+      render(<PluginActivationDialog {...defaultProps} onSubmit={onSubmit} />)
+
+      // Submit without entering tenantId
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+
+      // Should show error message
+      expect(screen.getByText('Tenant ID is required')).toBeInTheDocument()
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it('should clear error when user types', async () => {
+      const user = userEvent.setup()
+
+      render(<PluginActivationDialog {...defaultProps} />)
+
+      // Submit without entering tenantId
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+      expect(screen.getByText('Tenant ID is required')).toBeInTheDocument()
+
+      // Start typing
+      await user.type(screen.getByLabelText(/tenant id/i), 't')
+
+      // Error should be cleared
+      expect(screen.queryByText('Tenant ID is required')).not.toBeInTheDocument()
+    })
+
+    it('should call onSubmit with tenantId data', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+
+      render(<PluginActivationDialog {...defaultProps} onSubmit={onSubmit} />)
+
+      await user.type(screen.getByLabelText(/tenant id/i), 'my-tenant-123')
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+
+      expect(onSubmit).toHaveBeenCalledWith('bit-bi', {
+        pluginData: { tenantId: 'my-tenant-123' },
+      })
+    })
+
+    it('should trim tenantId before submission', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+
+      render(<PluginActivationDialog {...defaultProps} onSubmit={onSubmit} />)
+
+      await user.type(screen.getByLabelText(/tenant id/i), '  my-tenant  ')
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+
+      expect(onSubmit).toHaveBeenCalledWith('bit-bi', {
+        pluginData: { tenantId: 'my-tenant' },
+      })
+    })
+  })
+
+  describe('Other Plugin Form', () => {
+    it('should not show tenantId field for non-bit-bi plugins', () => {
+      render(<PluginActivationDialog {...defaultProps} plugin={mockOtherPlugin} />)
+
+      expect(screen.queryByLabelText(/tenant id/i)).not.toBeInTheDocument()
+    })
+
+    it('should show generic activation message', () => {
+      render(<PluginActivationDialog {...defaultProps} plugin={mockOtherPlugin} />)
+
+      expect(screen.getByText(/activate analytics for your account/i)).toBeInTheDocument()
+    })
+
+    it('should call onSubmit with empty pluginData', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+
+      render(
+        <PluginActivationDialog
+          {...defaultProps}
+          plugin={mockOtherPlugin}
+          onSubmit={onSubmit}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+
+      expect(onSubmit).toHaveBeenCalledWith('analytics', {
+        pluginData: {},
+      })
+    })
+  })
+
+  describe('Loading State', () => {
+    it('should show Activating... when isLoading', () => {
+      render(<PluginActivationDialog {...defaultProps} isLoading={true} />)
+
+      expect(screen.getByRole('button', { name: 'Activating...' })).toBeInTheDocument()
+    })
+
+    it('should disable buttons when isLoading', () => {
+      render(<PluginActivationDialog {...defaultProps} isLoading={true} />)
+
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Activating...' })).toBeDisabled()
+    })
+
+    it('should disable input when isLoading', () => {
+      render(<PluginActivationDialog {...defaultProps} isLoading={true} />)
+
+      expect(screen.getByLabelText(/tenant id/i)).toBeDisabled()
+    })
+  })
+
+  describe('Cancel Behavior', () => {
+    it('should call onClose when Cancel is clicked', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+
+      render(<PluginActivationDialog {...defaultProps} onClose={onClose} />)
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    it('should call onClose when dialog is dismissed', async () => {
+      const onClose = vi.fn()
+
+      render(<PluginActivationDialog {...defaultProps} onClose={onClose} />)
+
+      // Press Escape key to close dialog
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/features/my-plugins/ui/__tests__/PluginCard.test.tsx
+++ b/frontend/src/features/my-plugins/ui/__tests__/PluginCard.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for PluginCard Component
+ *
+ * Tests plugin card display, status badges, and action buttons.
+ *
+ * Feature: My Plugins Dashboard Widget
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PluginCard } from '../PluginCard'
+import type { AccountPluginSummary, AvailablePlugin } from '../../model/types'
+
+describe('PluginCard', () => {
+  const mockActivePlugin: AccountPluginSummary = {
+    pluginId: 'bit-bi',
+    pluginName: 'Bit BI',
+    isActive: true,
+    activatedAt: '2025-12-01T10:00:00Z',
+    deactivatedAt: null,
+    lastUsedAt: '2025-12-20T15:30:00Z',
+  }
+
+  const mockInactivePlugin: AccountPluginSummary = {
+    pluginId: 'analytics',
+    pluginName: 'Analytics',
+    isActive: false,
+    activatedAt: '2025-11-01T10:00:00Z',
+    deactivatedAt: '2025-12-15T10:00:00Z',
+    lastUsedAt: '2025-12-10T15:30:00Z',
+  }
+
+  const mockAvailablePlugin: AvailablePlugin = {
+    pluginId: 'bit-bi',
+    displayName: 'Bit BI',
+    version: '1.0.0',
+    isEnabled: true,
+  }
+
+  describe('Display', () => {
+    it('should render plugin name', () => {
+      render(<PluginCard plugin={mockActivePlugin} />)
+
+      expect(screen.getByText('Bit BI')).toBeInTheDocument()
+    })
+
+    it('should render version when availablePlugin is provided', () => {
+      render(<PluginCard availablePlugin={mockAvailablePlugin} />)
+
+      expect(screen.getByText('v1.0.0')).toBeInTheDocument()
+    })
+
+    it('should show Active badge for active plugins', () => {
+      render(<PluginCard plugin={mockActivePlugin} />)
+
+      expect(screen.getByText('Active')).toBeInTheDocument()
+    })
+
+    it('should show Inactive badge for inactive plugins', () => {
+      render(<PluginCard plugin={mockInactivePlugin} />)
+
+      expect(screen.getByText('Inactive')).toBeInTheDocument()
+    })
+
+    it('should display activated date', () => {
+      render(<PluginCard plugin={mockActivePlugin} />)
+
+      expect(screen.getByText(/activated/i)).toBeInTheDocument()
+    })
+
+    it('should display last used date when available', () => {
+      render(<PluginCard plugin={mockActivePlugin} />)
+
+      expect(screen.getByText(/last used/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Active Plugin Actions', () => {
+    it('should show Deactivate button for active plugins', () => {
+      render(<PluginCard plugin={mockActivePlugin} />)
+
+      expect(screen.getByRole('button', { name: 'Deactivate' })).toBeInTheDocument()
+    })
+
+    it('should call onDeactivate when Deactivate button is clicked', async () => {
+      const user = userEvent.setup()
+      const onDeactivate = vi.fn()
+
+      render(<PluginCard plugin={mockActivePlugin} onDeactivate={onDeactivate} />)
+
+      await user.click(screen.getByRole('button', { name: 'Deactivate' }))
+
+      expect(onDeactivate).toHaveBeenCalledWith('bit-bi')
+    })
+
+    it('should disable button and show loading text when isPending', () => {
+      render(<PluginCard plugin={mockActivePlugin} isPending={true} />)
+
+      const button = screen.getByRole('button', { name: 'Deactivating...' })
+      expect(button).toBeDisabled()
+    })
+  })
+
+  describe('Inactive Plugin Actions', () => {
+    it('should show Activate button for inactive plugins', () => {
+      render(<PluginCard plugin={mockInactivePlugin} />)
+
+      expect(screen.getByRole('button', { name: 'Activate' })).toBeInTheDocument()
+    })
+
+    it('should call onActivate when Activate button is clicked', async () => {
+      const user = userEvent.setup()
+      const onActivate = vi.fn()
+
+      render(<PluginCard plugin={mockInactivePlugin} onActivate={onActivate} />)
+
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+
+      expect(onActivate).toHaveBeenCalledWith('analytics')
+    })
+
+    it('should disable button and show loading text when isPending', () => {
+      render(<PluginCard plugin={mockInactivePlugin} isPending={true} />)
+
+      const button = screen.getByRole('button', { name: 'Activating...' })
+      expect(button).toBeDisabled()
+    })
+  })
+
+  describe('Available Plugin (Not Yet Activated)', () => {
+    it('should show Activate button when isActivated is false', () => {
+      render(<PluginCard availablePlugin={mockAvailablePlugin} isActivated={false} />)
+
+      expect(screen.getByRole('button', { name: 'Activate' })).toBeInTheDocument()
+    })
+
+    it('should use displayName from availablePlugin', () => {
+      render(<PluginCard availablePlugin={mockAvailablePlugin} />)
+
+      expect(screen.getByText('Bit BI')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/features/my-plugins/ui/__tests__/PluginList.test.tsx
+++ b/frontend/src/features/my-plugins/ui/__tests__/PluginList.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * Tests for PluginList Component
+ *
+ * Tests list rendering, loading states, error states, and empty states.
+ *
+ * Feature: My Plugins Dashboard Widget
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PluginList } from '../PluginList'
+import type { AccountPluginSummary, AvailablePlugin } from '../../model/types'
+
+describe('PluginList', () => {
+  const mockActivePlugins: AccountPluginSummary[] = [
+    {
+      pluginId: 'bit-bi',
+      pluginName: 'Bit BI',
+      isActive: true,
+      activatedAt: '2025-12-01T10:00:00Z',
+      deactivatedAt: null,
+      lastUsedAt: '2025-12-20T15:30:00Z',
+    },
+  ]
+
+  const mockAvailablePlugins: AvailablePlugin[] = [
+    {
+      pluginId: 'bit-bi',
+      displayName: 'Bit BI',
+      version: '1.0.0',
+      isEnabled: true,
+    },
+    {
+      pluginId: 'analytics',
+      displayName: 'Analytics',
+      version: '2.0.0',
+      isEnabled: true,
+    },
+    {
+      pluginId: 'disabled-plugin',
+      displayName: 'Disabled Plugin',
+      version: '1.0.0',
+      isEnabled: false,
+    },
+  ]
+
+  describe('Loading State', () => {
+    it('should show loading spinner when isLoading is true', () => {
+      render(<PluginList plugins={[]} isLoading={true} />)
+
+      expect(screen.getByText('Loading plugins...')).toBeInTheDocument()
+    })
+
+    it('should not render plugins when loading', () => {
+      render(<PluginList plugins={mockActivePlugins} isLoading={true} />)
+
+      expect(screen.queryByText('Bit BI')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('Error State', () => {
+    it('should show error message when error is provided', () => {
+      const error = new Error('Network error')
+
+      render(<PluginList plugins={[]} error={error} />)
+
+      expect(screen.getByText(/failed to load plugins/i)).toBeInTheDocument()
+      expect(screen.getByText(/network error/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Empty State', () => {
+    it('should show empty state when no plugins available', () => {
+      render(<PluginList plugins={[]} availablePlugins={[]} />)
+
+      expect(screen.getByText('No plugins available')).toBeInTheDocument()
+    })
+
+    it('should show empty state when all available plugins are disabled', () => {
+      const disabledOnlyPlugins: AvailablePlugin[] = [
+        {
+          pluginId: 'disabled',
+          displayName: 'Disabled',
+          version: '1.0.0',
+          isEnabled: false,
+        },
+      ]
+
+      render(<PluginList plugins={[]} availablePlugins={disabledOnlyPlugins} />)
+
+      expect(screen.getByText('No plugins available')).toBeInTheDocument()
+    })
+  })
+
+  describe('Plugin List Display', () => {
+    it('should render activated plugins', () => {
+      render(<PluginList plugins={mockActivePlugins} />)
+
+      expect(screen.getByText('Bit BI')).toBeInTheDocument()
+    })
+
+    it('should render unactivated available plugins', () => {
+      render(<PluginList plugins={[]} availablePlugins={mockAvailablePlugins} />)
+
+      // bit-bi and analytics should be shown (enabled)
+      expect(screen.getByText('Bit BI')).toBeInTheDocument()
+      expect(screen.getByText('Analytics')).toBeInTheDocument()
+      // disabled plugin should not be shown
+      expect(screen.queryByText('Disabled Plugin')).not.toBeInTheDocument()
+    })
+
+    it('should not show duplicate plugins (activated + available)', () => {
+      render(
+        <PluginList
+          plugins={mockActivePlugins}
+          availablePlugins={mockAvailablePlugins}
+        />
+      )
+
+      // bit-bi appears once (activated version takes precedence)
+      const bitBiElements = screen.getAllByText('Bit BI')
+      expect(bitBiElements).toHaveLength(1)
+
+      // analytics appears once (unactivated available)
+      expect(screen.getByText('Analytics')).toBeInTheDocument()
+    })
+
+    it('should show activated plugins before unactivated ones', () => {
+      render(
+        <PluginList
+          plugins={mockActivePlugins}
+          availablePlugins={mockAvailablePlugins}
+        />
+      )
+
+      const pluginCards = screen.getAllByRole('button')
+      // First should be Deactivate (for active plugin)
+      expect(pluginCards[0]).toHaveTextContent('Deactivate')
+      // Second should be Activate (for unactivated plugin)
+      expect(pluginCards[1]).toHaveTextContent('Activate')
+    })
+  })
+
+  describe('Interactions', () => {
+    it('should call onActivate when Activate button is clicked', async () => {
+      const user = userEvent.setup()
+      const onActivate = vi.fn()
+
+      render(
+        <PluginList
+          plugins={[]}
+          availablePlugins={mockAvailablePlugins}
+          onActivate={onActivate}
+        />
+      )
+
+      await user.click(screen.getAllByRole('button', { name: 'Activate' })[0])
+
+      expect(onActivate).toHaveBeenCalledWith('bit-bi')
+    })
+
+    it('should call onDeactivate when Deactivate button is clicked', async () => {
+      const user = userEvent.setup()
+      const onDeactivate = vi.fn()
+
+      render(
+        <PluginList plugins={mockActivePlugins} onDeactivate={onDeactivate} />
+      )
+
+      await user.click(screen.getByRole('button', { name: 'Deactivate' }))
+
+      expect(onDeactivate).toHaveBeenCalledWith('bit-bi')
+    })
+
+    it('should show pending state for plugins being processed', () => {
+      const pendingPluginIds = new Set(['bit-bi'])
+
+      render(
+        <PluginList
+          plugins={mockActivePlugins}
+          pendingPluginIds={pendingPluginIds}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Deactivating...' })).toBeDisabled()
+    })
+  })
+
+  describe('Grid Layout', () => {
+    it('should use grid layout for cards', () => {
+      const { container } = render(
+        <PluginList plugins={mockActivePlugins} availablePlugins={mockAvailablePlugins} />
+      )
+
+      const grid = container.querySelector('.grid')
+      expect(grid).toBeInTheDocument()
+      expect(grid).toHaveClass('sm:grid-cols-2')
+      expect(grid).toHaveClass('lg:grid-cols-3')
+    })
+  })
+})

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -7,11 +7,13 @@
  * Features:
  * - Navigation header with Dashboard/Accounts links
  * - 4 chart widgets in responsive grid
+ * - My Plugins widget for plugin management
  * - Logout button in header
  */
 
 import { Header } from '@/widgets/header/Header'
 import { DashboardCharts } from '@/widgets/dashboard-charts'
+import { MyPluginsWidget } from '@/widgets/my-plugins'
 
 export default function DashboardPage() {
   return (
@@ -25,6 +27,9 @@ export default function DashboardPage() {
           </p>
         </div>
         <DashboardCharts />
+        <div className="mt-8">
+          <MyPluginsWidget />
+        </div>
       </main>
     </div>
   )

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -14,6 +14,7 @@
 import { Header } from '@/widgets/header/Header'
 import { DashboardCharts } from '@/widgets/dashboard-charts'
 import { MyPluginsWidget } from '@/widgets/my-plugins'
+import { WidgetErrorBoundary } from '@/shared/ui/WidgetErrorBoundary'
 
 export default function DashboardPage() {
   return (
@@ -28,7 +29,9 @@ export default function DashboardPage() {
         </div>
         <DashboardCharts />
         <div className="mt-8">
-          <MyPluginsWidget />
+          <WidgetErrorBoundary widgetName="My Plugins">
+            <MyPluginsWidget />
+          </WidgetErrorBoundary>
         </div>
       </main>
     </div>

--- a/frontend/src/shared/api/apiRoutes.ts
+++ b/frontend/src/shared/api/apiRoutes.ts
@@ -110,3 +110,11 @@ export const COMPARISONS_SUMMARY_DOWNLOAD = (id: number) => `${COMPARISONS}/${id
 export const ADMIN_PLUGINS = `${ADMIN_API_BASE}/admin/plugins`;
 export const ADMIN_PLUGINS_AUDIT = `${ADMIN_PLUGINS}/audit`;
 export const ADMIN_PLUGINS_AUDIT_BY_PLUGIN = (pluginId: string) => `${ADMIN_PLUGINS}/${pluginId}/audit`;
+
+// Account Plugins (User-facing)
+export const ACCOUNT_PLUGINS = `${ADMIN_API_BASE}/account/plugins`;
+
+// Plugin Activation
+export const PLUGINS = `${ADMIN_API_BASE}/plugins`;
+export const PLUGINS_ACTIVATE = (pluginId: string) => `${PLUGINS}/${pluginId}/activate`;
+export const PLUGINS_DEACTIVATE = (pluginId: string) => `${PLUGINS}/${pluginId}/deactivate`;

--- a/frontend/src/shared/ui/WidgetErrorBoundary.tsx
+++ b/frontend/src/shared/ui/WidgetErrorBoundary.tsx
@@ -1,0 +1,84 @@
+/**
+ * Widget-specific Error Boundary component.
+ *
+ * Provides a compact error display suitable for dashboard widgets,
+ * unlike the full-page ErrorBoundary.
+ */
+
+import { Component, ErrorInfo, ReactNode } from 'react'
+import { AlertCircle, RefreshCw } from 'lucide-react'
+import { Button } from '@/shared/ui/ui/button'
+
+interface Props {
+  children: ReactNode
+  widgetName?: string
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+export class WidgetErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      hasError: false,
+      error: null,
+    }
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return {
+      hasError: true,
+      error,
+    }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error(
+      `WidgetErrorBoundary [${this.props.widgetName ?? 'Unknown'}] caught an error:`,
+      error,
+      errorInfo
+    )
+  }
+
+  handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+    })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center rounded-lg border border-red-200 bg-red-50 p-6 text-center">
+          <AlertCircle className="h-8 w-8 text-red-500 mb-3" />
+          <h3 className="text-sm font-medium text-red-800 mb-1">
+            {this.props.widgetName ? `${this.props.widgetName} Error` : 'Widget Error'}
+          </h3>
+          <p className="text-xs text-red-600 mb-4">
+            Something went wrong loading this widget.
+          </p>
+          {process.env.NODE_ENV === 'development' && this.state.error && (
+            <p className="text-xs text-red-500 mb-4 font-mono break-all max-w-full">
+              {this.state.error.message}
+            </p>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={this.handleReset}
+            className="text-red-700 border-red-300 hover:bg-red-100"
+          >
+            <RefreshCw className="h-3 w-3 mr-1" />
+            Try Again
+          </Button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/frontend/src/widgets/my-plugins/MyPluginsWidget.tsx
+++ b/frontend/src/widgets/my-plugins/MyPluginsWidget.tsx
@@ -5,7 +5,7 @@
  * Shows activated and available plugins with activation/deactivation actions.
  */
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { Plug } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
 import {
@@ -39,14 +39,22 @@ export function MyPluginsWidget() {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [selectedPlugin, setSelectedPlugin] = useState<AvailablePlugin | null>(null)
 
-  // Track pending plugin IDs
-  const pendingPluginIds = new Set<string>()
-  if (activatePluginMutation.isPending && activatePluginMutation.variables) {
-    pendingPluginIds.add(activatePluginMutation.variables.pluginId)
-  }
-  if (deactivatePluginMutation.isPending && deactivatePluginMutation.variables) {
-    pendingPluginIds.add(deactivatePluginMutation.variables)
-  }
+  // Track pending plugin IDs with useMemo to prevent unnecessary re-renders
+  const pendingPluginIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (activatePluginMutation.isPending && activatePluginMutation.variables) {
+      ids.add(activatePluginMutation.variables.pluginId)
+    }
+    if (deactivatePluginMutation.isPending && deactivatePluginMutation.variables) {
+      ids.add(deactivatePluginMutation.variables)
+    }
+    return ids
+  }, [
+    activatePluginMutation.isPending,
+    activatePluginMutation.variables,
+    deactivatePluginMutation.isPending,
+    deactivatePluginMutation.variables,
+  ])
 
   // Handlers
   const handleActivateClick = useCallback((pluginId: string) => {

--- a/frontend/src/widgets/my-plugins/MyPluginsWidget.tsx
+++ b/frontend/src/widgets/my-plugins/MyPluginsWidget.tsx
@@ -1,0 +1,112 @@
+/**
+ * MyPluginsWidget Component
+ *
+ * Dashboard widget for managing user's plugin integrations.
+ * Shows activated and available plugins with activation/deactivation actions.
+ */
+
+import { useState, useCallback } from 'react'
+import { Plug } from 'lucide-react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/shared/ui/ui/card'
+import {
+  useAccountPluginsQuery,
+  useAvailablePluginsQuery,
+  useActivatePluginMutation,
+  useDeactivatePluginMutation,
+} from '@/features/my-plugins'
+import { PluginList } from '@/features/my-plugins/ui/PluginList'
+import { PluginActivationDialog } from '@/features/my-plugins/ui/PluginActivationDialog'
+import type { AvailablePlugin, ActivatePluginRequest } from '@/features/my-plugins'
+
+export function MyPluginsWidget() {
+  // Queries
+  const {
+    data: accountPlugins,
+    isLoading: isLoadingAccountPlugins,
+    error: accountPluginsError,
+  } = useAccountPluginsQuery(true) // Include inactive to show all
+
+  const {
+    data: availablePlugins,
+    isLoading: isLoadingAvailablePlugins,
+  } = useAvailablePluginsQuery()
+
+  // Mutations
+  const activatePluginMutation = useActivatePluginMutation()
+  const deactivatePluginMutation = useDeactivatePluginMutation()
+
+  // Dialog state
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [selectedPlugin, setSelectedPlugin] = useState<AvailablePlugin | null>(null)
+
+  // Track pending plugin IDs
+  const pendingPluginIds = new Set<string>()
+  if (activatePluginMutation.isPending && activatePluginMutation.variables) {
+    pendingPluginIds.add(activatePluginMutation.variables.pluginId)
+  }
+  if (deactivatePluginMutation.isPending && deactivatePluginMutation.variables) {
+    pendingPluginIds.add(deactivatePluginMutation.variables)
+  }
+
+  // Handlers
+  const handleActivateClick = useCallback((pluginId: string) => {
+    const plugin = availablePlugins?.find((p) => p.pluginId === pluginId)
+    if (plugin) {
+      setSelectedPlugin(plugin)
+      setDialogOpen(true)
+    }
+  }, [availablePlugins])
+
+  const handleDeactivate = useCallback((pluginId: string) => {
+    deactivatePluginMutation.mutate(pluginId)
+  }, [deactivatePluginMutation])
+
+  const handleDialogClose = useCallback(() => {
+    setDialogOpen(false)
+    setSelectedPlugin(null)
+  }, [])
+
+  const handleDialogSubmit = useCallback((pluginId: string, request: ActivatePluginRequest) => {
+    activatePluginMutation.mutate(
+      { pluginId, request },
+      {
+        onSuccess: () => {
+          setDialogOpen(false)
+          setSelectedPlugin(null)
+        },
+      }
+    )
+  }, [activatePluginMutation])
+
+  const isLoading = isLoadingAccountPlugins || isLoadingAvailablePlugins
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Plug className="h-5 w-5" />
+          My Plugins
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <PluginList
+          plugins={accountPlugins?.content ?? []}
+          availablePlugins={availablePlugins ?? []}
+          isLoading={isLoading}
+          error={accountPluginsError}
+          pendingPluginIds={pendingPluginIds}
+          onActivate={handleActivateClick}
+          onDeactivate={handleDeactivate}
+        />
+
+        <PluginActivationDialog
+          open={dialogOpen}
+          plugin={selectedPlugin}
+          onClose={handleDialogClose}
+          onSubmit={handleDialogSubmit}
+          isLoading={activatePluginMutation.isPending}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/widgets/my-plugins/__tests__/MyPluginsWidget.test.tsx
+++ b/frontend/src/widgets/my-plugins/__tests__/MyPluginsWidget.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * Tests for MyPluginsWidget Component
+ *
+ * Tests widget container with data fetching, activation/deactivation flows,
+ * and dialog integration.
+ *
+ * Feature: My Plugins Dashboard Widget
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+import { MyPluginsWidget } from '../MyPluginsWidget'
+import * as myPluginsQueries from '@/features/my-plugins/api/myPluginsQueries'
+import * as myPluginsMutations from '@/features/my-plugins/api/myPluginsMutations'
+import type { AccountPluginListResponse, AvailablePlugin } from '@/features/my-plugins'
+
+// Mock the queries and mutations
+vi.mock('@/features/my-plugins/api/myPluginsQueries', () => ({
+  useAccountPluginsQuery: vi.fn(),
+  useAvailablePluginsQuery: vi.fn(),
+}))
+
+vi.mock('@/features/my-plugins/api/myPluginsMutations', () => ({
+  useActivatePluginMutation: vi.fn(),
+  useDeactivatePluginMutation: vi.fn(),
+}))
+
+// Mock sonner toast
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe('MyPluginsWidget', () => {
+  let queryClient: QueryClient
+
+  const mockAccountPluginsResponse: AccountPluginListResponse = {
+    content: [
+      {
+        pluginId: 'bit-bi',
+        pluginName: 'Bit BI',
+        isActive: true,
+        activatedAt: '2025-12-01T10:00:00Z',
+        deactivatedAt: null,
+        lastUsedAt: '2025-12-20T15:30:00Z',
+      },
+    ],
+    page: 0,
+    size: 20,
+    totalElements: 1,
+    totalPages: 1,
+  }
+
+  const mockAvailablePlugins: AvailablePlugin[] = [
+    {
+      pluginId: 'bit-bi',
+      displayName: 'Bit BI',
+      version: '1.0.0',
+      isEnabled: true,
+    },
+    {
+      pluginId: 'analytics',
+      displayName: 'Analytics',
+      version: '2.0.0',
+      isEnabled: true,
+    },
+  ]
+
+  const createWrapper = () => {
+    return ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+
+  const mockMutationResult = {
+    mutate: vi.fn(),
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    error: null,
+    variables: undefined,
+    reset: vi.fn(),
+  }
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    })
+    vi.clearAllMocks()
+
+    // Default mock implementations
+    vi.mocked(myPluginsMutations.useActivatePluginMutation).mockReturnValue(mockMutationResult as any)
+    vi.mocked(myPluginsMutations.useDeactivatePluginMutation).mockReturnValue(mockMutationResult as any)
+  })
+
+  describe('Loading State', () => {
+    it('should show loading state when fetching plugins', () => {
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      expect(screen.getByText('Loading plugins...')).toBeInTheDocument()
+    })
+  })
+
+  describe('Success State', () => {
+    it('should render widget title', () => {
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: mockAccountPluginsResponse,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      expect(screen.getByText('My Plugins')).toBeInTheDocument()
+    })
+
+    it('should render activated plugins', () => {
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: mockAccountPluginsResponse,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      expect(screen.getByText('Bit BI')).toBeInTheDocument()
+    })
+
+    it('should render available unactivated plugins', () => {
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: mockAccountPluginsResponse,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      expect(screen.getByText('Analytics')).toBeInTheDocument()
+    })
+  })
+
+  describe('Error State', () => {
+    it('should display error message when query fails', () => {
+      const error = new Error('Failed to fetch plugins')
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      expect(screen.getByText(/failed to load plugins/i)).toBeInTheDocument()
+    })
+  })
+
+  describe('Activation Flow', () => {
+    it('should open activation dialog when Activate is clicked', async () => {
+      const user = userEvent.setup()
+
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: { content: [], page: 0, size: 20, totalElements: 0, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      // Click Activate on first plugin (bit-bi)
+      const activateButtons = screen.getAllByRole('button', { name: 'Activate' })
+      await user.click(activateButtons[0])
+
+      // Dialog should open
+      expect(screen.getByText('Activate Bit BI')).toBeInTheDocument()
+    })
+
+    it('should call activate mutation when form is submitted', async () => {
+      const user = userEvent.setup()
+      const mockMutate = vi.fn()
+
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: { content: [], page: 0, size: 20, totalElements: 0, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsMutations.useActivatePluginMutation).mockReturnValue({
+        ...mockMutationResult,
+        mutate: mockMutate,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      // Open dialog
+      const activateButtons = screen.getAllByRole('button', { name: 'Activate' })
+      await user.click(activateButtons[0])
+
+      // Fill form and submit
+      await user.type(screen.getByLabelText(/tenant id/i), 'my-tenant')
+      await user.click(screen.getByRole('button', { name: 'Activate' }))
+
+      expect(mockMutate).toHaveBeenCalledWith(
+        {
+          pluginId: 'bit-bi',
+          request: { pluginData: { tenantId: 'my-tenant' } },
+        },
+        expect.any(Object)
+      )
+    })
+  })
+
+  describe('Deactivation Flow', () => {
+    it('should call deactivate mutation when Deactivate is clicked', async () => {
+      const user = userEvent.setup()
+      const mockMutate = vi.fn()
+
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: mockAccountPluginsResponse,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsMutations.useDeactivatePluginMutation).mockReturnValue({
+        ...mockMutationResult,
+        mutate: mockMutate,
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      await user.click(screen.getByRole('button', { name: 'Deactivate' }))
+
+      expect(mockMutate).toHaveBeenCalledWith('bit-bi')
+    })
+  })
+
+  describe('Pending State', () => {
+    it('should show pending state for plugin being activated', () => {
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: { content: [], page: 0, size: 20, totalElements: 0, totalPages: 0 },
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsMutations.useActivatePluginMutation).mockReturnValue({
+        ...mockMutationResult,
+        isPending: true,
+        variables: { pluginId: 'bit-bi', request: { pluginData: {} } },
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      // bit-bi button should show Activating...
+      expect(screen.getByRole('button', { name: 'Activating...' })).toBeDisabled()
+    })
+
+    it('should show pending state for plugin being deactivated', () => {
+      vi.mocked(myPluginsQueries.useAccountPluginsQuery).mockReturnValue({
+        data: mockAccountPluginsResponse,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsQueries.useAvailablePluginsQuery).mockReturnValue({
+        data: mockAvailablePlugins,
+        isLoading: false,
+        error: null,
+      } as any)
+      vi.mocked(myPluginsMutations.useDeactivatePluginMutation).mockReturnValue({
+        ...mockMutationResult,
+        isPending: true,
+        variables: 'bit-bi',
+      } as any)
+
+      render(<MyPluginsWidget />, { wrapper: createWrapper() })
+
+      expect(screen.getByRole('button', { name: 'Deactivating...' })).toBeDisabled()
+    })
+  })
+})

--- a/frontend/src/widgets/my-plugins/index.ts
+++ b/frontend/src/widgets/my-plugins/index.ts
@@ -1,0 +1,5 @@
+/**
+ * My Plugins Widget - Barrel Export
+ */
+
+export { MyPluginsWidget } from './MyPluginsWidget'

--- a/frontend/tests/unit/pages/dashboard/DashboardPage.test.tsx
+++ b/frontend/tests/unit/pages/dashboard/DashboardPage.test.tsx
@@ -25,6 +25,11 @@ vi.mock('@/widgets/header/Header', () => ({
   Header: () => <header data-testid="header">Header</header>,
 }))
 
+// Mock MyPluginsWidget to avoid React Query dependency
+vi.mock('@/widgets/my-plugins', () => ({
+  MyPluginsWidget: () => <div data-testid="my-plugins-widget">My Plugins</div>,
+}))
+
 describe('DashboardPage', () => {
   it('should render the page', () => {
     render(<DashboardPage />)
@@ -47,5 +52,11 @@ describe('DashboardPage', () => {
     render(<DashboardPage />)
     expect(screen.getByTestId('dashboard-charts')).toBeInTheDocument()
     expect(screen.getByText('Charts')).toBeInTheDocument()
+  })
+
+  it('should render my plugins widget', () => {
+    render(<DashboardPage />)
+    expect(screen.getByTestId('my-plugins-widget')).toBeInTheDocument()
+    expect(screen.getByText('My Plugins')).toBeInTheDocument()
   })
 })

--- a/specs/001-plugin-sql-generation/checklists/requirements.md
+++ b/specs/001-plugin-sql-generation/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Plugin SQL Generation Extension
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`
+- The PRD provided comprehensive details, allowing full specification without clarification markers

--- a/specs/001-plugin-sql-generation/contracts/openapi.yaml
+++ b/specs/001-plugin-sql-generation/contracts/openapi.yaml
@@ -1,0 +1,196 @@
+openapi: 3.0.3
+info:
+  title: Bit BI Plugin API
+  description: |
+    Plugin API for Bit BI integration with Data Forge Middleware.
+    Provides access to SQL changes generated from batch upload diffs.
+  version: 1.0.0
+  contact:
+    name: Data Forge Team
+
+servers:
+  - url: /api/v1/plugins/bit-bi
+    description: Plugin API base path
+
+security:
+  - PluginApiKey: []
+
+tags:
+  - name: SQL Changes
+    description: Retrieve SQL changes from batch comparisons
+  - name: Sites
+    description: List available sites for the account
+
+paths:
+  /sql-changes:
+    get:
+      tags:
+        - SQL Changes
+      summary: Retrieve SQL changes for a site
+      description: |
+        Returns all SQL changes (INSERT, UPDATE, DELETE statements) for a specific site
+        after a given date. Multiple SQL files are concatenated in chronological order.
+      operationId: getSqlChanges
+      parameters:
+        - name: siteId
+          in: query
+          required: true
+          description: UUID of the site to retrieve changes for
+          schema:
+            type: string
+            format: uuid
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        - name: since
+          in: query
+          required: true
+          description: ISO8601 timestamp. Returns changes after this date.
+          schema:
+            type: string
+            format: date-time
+          example: "2025-01-01T00:00:00Z"
+      responses:
+        '200':
+          description: SQL changes retrieved successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Concatenated SQL statements
+              example: |
+                INSERT INTO customers (id, name, email) VALUES ('1', 'John Doe', 'john@example.com');
+                --- END OF COMMAND "customers.csv:2" ---
+                UPDATE orders SET status = 'shipped' WHERE id = '42' AND customer_id = '1';
+                --- END OF COMMAND "orders.csv:15" ---
+        '400':
+          description: Invalid request parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                timestamp: "2025-12-22T10:00:00Z"
+                status: 400
+                error: "Bad Request"
+                message: "Invalid date format for 'since' parameter"
+                path: "/api/v1/plugins/bit-bi/sql-changes"
+        '401':
+          description: Invalid or missing API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                timestamp: "2025-12-22T10:00:00Z"
+                status: 401
+                error: "Unauthorized"
+                message: "Invalid or missing API key"
+                path: "/api/v1/plugins/bit-bi/sql-changes"
+        '403':
+          description: Site does not belong to account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                timestamp: "2025-12-22T10:00:00Z"
+                status: 403
+                error: "Forbidden"
+                message: "Site does not belong to your account"
+                path: "/api/v1/plugins/bit-bi/sql-changes"
+
+  /sites:
+    get:
+      tags:
+        - Sites
+      summary: List available sites
+      description: Returns a list of all sites belonging to the account associated with the API key.
+      operationId: listSites
+      responses:
+        '200':
+          description: Sites retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SiteListResponse'
+              example:
+                sites:
+                  - id: "550e8400-e29b-41d4-a716-446655440000"
+                    domain: "example.com"
+                    displayName: "Example Site"
+                  - id: "660f9500-f39c-52e5-b827-557766551111"
+                    domain: "shop.example.com"
+                    displayName: "Example Shop"
+        '401':
+          description: Invalid or missing API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    PluginApiKey:
+      type: apiKey
+      in: header
+      name: X-Plugin-Api-Key
+      description: |
+        Plugin API Key generated during Bit BI plugin activation.
+        Format: `plk_` followed by 32 alphanumeric characters.
+        Example: `plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6`
+
+  schemas:
+    SiteListResponse:
+      type: object
+      required:
+        - sites
+      properties:
+        sites:
+          type: array
+          items:
+            $ref: '#/components/schemas/Site'
+
+    Site:
+      type: object
+      required:
+        - id
+        - domain
+        - displayName
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique site identifier
+        domain:
+          type: string
+          description: Site domain name
+          example: "example.com"
+        displayName:
+          type: string
+          description: Human-readable site name
+          example: "Example Site"
+
+    ErrorResponse:
+      type: object
+      required:
+        - timestamp
+        - status
+        - error
+        - message
+        - path
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Error timestamp in ISO8601 format
+        status:
+          type: integer
+          description: HTTP status code
+        error:
+          type: string
+          description: HTTP error name
+        message:
+          type: string
+          description: Detailed error message
+        path:
+          type: string
+          description: Request path that caused the error

--- a/specs/001-plugin-sql-generation/data-model.md
+++ b/specs/001-plugin-sql-generation/data-model.md
@@ -1,0 +1,506 @@
+# Data Model: Plugin SQL Generation Extension
+
+**Feature Branch**: `001-plugin-sql-generation`
+**Date**: 2025-12-22
+
+## Entity Relationship Diagram
+
+```
+┌─────────────────┐       ┌──────────────────────┐       ┌─────────────────┐
+│    accounts     │       │   account_plugins    │       │  plugin_configs │
+├─────────────────┤       ├──────────────────────┤       ├─────────────────┤
+│ id (PK)         │◄──────│ account_id (FK)      │       │ plugin_id (PK)  │
+│ email           │       │ plugin_id (FK)       │───────│ client_id       │
+│ name            │       │ plugin_data (JSONB)  │       │ display_name    │
+│ is_active       │       │   └── tenantId       │       │ is_enabled      │
+└─────────────────┘       │   └── apiKey (NEW)   │       └─────────────────┘
+         │                │ is_active            │
+         │                │ activated_at         │
+         ▼                └──────────────────────┘
+┌─────────────────┐                │
+│     sites       │                │
+├─────────────────┤                │
+│ id (PK)         │                │
+│ account_id (FK) │                │
+│ domain          │                ▼
+│ display_name    │       ┌──────────────────────────┐
+└─────────────────┘       │  plugin_sql_generations  │ (NEW)
+         │                ├──────────────────────────┤
+         │                │ id (PK)                  │
+         ▼                │ account_plugin_id (FK)   │
+┌─────────────────┐       │ site_id (FK)             │
+│    batches      │       │ source_batch_id (FK)     │
+├─────────────────┤       │ comparison_batch_id (FK) │ NULL for first batch
+│ id (PK)         │◄──────│ s3_key                   │
+│ site_id (FK)    │       │ file_size_bytes          │
+│ account_id      │       │ statement_count          │
+│ status          │       │ insert_count             │
+│ started_at      │       │ update_count             │
+│ completed_at    │       │ delete_count             │
+└─────────────────┘       │ files_processed          │
+         │                │ generation_duration_ms   │
+         │                │ created_at               │
+         ▼                └──────────────────────────┘
+┌─────────────────┐
+│ uploaded_files  │
+├─────────────────┤
+│ id (PK)         │
+│ batch_id (FK)   │
+│ original_name   │
+│ s3_key          │
+│ file_size       │
+└─────────────────┘
+```
+
+## New Entity: PluginSqlGeneration
+
+### Purpose
+Tracks each SQL file generation event for audit, retrieval, and statistics.
+
+### Table Definition
+
+```sql
+-- V11__create_plugin_sql_generations_table.sql
+
+CREATE TABLE plugin_sql_generations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Foreign keys
+    account_plugin_id BIGINT NOT NULL,
+    site_id UUID NOT NULL,
+    source_batch_id UUID NOT NULL,
+    comparison_batch_id UUID,  -- NULL for first batch
+
+    -- S3 storage
+    s3_key VARCHAR(1000) NOT NULL,
+    file_size_bytes BIGINT NOT NULL,
+
+    -- Statistics
+    statement_count INTEGER NOT NULL DEFAULT 0,
+    insert_count INTEGER NOT NULL DEFAULT 0,
+    update_count INTEGER NOT NULL DEFAULT 0,
+    delete_count INTEGER NOT NULL DEFAULT 0,
+    files_processed INTEGER NOT NULL DEFAULT 0,
+
+    -- Performance tracking
+    generation_duration_ms BIGINT NOT NULL DEFAULT 0,
+
+    -- Timestamps
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT fk_sql_gen_account_plugin
+        FOREIGN KEY (account_plugin_id)
+        REFERENCES account_plugins(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sql_gen_site
+        FOREIGN KEY (site_id)
+        REFERENCES sites(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sql_gen_source_batch
+        FOREIGN KEY (source_batch_id)
+        REFERENCES batches(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sql_gen_comparison_batch
+        FOREIGN KEY (comparison_batch_id)
+        REFERENCES batches(id) ON DELETE SET NULL,
+
+    -- Ensure unique generation per source batch
+    CONSTRAINT uk_sql_gen_source_batch UNIQUE (source_batch_id)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_sql_gen_site_created ON plugin_sql_generations(site_id, created_at DESC);
+CREATE INDEX idx_sql_gen_account_plugin ON plugin_sql_generations(account_plugin_id);
+
+COMMENT ON TABLE plugin_sql_generations IS 'Tracks SQL file generation events for Bit BI plugin';
+COMMENT ON COLUMN plugin_sql_generations.comparison_batch_id IS 'NULL for first batch (all INSERTs)';
+COMMENT ON COLUMN plugin_sql_generations.s3_key IS 'Full S3 key path: plugins/bit-bi/{accountId}/{siteName}/{timestamp}.sql';
+```
+
+### JPA Entity
+
+```java
+@Entity
+@Table(name = "plugin_sql_generations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PluginSqlGeneration {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "account_plugin_id", nullable = false)
+    private Long accountPluginId;
+
+    @Column(name = "site_id", nullable = false)
+    private UUID siteId;
+
+    @Column(name = "source_batch_id", nullable = false)
+    private UUID sourceBatchId;
+
+    @Column(name = "comparison_batch_id")
+    private UUID comparisonBatchId;  // nullable for first batch
+
+    @Column(name = "s3_key", nullable = false, length = 1000)
+    private String s3Key;
+
+    @Column(name = "file_size_bytes", nullable = false)
+    private Long fileSizeBytes;
+
+    @Column(name = "statement_count", nullable = false)
+    private Integer statementCount;
+
+    @Column(name = "insert_count", nullable = false)
+    private Integer insertCount;
+
+    @Column(name = "update_count", nullable = false)
+    private Integer updateCount;
+
+    @Column(name = "delete_count", nullable = false)
+    private Integer deleteCount;
+
+    @Column(name = "files_processed", nullable = false)
+    private Integer filesProcessed;
+
+    @Column(name = "generation_duration_ms", nullable = false)
+    private Long generationDurationMs;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // Factory method
+    public static PluginSqlGeneration create(
+            Long accountPluginId,
+            UUID siteId,
+            UUID sourceBatchId,
+            UUID comparisonBatchId,
+            String s3Key,
+            long fileSizeBytes,
+            SqlGenerationStats stats,
+            long durationMs
+    ) {
+        PluginSqlGeneration entity = new PluginSqlGeneration();
+        entity.id = UUID.randomUUID();
+        entity.accountPluginId = accountPluginId;
+        entity.siteId = siteId;
+        entity.sourceBatchId = sourceBatchId;
+        entity.comparisonBatchId = comparisonBatchId;
+        entity.s3Key = s3Key;
+        entity.fileSizeBytes = fileSizeBytes;
+        entity.statementCount = stats.total();
+        entity.insertCount = stats.inserts();
+        entity.updateCount = stats.updates();
+        entity.deleteCount = stats.deletes();
+        entity.filesProcessed = stats.filesProcessed();
+        entity.generationDurationMs = durationMs;
+        entity.createdAt = LocalDateTime.now();
+        return entity;
+    }
+
+    public boolean isFirstBatch() {
+        return comparisonBatchId == null;
+    }
+}
+```
+
+---
+
+## Extended Schema: account_plugins.plugin_data
+
+### Current Schema (existing)
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["tenantId"],
+  "properties": {
+    "tenantId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-zA-Z0-9-_]+$"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### Extended Schema (this feature)
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["tenantId", "apiKey"],
+  "properties": {
+    "tenantId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64,
+      "pattern": "^[a-zA-Z0-9-_]+$",
+      "description": "Bit BI tenant identifier"
+    },
+    "apiKey": {
+      "type": "string",
+      "minLength": 36,
+      "maxLength": 36,
+      "pattern": "^plk_[a-zA-Z0-9]{32}$",
+      "description": "Plugin API Key for authentication"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+### Sample Data
+```json
+{
+  "tenantId": "bit-bi-tenant-acme",
+  "apiKey": "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+}
+```
+
+---
+
+## Value Objects
+
+### SqlGenerationStats (record)
+
+```java
+public record SqlGenerationStats(
+    int inserts,
+    int updates,
+    int deletes,
+    int filesProcessed
+) {
+    public int total() {
+        return inserts + updates + deletes;
+    }
+
+    public static SqlGenerationStats empty() {
+        return new SqlGenerationStats(0, 0, 0, 0);
+    }
+
+    public SqlGenerationStats merge(SqlGenerationStats other) {
+        return new SqlGenerationStats(
+            this.inserts + other.inserts,
+            this.updates + other.updates,
+            this.deletes + other.deletes,
+            this.filesProcessed + other.filesProcessed
+        );
+    }
+}
+```
+
+### CsvRowDiff (record)
+
+```java
+public record CsvRowDiff(
+    DiffType type,
+    int lineNumber,
+    Map<String, String> values,
+    Map<String, String> changedColumns  // only for MODIFIED: old values
+) {
+    public enum DiffType {
+        ADDED,
+        MODIFIED,
+        DELETED
+    }
+
+    public static CsvRowDiff added(int lineNumber, Map<String, String> values) {
+        return new CsvRowDiff(DiffType.ADDED, lineNumber, values, Map.of());
+    }
+
+    public static CsvRowDiff deleted(int lineNumber, Map<String, String> values) {
+        return new CsvRowDiff(DiffType.DELETED, lineNumber, values, Map.of());
+    }
+
+    public static CsvRowDiff modified(int lineNumber, Map<String, String> newValues, Map<String, String> changedColumns) {
+        return new CsvRowDiff(DiffType.MODIFIED, lineNumber, newValues, changedColumns);
+    }
+}
+```
+
+### DbfColumnType (enum)
+
+```java
+public enum DbfColumnType {
+    CHARACTER("C", true),    // Empty = NULL
+    NUMERIC("N", true),      // Empty = NULL
+    LOGICAL("L", true),      // Empty = NULL
+    DATE("D", true),         // Empty = NULL
+    FLOAT("F", true),        // Empty = NULL
+    DATETIME("T", true),     // Empty = NULL
+    INTEGER("I", false),     // Empty = 0
+    CURRENCY("Y", false);    // Empty = 0
+
+    private final String code;
+    private final boolean emptyIsNull;
+
+    DbfColumnType(String code, boolean emptyIsNull) {
+        this.code = code;
+        this.emptyIsNull = emptyIsNull;
+    }
+
+    public boolean isEmptyNull() {
+        return emptyIsNull;
+    }
+
+    public static DbfColumnType fromCode(String code) {
+        for (DbfColumnType type : values()) {
+            if (type.code.equalsIgnoreCase(code)) {
+                return type;
+            }
+        }
+        return CHARACTER;  // Default to CHARACTER (empty = NULL)
+    }
+}
+```
+
+### PluginApiKey (value object)
+
+```java
+public record PluginApiKey(String value) {
+    private static final String PREFIX = "plk_";
+    private static final int KEY_LENGTH = 32;
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    public PluginApiKey {
+        Objects.requireNonNull(value, "API key value cannot be null");
+        if (!value.matches("^plk_[a-zA-Z0-9]{32}$")) {
+            throw new IllegalArgumentException("Invalid API key format");
+        }
+    }
+
+    public static PluginApiKey generate() {
+        StringBuilder key = new StringBuilder(PREFIX);
+        for (int i = 0; i < KEY_LENGTH; i++) {
+            key.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+        }
+        return new PluginApiKey(key.toString());
+    }
+
+    @Override
+    public String toString() {
+        // Mask for security in logs
+        return PREFIX + "****" + value.substring(value.length() - 4);
+    }
+}
+```
+
+---
+
+## Repository Interface
+
+```java
+public interface PluginSqlGenerationRepository {
+
+    PluginSqlGeneration save(PluginSqlGeneration generation);
+
+    Optional<PluginSqlGeneration> findById(UUID id);
+
+    /**
+     * Find all SQL generations for a site after a given date.
+     * Used by the Plugin API to retrieve SQL changes.
+     */
+    List<PluginSqlGeneration> findBySiteIdAndCreatedAtAfter(
+        UUID siteId,
+        LocalDateTime since
+    );
+
+    /**
+     * Find generation by source batch (unique constraint).
+     */
+    Optional<PluginSqlGeneration> findBySourceBatchId(UUID sourceBatchId);
+
+    /**
+     * Check if generation already exists for a batch.
+     */
+    boolean existsBySourceBatchId(UUID sourceBatchId);
+}
+```
+
+---
+
+## Database Queries
+
+### Find SQL generations by site and date (Plugin API)
+
+```sql
+SELECT * FROM plugin_sql_generations
+WHERE site_id = :siteId
+  AND created_at > :since
+ORDER BY created_at ASC;
+```
+
+### Validate API Key and get account
+
+```sql
+SELECT ap.account_id
+FROM account_plugins ap
+WHERE ap.plugin_id = 'bit-bi'
+  AND ap.is_active = true
+  AND ap.plugin_data @> :apiKeyJson::jsonb;
+
+-- Example: :apiKeyJson = '{"apiKey": "plk_xxx..."}'
+```
+
+### Find previous batch for site
+
+```sql
+SELECT * FROM batches
+WHERE site_id = :siteId
+  AND status IN ('COMPLETED', 'COMPLETED_WITH_WARNINGS')
+  AND id != :currentBatchId
+ORDER BY completed_at DESC
+LIMIT 1;
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule | Error Message |
+|-------|------|---------------|
+| apiKey | Required, format `plk_` + 32 alphanumeric | Invalid API key format |
+| siteId | Must belong to API Key's account | Site not found or access denied |
+| since | Valid ISO8601 timestamp | Invalid date format |
+| tenantId | Required for plugin activation | Tenant ID is required |
+
+---
+
+## State Transitions
+
+### SQL Generation Lifecycle
+
+```
+BatchCompletedEvent
+       │
+       ▼
+[Check Plugin Active] ──No──► (no action)
+       │ Yes
+       ▼
+[Find Previous Batch]
+       │
+       ├── None found ──► [Generate INSERTs for all rows]
+       │
+       └── Found ──► [Compare files between batches]
+                          │
+                          ▼
+                    [Generate SQL]
+                          │
+                          ▼
+                    [Upload to S3]
+                          │
+                          ▼
+               [Save PluginSqlGeneration]
+                          │
+                          ▼
+                       COMPLETE
+```
+
+### No SQL Generation Cases
+
+- Plugin not activated for account → Skip silently
+- Empty diff (identical files) → Do NOT create PluginSqlGeneration record
+- Binary files in batch → Skip (log warning)
+- Batch with no CSV files → Do NOT create record

--- a/specs/001-plugin-sql-generation/plan.md
+++ b/specs/001-plugin-sql-generation/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Plugin SQL Generation Extension
+
+**Branch**: `001-plugin-sql-generation` | **Date**: 2025-12-22 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-plugin-sql-generation/spec.md`
+**Extends**: PRD-013 (Plugin System & Bit BI OAuth Integration)
+
+## Summary
+
+Extend the existing Bit BI plugin to automatically generate PostgreSQL SQL files (INSERT, UPDATE, DELETE statements) when batch uploads complete. The system compares CSV files between consecutive batches for the same site, produces SQL reflecting row differences, stores generated files in S3, and provides a Plugin API for Bit BI users to retrieve SQL changes. **Development follows TDD methodology (MANDATORY)**.
+
+## Technical Context
+
+**Language/Version**: Java 21 (LTS) with Spring Boot 3.5.6
+**Primary Dependencies**: Spring Boot 3.5.6, Spring Security 6 (OAuth2 Resource Server + Auth0), Spring Data JPA, Spring Events (ApplicationEventPublisher), Hypersistence Utils (JSONB), Apache Commons CSV 1.12.0, java-diff-utils 4.12, ICU4J 76.1
+**Storage**: PostgreSQL 16 (new table: `plugin_sql_generations`), AWS S3 (SQL file storage at `plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql`)
+**Testing**: JUnit 5 + Mockito (unit), Testcontainers + MockMvc (integration/contract), TDD mandatory
+**Target Platform**: Linux server (Docker), AWS ECS
+**Project Type**: Web application (backend-only API extension, no frontend)
+**Performance Goals**: SQL generation <60s for 100 CSV files (SC-001), API response <2s (SC-002), API Key validation <50ms (SC-004)
+**Constraints**: Streaming CSV processing for large files (>100MB), 100% accuracy on row changes (SC-003)
+**Scale/Scope**: Multi-tenant SaaS, ~100 accounts, ~500 sites, ~10 batches/day per account
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| TDD Mandatory | ✅ COMPLIANT | All development follows TDD: Contract tests first → Integration tests → Unit tests → Implementation |
+| DDD Architecture | ✅ COMPLIANT | Uses existing plugin domain structure (Package by Layered Feature) |
+| Library-First | ✅ COMPLIANT | Extends existing plugin infrastructure without new external libraries |
+| Security | ✅ COMPLIANT | API Key authentication, siteId ownership verification, no SQL injection risks |
+| Observability | ✅ COMPLIANT | Micrometer metrics, structured logging with MDC context |
+
+**Pre-Phase 0 Gate**: PASSED - No violations
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-plugin-sql-generation/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (OpenAPI)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/java/com/bitbi/dfm/plugin/
+├── domain/
+│   ├── Plugin.java                    # (existing) Plugin interface
+│   ├── PluginSqlGeneration.java       # NEW: Entity for SQL generation tracking
+│   └── PluginSqlGenerationRepository.java  # NEW: Repository interface
+├── application/
+│   ├── BitBiPlugin.java               # (existing) Extend with SQL generation
+│   ├── SqlGenerationService.java      # NEW: Core SQL generation orchestration
+│   ├── CsvDiffService.java            # NEW: CSV row-level diff logic
+│   ├── SqlStatementGenerator.java     # NEW: SQL statement formatting
+│   └── PluginApiKeyService.java       # NEW: API Key generation & validation
+├── infrastructure/
+│   ├── persistence/
+│   │   └── JpaPluginSqlGenerationRepository.java  # NEW
+│   └── storage/
+│       └── S3SqlFileStorageService.java           # NEW: S3 operations for SQL files
+└── presentation/
+    ├── BitBiPluginApiController.java  # NEW: Plugin API endpoints
+    └── dto/
+        ├── SqlChangesResponseDto.java # NEW
+        └── SiteListResponseDto.java   # NEW
+
+src/test/java/com/bitbi/dfm/plugin/
+├── contract/
+│   └── BitBiPluginApiContractTest.java  # NEW: API contract tests (TDD first)
+├── integration/
+│   ├── SqlGenerationIntegrationTest.java  # NEW
+│   └── PluginApiKeyIntegrationTest.java   # NEW
+└── unit/
+    ├── CsvDiffServiceTest.java            # NEW
+    └── SqlStatementGeneratorTest.java     # NEW
+
+src/main/resources/db/migration/
+└── V11__create_plugin_sql_generations_table.sql  # NEW
+```
+
+**Structure Decision**: Extends existing `plugin` package following DDD/PbLF pattern. No new packages created, all code lives within `com.bitbi.dfm.plugin`.
+
+## Complexity Tracking
+
+> **No constitution violations. This section is empty.**

--- a/specs/001-plugin-sql-generation/quickstart.md
+++ b/specs/001-plugin-sql-generation/quickstart.md
@@ -1,0 +1,266 @@
+# Quickstart: Plugin SQL Generation Extension
+
+**Feature Branch**: `001-plugin-sql-generation`
+**Date**: 2025-12-22
+
+## Prerequisites
+
+- Java 21 (LTS)
+- Docker & Docker Compose (for PostgreSQL, LocalStack)
+- Gradle 8.x (wrapper included)
+
+## Local Development Setup
+
+### 1. Start Infrastructure
+
+```bash
+# Start PostgreSQL and LocalStack (S3)
+docker-compose up -d postgres localstack
+
+# Wait for services to be ready
+docker-compose logs -f postgres  # Should show "database system is ready"
+
+# Create S3 bucket in LocalStack
+aws --endpoint-url=http://localhost:4566 s3 mb s3://dataforge-uploads
+```
+
+### 2. Run Database Migrations
+
+```bash
+./gradlew flywayMigrate
+```
+
+### 3. Run the Application
+
+```bash
+./gradlew bootRun --args='--spring.profiles.active=dev'
+```
+
+Application will be available at `http://localhost:8080`
+
+### 4. Verify Setup
+
+```bash
+# Check health
+curl http://localhost:8080/actuator/health
+
+# Check Swagger UI
+open http://localhost:8080/swagger-ui.html
+```
+
+---
+
+## TDD Development Workflow (MANDATORY)
+
+All development MUST follow the Red-Green-Refactor cycle:
+
+### Step 1: Write Failing Test (RED)
+
+```bash
+# Run tests to see them fail
+./gradlew test --tests "BitBiPluginApiContractTest"
+# Expected: FAILED - classes don't exist yet
+```
+
+### Step 2: Implement Minimum Code (GREEN)
+
+```bash
+# Implement just enough to make tests pass
+# Run tests again
+./gradlew test --tests "BitBiPluginApiContractTest"
+# Expected: PASSED
+```
+
+### Step 3: Refactor
+
+```bash
+# Clean up code while keeping tests green
+./gradlew test
+# Expected: All tests still pass
+```
+
+---
+
+## Test Commands
+
+```bash
+# Run all tests
+./gradlew test
+
+# Run specific test class
+./gradlew test --tests "BitBiPluginApiContractTest"
+
+# Run integration tests only
+./gradlew test --tests "*IntegrationTest"
+
+# Run with coverage
+./gradlew test jacocoTestReport
+open build/reports/jacoco/test/html/index.html
+```
+
+---
+
+## API Testing Examples
+
+### Activate Bit BI Plugin (get API Key)
+
+```bash
+# First, get an admin JWT token (Auth0)
+TOKEN="eyJhbG..."  # Your Auth0 token
+
+# Activate plugin for an account
+curl -X POST "http://localhost:8080/api/v1/plugins/bit-bi/activate" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tenantId": "my-tenant-id"
+  }'
+
+# Response includes the generated API Key:
+# {
+#   "pluginId": "bit-bi",
+#   "activatedAt": "2025-12-22T10:00:00Z",
+#   "apiKey": "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+# }
+```
+
+### List Sites (Plugin API)
+
+```bash
+API_KEY="plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+
+curl "http://localhost:8080/api/v1/plugins/bit-bi/sites" \
+  -H "X-Plugin-Api-Key: $API_KEY"
+
+# Response:
+# {
+#   "sites": [
+#     {"id": "...", "domain": "example.com", "displayName": "Example"}
+#   ]
+# }
+```
+
+### Get SQL Changes (Plugin API)
+
+```bash
+API_KEY="plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+SITE_ID="550e8400-e29b-41d4-a716-446655440000"
+SINCE="2025-01-01T00:00:00Z"
+
+curl "http://localhost:8080/api/v1/plugins/bit-bi/sql-changes?siteId=$SITE_ID&since=$SINCE" \
+  -H "X-Plugin-Api-Key: $API_KEY"
+
+# Response (text/plain):
+# INSERT INTO customers (id, name) VALUES ('1', 'John');
+# --- END OF COMMAND "customers.csv:2" ---
+```
+
+---
+
+## Key Files to Create (TDD Order)
+
+### Phase 1: Contract Tests (Write FIRST)
+
+1. `src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java`
+
+### Phase 2: Unit Tests
+
+2. `src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java`
+3. `src/test/java/com/bitbi/dfm/plugin/unit/SqlStatementGeneratorTest.java`
+4. `src/test/java/com/bitbi/dfm/plugin/unit/PluginApiKeyTest.java`
+
+### Phase 3: Integration Tests
+
+5. `src/test/java/com/bitbi/dfm/plugin/integration/SqlGenerationIntegrationTest.java`
+6. `src/test/java/com/bitbi/dfm/plugin/integration/PluginApiKeyIntegrationTest.java`
+
+### Phase 4: Implementation
+
+7. `src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGeneration.java`
+8. `src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java`
+9. `src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java`
+10. `src/main/java/com/bitbi/dfm/plugin/application/SqlStatementGenerator.java`
+11. `src/main/java/com/bitbi/dfm/plugin/application/PluginApiKeyService.java`
+12. `src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java`
+13. `src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java`
+14. `src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java`
+15. `src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java`
+
+### Phase 5: Database Migration
+
+16. `src/main/resources/db/migration/V11__create_plugin_sql_generations_table.sql`
+
+---
+
+## Troubleshooting
+
+### Tests fail with "Connection refused"
+
+```bash
+# Ensure Docker containers are running
+docker-compose ps
+
+# Restart if needed
+docker-compose restart postgres localstack
+```
+
+### S3 bucket not found
+
+```bash
+# Recreate bucket
+aws --endpoint-url=http://localhost:4566 s3 mb s3://dataforge-uploads
+```
+
+### Plugin not registered
+
+```bash
+# Check plugin_configs table
+docker-compose exec postgres psql -U dfm -d dataforge -c "SELECT * FROM plugin_configs;"
+
+# Should show 'bit-bi' plugin
+```
+
+### API Key validation fails
+
+```bash
+# Check account_plugins table for apiKey in plugin_data
+docker-compose exec postgres psql -U dfm -d dataforge -c \
+  "SELECT plugin_data FROM account_plugins WHERE plugin_id = 'bit-bi';"
+```
+
+---
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SPRING_PROFILES_ACTIVE` | Active profile | `dev` |
+| `S3_BUCKET_NAME` | S3 bucket for uploads | `dataforge-uploads` |
+| `S3_ENDPOINT_URL` | S3 endpoint (LocalStack) | `http://localhost:4566` |
+| `PLUGINS_BITBI_ENABLED` | Enable Bit BI plugin | `true` |
+
+### application-dev.yml additions
+
+```yaml
+plugins:
+  bitbi:
+    enabled: true
+    sql-generation:
+      timeout-seconds: 60  # SC-001: <60s for 100 files
+```
+
+---
+
+## Verification Checklist
+
+- [ ] PostgreSQL running with Flyway migrations applied
+- [ ] LocalStack S3 running with bucket created
+- [ ] Contract tests written and failing (RED)
+- [ ] Unit tests written and failing (RED)
+- [ ] Implementation code passes all tests (GREEN)
+- [ ] Integration tests pass with Testcontainers
+- [ ] API responds correctly to Plugin API Key authentication
+- [ ] SQL files generated and stored in S3
+- [ ] All tests pass: `./gradlew test`

--- a/specs/001-plugin-sql-generation/research.md
+++ b/specs/001-plugin-sql-generation/research.md
@@ -1,0 +1,285 @@
+# Research: Plugin SQL Generation Extension
+
+**Feature Branch**: `001-plugin-sql-generation`
+**Date**: 2025-12-22
+**Status**: Complete
+
+## 1. CSV Diff Algorithm for Row-Level Comparison
+
+### Decision: Row-based comparison with composite key detection
+
+**Rationale**: Unlike the existing `DiffServiceImpl` which performs line-level text diff, SQL generation requires semantic understanding of CSV structure to identify added, modified, and deleted rows.
+
+**Algorithm**:
+1. Parse both CSV files into memory as `List<Map<String, String>>` (column name → value)
+2. Detect row identity using ALL columns (no primary key assumption)
+3. Compare rows by exact value match across all columns
+4. Classify changes:
+   - **ADDED**: Row exists in current batch, not in previous
+   - **DELETED**: Row exists in previous batch, not in current
+   - **MODIFIED**: Row exists in both, but some values differ
+
+**Alternatives Considered**:
+- **java-diff-utils (existing)**: Line-level diff, doesn't understand CSV semantics
+- **CSV fingerprinting with hash**: Fast lookup but loses ability to detect which columns changed
+- **Row-by-row streaming comparison**: Memory efficient but O(n²) complexity
+
+**Implementation**: Use Apache Commons CSV for parsing (already in dependencies), in-memory HashMap for O(n) comparison.
+
+---
+
+## 2. DBF Type Information for NULL Handling
+
+### Decision: Type metadata embedded in CSV headers or separate metadata file
+
+**Rationale**: Spec requires different NULL handling based on field type:
+- Character, Numeric, Logical, Date, Float, DateTime → empty string = NULL
+- Integer, Currency → empty string = 0
+
+**Research Finding**: The spec mentions "DBF type information" which suggests the source data comes from dBASE format. Two options for type metadata:
+
+**Option A (Recommended)**: Header convention `column_name:TYPE`
+- Example: `name:C`, `age:N`, `price:Y` where C=Character, N=Numeric, Y=Currency
+- Parsed at CSV load time
+- Simple, self-contained
+
+**Option B**: Separate `.meta.json` file per CSV
+- Example: `customers.csv` + `customers.meta.json` with type mappings
+- More complex but allows rich metadata
+
+**Decision**: Implement Option A with fallback to Option B if header doesn't contain types. Default to Character type (NULL for empty) if no type info available.
+
+**DBF Type Mapping**:
+| DBF Type | Code | Empty String Handling |
+|----------|------|----------------------|
+| Character | C | NULL |
+| Numeric | N | NULL |
+| Logical | L | NULL |
+| Date | D | NULL |
+| Float | F | NULL |
+| DateTime | T | NULL |
+| Integer | I | 0 |
+| Currency | Y | 0 |
+
+---
+
+## 3. Plugin API Key Authentication
+
+### Decision: Prefix-based API Key stored in account_plugins.plugin_data JSONB
+
+**Rationale**: API Key must be:
+1. Generated on plugin activation
+2. Unique per account
+3. Rotatable (re-activation generates new key)
+4. Fast to validate (<50ms per SC-004)
+
+**Format**: `plk_` + 32 alphanumeric characters = 36 characters total
+- `plk_` prefix identifies as Plugin API Key
+- 32 chars of Base62 provides ~190 bits of entropy
+
+**Storage**: `account_plugins.plugin_data` JSONB field, alongside existing `tenantId`:
+```json
+{
+  "tenantId": "bit-bi-tenant-123",
+  "apiKey": "plk_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6"
+}
+```
+
+**Validation**: Add GIN index on `plugin_data` JSONB for fast lookup by `apiKey`.
+
+**Existing Index**: `idx_account_plugins_data ON account_plugins USING GIN(plugin_data)` already exists (V8 migration).
+
+**Alternative Considered**: Separate `plugin_api_keys` table - rejected because:
+- Adds complexity (new entity, migration, repository)
+- No benefit over JSONB storage with existing index
+
+---
+
+## 4. S3 Path Structure for SQL Files
+
+### Decision: `plugins/bit-bi/{accountId}/{siteName}/{source_datetime}--{comparison_datetime}.sql`
+
+**Rationale**:
+- Consistent with spec FR-009
+- `siteName` is human-readable (domain), not UUID
+- Double-dash `--` separates source and comparison timestamps
+- First batch uses `{source_datetime}--first-batch.sql`
+
+**Example Paths**:
+- Regular: `plugins/bit-bi/550e8400-e29b-41d4-a716-446655440000/example.com/2025-12-22T14-30-00--2025-12-22T15-00-00.sql`
+- First batch: `plugins/bit-bi/550e8400-e29b-41d4-a716-446655440000/example.com/2025-12-22T14-30-00--first-batch.sql`
+
+**Timestamp Format**: ISO8601 with colons replaced by hyphens (`T14-30-00` instead of `T14:30:00`) for S3 key compatibility.
+
+---
+
+## 5. SQL Statement Formatting
+
+### Decision: PostgreSQL-specific syntax with trailing comments
+
+**Rationale**: Spec explicitly mentions PostgreSQL and requires comment format after each statement.
+
+**INSERT Format**:
+```sql
+INSERT INTO tablename (col1, col2, col3) VALUES ('val1', 'val2', 123);
+--- END OF COMMAND "filename.csv:42" ---
+```
+
+**UPDATE Format**:
+```sql
+UPDATE tablename SET col1 = 'new_val' WHERE col2 = 'unchanged1' AND col3 = 'unchanged2';
+--- END OF COMMAND "filename.csv:42" ---
+```
+
+**DELETE Format**:
+```sql
+DELETE FROM tablename WHERE col1 = 'val1' AND col2 = 'val2' AND col3 = 'val3';
+--- END OF COMMAND "filename.csv:42" ---
+```
+
+**Value Escaping**:
+- Single quotes doubled: `O'Brien` → `'O''Brien'`
+- NULL values: unquoted `NULL` keyword
+- Integer/Currency zeros: unquoted `0`
+- All other values: single-quoted strings
+
+**Table Name Derivation**: CSV filename without extension (e.g., `customers.csv` → `customers`)
+
+---
+
+## 6. Batch Comparison Strategy
+
+### Decision: Compare files by filename match between batches
+
+**Rationale**: Spec requires comparing "current batch files against previous batch files for the same site".
+
+**Matching Logic**:
+1. Get list of files from current batch (from `uploaded_files` table)
+2. Get list of files from previous batch for same site (most recent COMPLETED batch)
+3. Match files by `original_file_name` (exact match, case-sensitive)
+4. For matched files: generate UPDATE/DELETE/INSERT based on row diff
+5. For new files (in current, not in previous): generate INSERT for all rows
+6. For deleted files (in previous, not in current): generate DELETE for all rows
+
+**Edge Cases**:
+- First batch: No previous batch exists → INSERT all rows from all files
+- File renamed: Treated as delete + add (no rename detection)
+
+---
+
+## 7. Plugin Event Integration
+
+### Decision: Extend existing BitBiPlugin.execute() method
+
+**Rationale**: The plugin infrastructure already dispatches `BATCH_COMPLETED` events to BitBiPlugin. SQL generation should be triggered within this existing flow.
+
+**Current Flow**:
+1. `BatchService.completeBatch()` publishes `BatchCompletedEvent`
+2. `BatchEventListener.onBatchCompleted()` creates `PluginEvent` and calls `PluginEventDispatcher.dispatch()`
+3. `PluginEventDispatcher` finds active `AccountPlugin` records and calls `plugin.execute()`
+4. `BitBiPlugin.execute()` currently logs (no-op)
+
+**Extended Flow** (this feature):
+1-3. Same as above
+4. `BitBiPlugin.execute()` calls `SqlGenerationService.generateForBatch(batchId, accountPlugin)`
+5. `SqlGenerationService` orchestrates:
+   - Find previous batch for same site
+   - For each matched file pair, call `CsvDiffService.diff()`
+   - For each diff result, call `SqlStatementGenerator.generate()`
+   - Concatenate all SQL into single file
+   - Upload to S3 via `S3SqlFileStorageService`
+   - Save metadata to `plugin_sql_generations` table
+
+**Async Consideration**: Plugin execution already runs on `pluginExecutionExecutor` (10 core threads, 20 max). SQL generation can run synchronously within the 30-second timeout. For batches with many large files, may need to extend timeout or use dedicated executor.
+
+---
+
+## 8. API Key Validation Performance
+
+### Decision: Database lookup with JSONB containment query
+
+**Rationale**: Need to validate API Key and retrieve associated accountId in <50ms.
+
+**Query**:
+```sql
+SELECT account_id FROM account_plugins
+WHERE plugin_id = 'bit-bi'
+  AND is_active = true
+  AND plugin_data @> '{"apiKey": "plk_xxx..."}'::jsonb
+```
+
+**Performance**: GIN index on `plugin_data` supports `@>` operator. Expected query time <10ms with index.
+
+**Alternative Considered**: In-memory cache with TTL - rejected for v1 due to:
+- Added complexity (cache invalidation on key rotation)
+- Database query fast enough to meet SLA
+- Can add caching later if needed
+
+---
+
+## 9. Existing Infrastructure Reuse
+
+### Can Reuse:
+- `S3FileContentService`: Fetch CSV content from S3 (supports gzip decompression)
+- `CsvDecompressionService`: Handle .csv.gz files
+- Apache Commons CSV (1.12.0): CSV parsing
+- `PluginEventDispatcher`: Event delivery infrastructure
+- `AccountPluginRepository`: API Key storage
+- `PluginAuditLogRepository`: Audit trail
+
+### Must Create New:
+- `PluginSqlGeneration`: Entity for tracking SQL file generation
+- `CsvDiffService`: Row-level CSV comparison (semantic diff, not text diff)
+- `SqlStatementGenerator`: PostgreSQL statement formatting
+- `S3SqlFileStorageService`: Upload SQL files to plugin-specific S3 path
+- `PluginApiKeyService`: Key generation and validation
+- `BitBiPluginApiController`: REST endpoints for Plugin API
+
+---
+
+## 10. TDD Implementation Order
+
+**MANDATORY**: All development follows TDD cycle (Red → Green → Refactor).
+
+### Phase 1: Contract Tests First
+1. Write `BitBiPluginApiContractTest` with MockMvc
+   - `GET /api/v1/plugins/bit-bi/sql-changes` - 401, 403, 200 scenarios
+   - `GET /api/v1/plugins/bit-bi/sites` - 401, 200 scenarios
+2. Tests MUST fail initially (Red phase)
+
+### Phase 2: Domain & Application Layer
+1. Write unit tests for `CsvDiffServiceTest`
+   - Test row comparison logic
+   - Test DBF type handling
+2. Write unit tests for `SqlStatementGeneratorTest`
+   - Test INSERT, UPDATE, DELETE formatting
+   - Test NULL handling by type
+   - Test special character escaping
+3. Implement services to pass tests (Green phase)
+
+### Phase 3: Integration Tests
+1. Write `SqlGenerationIntegrationTest` with Testcontainers
+   - End-to-end batch completion → SQL file generation
+2. Write `PluginApiKeyIntegrationTest`
+   - Key generation on activation
+   - Key validation performance
+
+### Phase 4: API Implementation
+1. Implement `BitBiPluginApiController` to pass contract tests
+2. Verify all tests pass
+
+---
+
+## Summary of Decisions
+
+| Topic | Decision |
+|-------|----------|
+| CSV Diff | Row-based with HashMap for O(n) comparison |
+| DBF Types | Header convention `column:TYPE` with fallback |
+| API Key | `plk_` + 32 alphanumeric in plugin_data JSONB |
+| S3 Path | `plugins/bit-bi/{accountId}/{siteName}/{timestamps}.sql` |
+| SQL Format | PostgreSQL with `--- END OF COMMAND "file:line" ---` |
+| Batch Matching | By filename, previous = most recent COMPLETED for site |
+| Event Integration | Extend BitBiPlugin.execute() |
+| Key Validation | JSONB containment query with GIN index |
+| TDD Order | Contract → Unit → Integration → Implementation |

--- a/specs/001-plugin-sql-generation/spec.md
+++ b/specs/001-plugin-sql-generation/spec.md
@@ -1,0 +1,208 @@
+# Feature Specification: Plugin SQL Generation Extension
+
+**Feature Branch**: `001-plugin-sql-generation`
+**Created**: 2025-12-22
+**Status**: Draft
+**Extends**: PRD-013 (Plugin System & Bit BI OAuth Integration)
+**Input**: User description: "Extension to plugin system for automatic SQL file generation based on sequential batch upload differences"
+
+## Overview
+
+This feature extends the existing plugin system (PRD-013) to automatically generate PostgreSQL SQL files when batch uploads complete. The system compares files between consecutive batches for the same site and produces SQL statements (INSERT, UPDATE, DELETE) reflecting the differences. A Plugin API allows Bit BI users to retrieve these SQL changes by site and date.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Automatic Diff Generation on Batch Completion (Priority: P1)
+
+When a batch upload completes for an account with the Bit BI plugin activated, the system automatically compares all files in the current batch against the previous batch for the same site and generates SQL statements.
+
+**Why this priority**: This is the core automation that enables the entire feature. Without automatic diff generation, no SQL files can be created.
+
+**Independent Test**: Can be fully tested by uploading two consecutive batches to a site with Bit BI plugin active and verifying SQL file generation in S3.
+
+**Acceptance Scenarios**:
+
+1. **Given** an account with activated Bit BI plugin, **When** a batch upload completes (`BATCH_COMPLETED` event), **Then** the system automatically generates a diff between current batch files and previous batch files for the same site.
+
+2. **Given** this is the first batch for a site, **When** the batch upload completes, **Then** INSERT statements are generated for all rows in all CSV files.
+
+3. **Given** a previous batch exists for the site, **When** diff is executed, **Then** the result contains added rows (INSERT), modified rows (UPDATE), and deleted rows (DELETE).
+
+4. **Given** the Bit BI plugin is deactivated for the account, **When** a batch upload completes, **Then** no diff or SQL generation occurs.
+
+---
+
+### User Story 2 - SQL File Generation from Diff Results (Priority: P1)
+
+Based on the diff results, the system generates PostgreSQL SQL files with properly formatted INSERT, UPDATE, and DELETE statements.
+
+**Why this priority**: Without SQL generation, the diff results cannot be consumed by downstream systems. This is essential for delivering value.
+
+**Independent Test**: Can be tested by providing mock diff results and verifying the generated SQL statements match expected format and content.
+
+**Acceptance Scenarios**:
+
+1. **Given** a diff shows an added row, **When** SQL is generated, **Then** an `INSERT INTO {table} (...) VALUES (...)` statement is created with all column values.
+
+2. **Given** a diff shows a modified row, **When** SQL is generated, **Then** an `UPDATE {table} SET changed_col=new_val WHERE unchanged_col1=val1 AND unchanged_col2=val2` statement is created using unchanged fields in the WHERE clause.
+
+3. **Given** a diff shows a deleted row, **When** SQL is generated, **Then** a `DELETE FROM {table} WHERE col1=val1 AND col2=val2 AND ...` statement is created using all fields in the WHERE clause.
+
+4. **Given** any SQL statement is generated, **When** formatting is applied, **Then** a comment `--- END OF COMMAND "{filename}:{line_number}" ---` is appended after each statement.
+
+5. **Given** an empty string value in a Character/Numeric/Date type field, **When** SQL is generated, **Then** the value is represented as NULL.
+
+6. **Given** an empty string value in an Integer or Currency type field, **When** SQL is generated, **Then** the value is represented as 0 (not NULL).
+
+---
+
+### User Story 3 - Retrieve SQL Changes via Plugin API (Priority: P1)
+
+Bit BI users with a valid Plugin API Key can retrieve all SQL changes for a specific site after a given date through an API endpoint.
+
+**Why this priority**: This is the primary way consumers access the generated SQL. Without this endpoint, the generated files have no practical use.
+
+**Independent Test**: Can be tested by making API requests with valid/invalid credentials and verifying correct responses and authorization.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Plugin API Key, **When** requesting `GET /sql-changes?siteId=X&since=2025-01-01T00:00:00Z`, **Then** all SQL changes for site X after the specified date are returned as plain text.
+
+2. **Given** an invalid API Key, **When** the request is executed, **Then** 401 Unauthorized is returned.
+
+3. **Given** a valid API Key but siteId does not belong to the account, **When** the request is executed, **Then** 403 Forbidden is returned.
+
+4. **Given** no changes exist after the specified date, **When** the request is executed, **Then** 200 OK with empty body is returned.
+
+5. **Given** multiple SQL files exist for the site after the date, **When** the request is executed, **Then** all files are concatenated and returned in chronological order.
+
+---
+
+### User Story 4 - List Available Sites via Plugin API (Priority: P2)
+
+Bit BI users can retrieve a list of sites available for their account through the Plugin API.
+
+**Why this priority**: Helps users discover which sites they can query. Useful but not essential for core functionality.
+
+**Independent Test**: Can be tested by making API request with valid API Key and verifying site list matches account's sites.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Plugin API Key, **When** requesting `GET /sites`, **Then** a list of all sites belonging to the account is returned with id, name, and domain.
+
+2. **Given** an invalid API Key, **When** the request is executed, **Then** 401 Unauthorized is returned.
+
+---
+
+### User Story 5 - SQL File Storage in S3 (Priority: P2)
+
+Generated SQL files are stored in AWS S3 with a structured path for organization and retrieval.
+
+**Why this priority**: Storage is required for the API to function, but the specific path structure is a detail that can be adjusted.
+
+**Independent Test**: Can be tested by triggering SQL generation and verifying file exists at expected S3 path.
+
+**Acceptance Scenarios**:
+
+1. **Given** an SQL file is generated, **When** saved to S3, **Then** the path follows: `plugins/bit-bi/{accountId}/{siteName}/{source_datetime}--{comparison_datetime}.sql`.
+
+2. **Given** this is the first batch for a site, **When** saved to S3, **Then** the path uses: `plugins/bit-bi/{accountId}/{siteName}/{source_datetime}--first-batch.sql`.
+
+3. **Given** a file is successfully saved, **When** requested through the API, **Then** the content is loaded from S3 and returned to the client.
+
+---
+
+### User Story 6 - Plugin API Key Generation (Priority: P2)
+
+When the Bit BI plugin is activated, a Plugin API Key is generated and stored for API authentication.
+
+**Why this priority**: Required for API authentication but can reuse existing plugin activation infrastructure.
+
+**Independent Test**: Can be tested by activating Bit BI plugin and verifying API Key is generated and stored in plugin_data.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user activates the Bit BI plugin, **When** activation completes, **Then** a Plugin API Key is generated in format `plk_` + 32 alphanumeric characters.
+
+2. **Given** a Plugin API Key is generated, **When** stored, **Then** it is saved in `account_plugins.plugin_data` JSONB field alongside tenantId.
+
+3. **Given** an existing API Key exists, **When** plugin is re-activated, **Then** a new API Key is generated (key rotation).
+
+---
+
+### Edge Cases
+
+- **Empty diff (identical files)**: No SQL file is created, no record in plugin_sql_generations
+- **Binary files in batch**: Skipped - only CSV/text files are processed
+- **Batch with no files**: No SQL file is created
+- **Site deleted after SQL generation**: SQL files remain in S3 for audit purposes
+- **File encoding detection**: Auto-detect using ICU4J for UTF-8, Windows-1252, ISO-8859-1
+- **Special characters in values**: Properly escaped in SQL statements (single quotes doubled)
+- **NULL vs empty string**: Handled according to DBF type rules (see US2 scenarios 5-6)
+- **Large files**: Streaming processing to avoid memory issues
+- **Concurrent batch completions**: Each processed independently with unique SQL file
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### SQL Generation
+
+- **FR-001**: System MUST automatically trigger diff generation when `BATCH_COMPLETED` event occurs for accounts with activated Bit BI plugin
+- **FR-002**: System MUST generate `INSERT INTO {table} (...) VALUES (...)` statements for added rows
+- **FR-003**: System MUST generate `UPDATE {table} SET ... WHERE ...` statements for modified rows, using unchanged fields in WHERE clause
+- **FR-004**: System MUST generate `DELETE FROM {table} WHERE ...` statements for deleted rows, using all fields in WHERE clause
+- **FR-005**: System MUST append comment `--- END OF COMMAND "{filename}:{line_number}" ---` after each SQL statement
+- **FR-006**: System MUST convert empty strings to NULL for Character, Numeric, Logical, Date, Float, DateTime types
+- **FR-007**: System MUST convert empty strings to 0 (not NULL) for Integer and Currency types
+- **FR-008**: System MUST derive table names from CSV filenames (without extension)
+- **FR-009**: System MUST save SQL files to S3 at path `plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql`
+
+#### Plugin API
+
+- **FR-010**: System MUST provide endpoint `GET /api/v1/plugins/bit-bi/sql-changes` accepting siteId and since parameters
+- **FR-011**: System MUST provide endpoint `GET /api/v1/plugins/bit-bi/sites` returning account's sites
+- **FR-012**: System MUST validate Plugin API Key on all plugin API requests
+- **FR-013**: System MUST verify siteId belongs to the API Key's account before returning data
+- **FR-014**: System MUST return 401 Unauthorized for invalid or missing API Key
+- **FR-015**: System MUST return 403 Forbidden when siteId does not belong to account
+- **FR-016**: System MUST generate Plugin API Key (format: `plk_` + 32 alphanumeric) when Bit BI plugin is activated
+
+#### Data Storage
+
+- **FR-017**: System MUST track SQL generations in database with metadata (site, batch IDs, S3 key, file size, statement count, timestamp)
+- **FR-018**: System MUST support lookup of SQL generations by site and date range
+
+### Key Entities
+
+- **PluginSqlGeneration**: Tracks each SQL file generation - links to account plugin, site, source batch, comparison batch, S3 location, and metadata
+- **Plugin API Key**: Authentication credential stored in account_plugins.plugin_data - bound to account, grants access to all account sites
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: SQL generation completes within 60 seconds for a batch containing 100 CSV files
+- **SC-002**: API endpoint `GET /sql-changes` returns response within 2 seconds
+- **SC-003**: 100% of row additions, modifications, and deletions are accurately reflected in generated SQL
+- **SC-004**: API Key validation completes in under 50 milliseconds
+- **SC-005**: All API calls and SQL generations are recorded in audit trail
+- **SC-006**: Users can retrieve SQL changes for any site within their account without errors
+- **SC-007**: First batch for a site generates valid INSERT statements for all rows
+
+## Assumptions
+
+- The existing plugin infrastructure (PRD-013) is fully implemented and functional
+- `PluginEventDispatcher` correctly dispatches `BATCH_COMPLETED` events to registered plugins
+- CSV files use standard delimiters (comma, semicolon, or tab) and can be auto-detected
+- S3 bucket `dataforge-uploads` exists and is accessible by the application
+- DBF type information is available for each column to determine NULL handling rules
+
+## Out of Scope
+
+- Web UI for viewing SQL files (API-only access)
+- Support for SQL dialects other than PostgreSQL
+- Manual triggering of diff (automatic on BATCH_COMPLETED only)
+- Editing generated SQL files
+- Regeneration of SQL for existing batches
+- Real-time streaming of SQL changes (batch retrieval only)

--- a/specs/001-plugin-sql-generation/tasks.md
+++ b/specs/001-plugin-sql-generation/tasks.md
@@ -1,0 +1,335 @@
+# Tasks: Plugin SQL Generation Extension
+
+**Input**: Design documents from `/specs/001-plugin-sql-generation/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: TDD is MANDATORY for this feature. All tests must be written FIRST and verified to FAIL before implementation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Backend**: `src/main/java/com/bitbi/dfm/plugin/` (following existing PbLF structure)
+- **Tests**: `src/test/java/com/bitbi/dfm/plugin/`
+- **Migrations**: `src/main/resources/db/migration/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Database schema and shared value objects needed by all user stories
+
+- [x] T001 Create database migration V11__create_plugin_sql_generations_table.sql in src/main/resources/db/migration/
+- [x] T002 [P] Create SqlGenerationStats record in src/main/java/com/bitbi/dfm/plugin/domain/SqlGenerationStats.java
+- [x] T003 [P] Create CsvRowDiff record in src/main/java/com/bitbi/dfm/plugin/domain/CsvRowDiff.java
+- [x] T004 [P] Create DbfColumnType enum in src/main/java/com/bitbi/dfm/plugin/domain/DbfColumnType.java
+- [x] T005 [P] Create PluginApiKey value object in src/main/java/com/bitbi/dfm/plugin/domain/PluginApiKey.java
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before ANY user story can be implemented
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T006 Create PluginSqlGeneration entity in src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGeneration.java
+- [x] T007 Create PluginSqlGenerationRepository interface in src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
+- [x] T008 Implement JpaPluginSqlGenerationRepository in src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
+- [x] T009 [P] Create SqlChangesResponseDto record in src/main/java/com/bitbi/dfm/plugin/presentation/dto/SqlChangesResponseDto.java
+- [x] T010 [P] Create SiteListResponseDto record in src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteListResponseDto.java
+- [x] T011 [P] Create SiteDto record in src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteDto.java
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Automatic Diff Generation on Batch Completion (Priority: P1)
+
+**Goal**: Automatically compare CSV files between consecutive batches when BATCH_COMPLETED event fires for accounts with active Bit BI plugin
+
+**Independent Test**: Upload two consecutive batches to a site with Bit BI plugin active and verify diff results are produced
+
+### Tests for User Story 1 (TDD - Write FIRST)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T012 [P] [US1] Unit test CsvDiffServiceTest in src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java - test row comparison logic, DBF type handling, added/modified/deleted detection
+- [x] T013 [P] [US1] Integration test SqlGenerationIntegrationTest batch completion trigger in src/test/java/com/bitbi/dfm/plugin/integration/SqlGenerationIntegrationTest.java - test BATCH_COMPLETED event triggers diff generation
+
+### Implementation for User Story 1
+
+- [x] T014 [US1] Implement CsvDiffService in src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java - row-based comparison with HashMap for O(n), handle DBF types
+- [x] T015 [US1] Extend BitBiPlugin.execute() to call SqlGenerationService on BATCH_COMPLETED event in src/main/java/com/bitbi/dfm/plugin/application/BitBiPlugin.java
+- [x] T016 [US1] Add findPreviousBatchForSite query to BatchRepository in src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
+- [x] T017 [US1] Add metrics for diff generation (diff.files.processed, diff.duration) using Micrometer
+
+**Checkpoint**: At this point, User Story 1 should be fully functional - batch completion triggers CSV diff generation
+
+---
+
+## Phase 4: User Story 2 - SQL File Generation from Diff Results (Priority: P1)
+
+**Goal**: Generate PostgreSQL SQL files (INSERT, UPDATE, DELETE) from diff results with proper formatting and NULL handling
+
+**Independent Test**: Provide mock diff results and verify generated SQL statements match expected format
+
+**Depends on**: US1 (diff results are input to SQL generation)
+
+### Tests for User Story 2 (TDD - Write FIRST)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T018 [P] [US2] Unit test SqlStatementGeneratorTest in src/test/java/com/bitbi/dfm/plugin/unit/SqlStatementGeneratorTest.java - test INSERT, UPDATE, DELETE formatting, NULL handling by type, special character escaping, END OF COMMAND comments
+- [x] T019 [P] [US2] Integration test SqlGenerationIntegrationTest full generation in src/test/java/com/bitbi/dfm/plugin/integration/SqlGenerationIntegrationTest.java - test end-to-end from batch completion to SQL file
+
+### Implementation for User Story 2
+
+- [x] T020 [US2] Implement SqlStatementGenerator in src/main/java/com/bitbi/dfm/plugin/application/SqlStatementGenerator.java - PostgreSQL syntax, value escaping, NULL/0 by type, END OF COMMAND comments
+- [x] T021 [US2] Implement SqlGenerationService orchestration in src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java - find previous batch, call diff service, call statement generator, aggregate results
+- [x] T022 [US2] Add metrics for SQL generation (sql.statements.generated, sql.generation.duration) using Micrometer
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should work together - batch completion generates SQL content
+
+---
+
+## Phase 5: User Story 5 - SQL File Storage in S3 (Priority: P2)
+
+**Goal**: Store generated SQL files in S3 with structured path for retrieval
+
+**Independent Test**: Trigger SQL generation and verify file exists at expected S3 path
+
+**Depends on**: US2 (SQL content to store)
+
+**Note**: Promoted before US3 (API) because US3 needs S3 storage to retrieve files
+
+### Tests for User Story 5 (TDD - Write FIRST)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T023 [P] [US5] Integration test S3SqlFileStorageServiceTest in src/test/java/com/bitbi/dfm/plugin/integration/S3SqlFileStorageServiceTest.java - test S3 upload path structure, content retrieval, first batch vs comparison batch paths
+
+### Implementation for User Story 5
+
+- [x] T024 [US5] Implement S3SqlFileStorageService in src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java - upload SQL files with path plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
+- [x] T025 [US5] Update SqlGenerationService to save SQL to S3 and record in plugin_sql_generations table in src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
+- [x] T026 [US5] Add metrics for S3 operations (s3.sql.upload.duration, s3.sql.file.size) using Micrometer
+
+**Checkpoint**: At this point, US1 + US2 + US5 work together - batch completion generates and stores SQL files
+
+---
+
+## Phase 6: User Story 6 - Plugin API Key Generation (Priority: P2)
+
+**Goal**: Generate Plugin API Key on Bit BI plugin activation for API authentication
+
+**Independent Test**: Activate Bit BI plugin and verify API Key is generated and stored in plugin_data
+
+**Note**: Promoted before US3/US4 (API) because those endpoints require API Key authentication
+
+### Tests for User Story 6 (TDD - Write FIRST)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T027 [P] [US6] Unit test PluginApiKeyTest in src/test/java/com/bitbi/dfm/plugin/unit/PluginApiKeyTest.java - test key format (plk_ + 32 alphanumeric), generation, validation
+- [ ] T028 [P] [US6] Integration test PluginApiKeyIntegrationTest in src/test/java/com/bitbi/dfm/plugin/integration/PluginApiKeyIntegrationTest.java - test key generation on activation, key rotation on re-activation, key validation performance (<50ms)
+
+### Implementation for User Story 6
+
+- [x] T029 [US6] Implement PluginApiKeyService in src/main/java/com/bitbi/dfm/plugin/application/PluginApiKeyService.java - generate key, validate key, find account by key (JSONB containment query)
+- [ ] T030 [US6] Extend BitBiPlugin activation to generate and store API Key in plugin_data in src/main/java/com/bitbi/dfm/plugin/application/BitBiPlugin.java
+- [ ] T031 [US6] Update extended JSON schema for account_plugins.plugin_data (add apiKey field validation)
+
+**Checkpoint**: At this point, API Key infrastructure is ready for API endpoints
+
+---
+
+## Phase 7: User Story 3 - Retrieve SQL Changes via Plugin API (Priority: P1)
+
+**Goal**: Expose GET /api/v1/plugins/bit-bi/sql-changes endpoint for retrieving SQL changes by site and date
+
+**Independent Test**: Make API requests with valid/invalid credentials and verify correct responses
+
+**Depends on**: US5 (S3 storage), US6 (API Key auth)
+
+### Tests for User Story 3 (TDD - Write FIRST)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T032 [P] [US3] Contract test BitBiPluginApiContractTest GET /sql-changes in src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java - test 200 OK with SQL content, 200 OK empty body, 400 invalid params, 401 unauthorized, 403 forbidden (site not owned)
+- [ ] T033 [P] [US3] Integration test PluginApiIntegrationTest GET /sql-changes in src/test/java/com/bitbi/dfm/plugin/integration/PluginApiIntegrationTest.java - test end-to-end with Testcontainers
+
+### Implementation for User Story 3
+
+- [ ] T034 [US3] Implement PluginApiKeyAuthenticationFilter in src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java - extract X-Plugin-Api-Key header, validate, set authentication context
+- [ ] T035 [US3] Configure Spring Security for /api/v1/plugins/bit-bi/** to use PluginApiKeyAuthenticationFilter
+- [ ] T036 [US3] Implement BitBiPluginApiController GET /sql-changes in src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java - validate siteId ownership, fetch SQL generations, concatenate S3 content, return text/plain
+- [ ] T037 [US3] Add SqlChangesQueryService for retrieving and concatenating SQL files in src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
+
+**Checkpoint**: At this point, User Story 3 should be fully functional - API returns SQL changes
+
+---
+
+## Phase 8: User Story 4 - List Available Sites via Plugin API (Priority: P2)
+
+**Goal**: Expose GET /api/v1/plugins/bit-bi/sites endpoint for listing account's sites
+
+**Independent Test**: Make API request with valid API Key and verify site list matches account's sites
+
+**Depends on**: US6 (API Key auth)
+
+### Tests for User Story 4 (TDD - Write FIRST)
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T038 [P] [US4] Contract test BitBiPluginApiContractTest GET /sites in src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java - test 200 OK with site list, 401 unauthorized
+- [ ] T039 [P] [US4] Integration test PluginApiIntegrationTest GET /sites in src/test/java/com/bitbi/dfm/plugin/integration/PluginApiIntegrationTest.java - test end-to-end with Testcontainers
+
+### Implementation for User Story 4
+
+- [ ] T040 [US4] Implement BitBiPluginApiController GET /sites in src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java - extract accountId from auth, fetch sites, map to SiteDto
+
+**Checkpoint**: At this point, User Story 4 should be fully functional - API returns site list
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements that affect multiple user stories
+
+- [ ] T041 [P] Add OpenAPI documentation annotations to BitBiPluginApiController
+- [ ] T042 [P] Add MDC context (siteId, batchId, accountId) to all SQL generation operations for structured logging
+- [ ] T043 [P] Add plugin audit log entries for SQL generation events using PluginAuditLogRepository
+- [ ] T044 Run all tests and verify coverage with ./gradlew test jacocoTestReport
+- [ ] T045 Run quickstart.md validation scenarios manually
+- [ ] T046 Update CLAUDE.md with Plugin SQL Generation section documenting new components
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **US1 Diff Generation (Phase 3)**: Depends on Foundational
+- **US2 SQL Generation (Phase 4)**: Depends on US1 (uses diff results)
+- **US5 S3 Storage (Phase 5)**: Depends on US2 (stores SQL content)
+- **US6 API Key (Phase 6)**: Depends on Foundational (can parallelize with US1-US5)
+- **US3 SQL Changes API (Phase 7)**: Depends on US5 + US6 (needs storage + auth)
+- **US4 Sites API (Phase 8)**: Depends on US6 (needs auth)
+- **Polish (Phase 9)**: Depends on all user stories being complete
+
+### User Story Dependencies (Visual)
+
+```
+Setup → Foundational ─┬─→ US1 (Diff) → US2 (SQL Gen) → US5 (S3) ─┬─→ US3 (SQL API)
+                      │                                          │
+                      └─→ US6 (API Key) ────────────────────────┴─→ US4 (Sites API)
+```
+
+### Critical Path
+
+1. **MVP**: Setup → Foundational → US1 → US2 → US5 → US6 → US3 (provides core value)
+2. **Full Feature**: + US4 + Polish
+
+### Within Each User Story (TDD Order)
+
+1. Tests MUST be written and FAIL before implementation
+2. Unit tests before integration tests
+3. Domain/application layer before infrastructure
+4. Implementation to pass tests (Green)
+5. Refactor if needed while keeping tests green
+
+### Parallel Opportunities
+
+**Phase 1 (Setup)**:
+```bash
+# Run in parallel (different files):
+T002 SqlGenerationStats
+T003 CsvRowDiff
+T004 DbfColumnType
+T005 PluginApiKey
+```
+
+**Phase 2 (Foundational)**:
+```bash
+# Run in parallel (different files):
+T009 SqlChangesResponseDto
+T010 SiteListResponseDto
+T011 SiteDto
+```
+
+**Tests within each User Story**:
+```bash
+# US1 tests in parallel:
+T012 CsvDiffServiceTest
+T013 SqlGenerationIntegrationTest (batch trigger part)
+
+# US3 tests in parallel:
+T032 BitBiPluginApiContractTest (/sql-changes)
+T033 PluginApiIntegrationTest (/sql-changes)
+```
+
+**US6 can run in parallel with US1-US5** (API Key generation is independent of SQL generation flow)
+
+---
+
+## Implementation Strategy
+
+### MVP First (Core SQL Generation + API)
+
+1. Complete Phase 1: Setup (T001-T005)
+2. Complete Phase 2: Foundational (T006-T011)
+3. Complete Phase 3: US1 - Diff Generation (T012-T017)
+4. Complete Phase 4: US2 - SQL Generation (T018-T022)
+5. Complete Phase 5: US5 - S3 Storage (T023-T026)
+6. Complete Phase 6: US6 - API Key (T027-T031)
+7. Complete Phase 7: US3 - SQL Changes API (T032-T037)
+8. **STOP and VALIDATE**: Test end-to-end: batch upload → SQL generation → API retrieval
+
+### Incremental Delivery
+
+1. **Milestone 1** (US1+US2+US5): Batch completion generates and stores SQL files
+   - Verify: Upload batches, check S3 for SQL files
+2. **Milestone 2** (+ US6): API Key generation works
+   - Verify: Activate plugin, get API Key
+3. **Milestone 3** (+ US3): SQL Changes API works (MVP COMPLETE!)
+   - Verify: API returns SQL content
+4. **Milestone 4** (+ US4): Sites API works
+   - Verify: API returns site list
+5. **Milestone 5** (Polish): Documentation, logging, audit trail
+
+### Estimated Task Count by Phase
+
+| Phase | Tasks | Parallelizable |
+|-------|-------|----------------|
+| Setup | 5 | 4 |
+| Foundational | 6 | 3 |
+| US1 (P1) | 6 | 2 |
+| US2 (P1) | 5 | 2 |
+| US5 (P2) | 4 | 1 |
+| US6 (P2) | 5 | 2 |
+| US3 (P1) | 6 | 2 |
+| US4 (P2) | 3 | 2 |
+| Polish | 6 | 3 |
+| **Total** | **46** | **21** |
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- TDD is MANDATORY: All tests must be written FIRST and verified to FAIL
+- Each user story should be independently testable after completion
+- Commit after each task or logical group
+- Stop at any checkpoint to validate progress
+- US1+US2 are tightly coupled (diff → SQL gen) but US2 depends on US1 output
+- US3+US4 both require US6 (API Key auth) to function

--- a/src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
@@ -47,4 +47,14 @@ public interface BatchRepository {
     Page<Batch> findAll(Pageable pageable);
 
     boolean existsById(UUID id);
+
+    /**
+     * Finds the most recent completed batch for a site, excluding a specific batch.
+     * Used by SQL generation to find the previous batch for comparison.
+     *
+     * @param siteId The site ID to find batches for
+     * @param excludeBatchId The batch ID to exclude (typically the current batch)
+     * @return Optional containing the most recent completed batch
+     */
+    Optional<Batch> findPreviousBatchForSite(UUID siteId, UUID excludeBatchId);
 }

--- a/src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
@@ -57,4 +57,23 @@ public interface BatchRepository {
      * @return Optional containing the most recent completed batch
      */
     Optional<Batch> findPreviousBatchForSite(UUID siteId, UUID excludeBatchId);
+
+    /**
+     * Finds a batch by ID with uploaded files eagerly loaded (JOIN FETCH).
+     * Prevents N+1 query problem when accessing files.
+     *
+     * @param batchId The batch ID
+     * @return Optional containing the batch with files
+     */
+    Optional<Batch> findByIdWithFiles(UUID batchId);
+
+    /**
+     * Finds the previous batch for a site with uploaded files eagerly loaded.
+     * Used by SQL generation for efficient file comparison.
+     *
+     * @param siteId The site ID
+     * @param excludeBatchId The batch ID to exclude
+     * @return Optional containing the previous batch with files
+     */
+    Optional<Batch> findPreviousBatchForSiteWithFiles(UUID siteId, UUID excludeBatchId);
 }

--- a/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
@@ -206,4 +206,26 @@ public interface JpaBatchRepository extends JpaRepository<Batch, UUID>, BatchRep
         WHERE b.id = :batchId
         """)
     Optional<Batch> findByIdWithFiles(UUID batchId);
+
+    /**
+     * Finds the most recent completed batch for a site, excluding a specific batch.
+     * Used by SQL generation to find the previous batch for comparison.
+     * <p>
+     * Only considers COMPLETED or COMPLETED_WITH_WARNINGS batches as valid previous batches.
+     * </p>
+     *
+     * @param siteId The site ID to find batches for
+     * @param excludeBatchId The batch ID to exclude (typically the current batch)
+     * @return Optional containing the most recent completed batch
+     */
+    @Query("""
+        SELECT b
+        FROM Batch b
+        WHERE b.siteId = :siteId
+          AND b.id <> :excludeBatchId
+          AND b.status IN ('COMPLETED', 'COMPLETED_WITH_WARNINGS')
+        ORDER BY b.completedAt DESC
+        LIMIT 1
+        """)
+    Optional<Batch> findPreviousBatchForSite(UUID siteId, UUID excludeBatchId);
 }

--- a/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
@@ -228,4 +228,27 @@ public interface JpaBatchRepository extends JpaRepository<Batch, UUID>, BatchRep
         LIMIT 1
         """)
     Optional<Batch> findPreviousBatchForSite(UUID siteId, UUID excludeBatchId);
+
+    /**
+     * Finds the previous batch for a site with uploaded files eagerly loaded.
+     * <p>
+     * Uses LEFT JOIN FETCH to avoid N+1 query problem.
+     * Only considers COMPLETED or COMPLETED_WITH_WARNINGS batches.
+     * </p>
+     *
+     * @param siteId The site ID to find batches for
+     * @param excludeBatchId The batch ID to exclude (typically the current batch)
+     * @return Optional containing the previous batch with files
+     */
+    @Query("""
+        SELECT b
+        FROM Batch b
+        LEFT JOIN FETCH b.uploadedFiles
+        WHERE b.siteId = :siteId
+          AND b.id <> :excludeBatchId
+          AND b.status IN ('COMPLETED', 'COMPLETED_WITH_WARNINGS')
+        ORDER BY b.completedAt DESC
+        LIMIT 1
+        """)
+    Optional<Batch> findPreviousBatchForSiteWithFiles(UUID siteId, UUID excludeBatchId);
 }

--- a/src/main/java/com/bitbi/dfm/plugin/application/BitBiPlugin.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/BitBiPlugin.java
@@ -6,10 +6,13 @@ import com.bitbi.dfm.plugin.domain.PluginEvent;
 import com.bitbi.dfm.plugin.domain.PluginEventType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Bit BI plugin implementation.
@@ -21,7 +24,8 @@ import java.util.Set;
  * <p>Plugin Data Schema (validated via JSON Schema):
  * <pre>
  * {
- *   "tenantId": "string (1-64 chars, alphanumeric with hyphens/underscores)"
+ *   "tenantId": "string (1-64 chars, alphanumeric with hyphens/underscores)",
+ *   "apiKey": "string (optional, system-generated, format: plk_[a-zA-Z0-9]{32})"
  * }
  * </pre>
  *
@@ -43,9 +47,31 @@ public class BitBiPlugin implements Plugin {
     public static final String PLUGIN_NAME = "Bit BI";
     public static final String PLUGIN_VERSION = "1.0.0";
 
+    private SqlGenerationService sqlGenerationService;
+    private PluginApiKeyService pluginApiKeyService;
+
+    /**
+     * Inject SqlGenerationService lazily to avoid circular dependency.
+     */
+    @Autowired
+    @Lazy
+    public void setSqlGenerationService(SqlGenerationService sqlGenerationService) {
+        this.sqlGenerationService = sqlGenerationService;
+    }
+
+    /**
+     * Inject PluginApiKeyService lazily to avoid circular dependency.
+     */
+    @Autowired
+    @Lazy
+    public void setPluginApiKeyService(PluginApiKeyService pluginApiKeyService) {
+        this.pluginApiKeyService = pluginApiKeyService;
+    }
+
     /**
      * JSON Schema for validating Bit BI plugin data.
      * Requires tenantId field with specific format constraints.
+     * apiKey is optional and system-generated on activation.
      */
     private static final String SCHEMA_JSON = """
         {
@@ -59,6 +85,13 @@ public class BitBiPlugin implements Plugin {
               "maxLength": 64,
               "pattern": "^[a-zA-Z0-9-_]+$",
               "description": "Bit BI tenant identifier"
+            },
+            "apiKey": {
+              "type": "string",
+              "minLength": 36,
+              "maxLength": 36,
+              "pattern": "^plk_[a-zA-Z0-9]{32}$",
+              "description": "Plugin API Key (system-generated on activation)"
             }
           },
           "additionalProperties": false
@@ -93,11 +126,8 @@ public class BitBiPlugin implements Plugin {
     /**
      * Executes the plugin logic when a batch completion event is received.
      *
-     * <p>For Bit BI, this will notify the Bit BI service about the completed batch
-     * using the tenantId from the activation record.</p>
-     *
-     * <p>Note: In v1, this is a no-op placeholder. Actual Bit BI API integration
-     * will be implemented when Bit BI provides their webhook endpoint.</p>
+     * <p>For Bit BI, this generates SQL files from CSV diffs between batches
+     * and stores them in S3 for later retrieval via the Plugin API.</p>
      *
      * @param event the batch completion event
      * @param accountPlugin the activation record containing tenantId
@@ -111,24 +141,27 @@ public class BitBiPlugin implements Plugin {
             event.type().getEventName(),
             event.resourceId());
 
-        // TODO: Implement actual Bit BI webhook notification
-        // This will be implemented when Bit BI provides their webhook endpoint
-        // For now, just log the event for validation
-
         if (event.type() == PluginEventType.BATCH_COMPLETED) {
-            log.debug("Batch {} completed for tenant {}. Files: {}, Size: {}",
-                event.resourceId(),
-                tenantId,
-                event.metadata().get("uploadedFilesCount"),
-                event.metadata().get("totalSize"));
+            UUID batchId = event.resourceId();
+
+            log.info("Triggering SQL generation for batch {} (tenant: {})",
+                batchId, tenantId);
+
+            try {
+                sqlGenerationService.generateSqlForBatch(batchId, accountPlugin.getId());
+            } catch (Exception e) {
+                log.error("SQL generation failed for batch {} (tenant: {}): {}",
+                    batchId, tenantId, e.getMessage(), e);
+                // Don't rethrow - SQL generation failure shouldn't fail the event processing
+            }
         }
     }
 
     /**
      * Called when Bit BI plugin is activated for an account.
      *
-     * <p>Logs the activation for audit purposes. In the future, this could
-     * notify Bit BI about the new connection.</p>
+     * <p>Generates and stores an API Key for Plugin API authentication.
+     * The API Key is stored in plugin_data and can be retrieved via the admin API.</p>
      *
      * @param accountPlugin the activation record
      */
@@ -139,7 +172,15 @@ public class BitBiPlugin implements Plugin {
             accountPlugin.getAccountId(),
             tenantId);
 
-        // TODO: Optionally notify Bit BI about the new connection
+        // Generate API Key for Plugin API authentication
+        try {
+            var apiKey = pluginApiKeyService.generateApiKey(accountPlugin.getId());
+            log.info("Generated API Key for account {}: {}", accountPlugin.getAccountId(), apiKey);
+        } catch (Exception e) {
+            log.error("Failed to generate API Key for account {}: {}",
+                accountPlugin.getAccountId(), e.getMessage(), e);
+            // Don't fail activation if API key generation fails
+        }
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/plugin/application/BitBiPlugin.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/BitBiPlugin.java
@@ -175,7 +175,10 @@ public class BitBiPlugin implements Plugin {
         // Generate API Key for Plugin API authentication
         try {
             var apiKey = pluginApiKeyService.generateApiKey(accountPlugin.getId());
-            log.info("Generated API Key for account {}: {}", accountPlugin.getAccountId(), apiKey);
+            // Log only first 12 chars of API key for security (plk_ + 8 chars)
+            String keyValue = apiKey.value();
+            String truncatedKey = keyValue.length() > 12 ? keyValue.substring(0, 12) + "..." : keyValue;
+            log.info("Generated API Key for account {}: {}", accountPlugin.getAccountId(), truncatedKey);
         } catch (Exception e) {
             log.error("Failed to generate API Key for account {}: {}",
                 accountPlugin.getAccountId(), e.getMessage(), e);

--- a/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
@@ -13,6 +13,37 @@ import java.util.stream.Collectors;
 /**
  * Service for comparing CSV files and generating row-level diffs.
  * Used to detect added, modified, and deleted rows between batch uploads.
+ *
+ * <h2>Row Identity Detection</h2>
+ * <p>
+ * <strong>IMPORTANT:</strong> This service uses the <b>first column</b> of the CSV
+ * as the row identity key for detecting modifications vs additions/deletions.
+ * </p>
+ *
+ * <h3>Assumptions</h3>
+ * <ul>
+ *   <li>The first column contains a unique identifier (e.g., id, sku, email)</li>
+ *   <li>The first column values are stable between batches</li>
+ *   <li>Column order remains consistent between batches</li>
+ * </ul>
+ *
+ * <h3>Limitations</h3>
+ * <ul>
+ *   <li>If the first column is NOT unique (e.g., country, category), incorrect
+ *       UPDATE/DELETE statements may be generated</li>
+ *   <li>If a row exists with the same key in both batches but different values,
+ *       it will be detected as MODIFIED</li>
+ *   <li>Rows without a key value fall back to full row comparison (slower)</li>
+ * </ul>
+ *
+ * <h3>Recommendations for CSV Structure</h3>
+ * <ul>
+ *   <li>Place the unique identifier column (id, primary key) as the first column</li>
+ *   <li>Ensure identifier values are immutable and unique within the file</li>
+ *   <li>Use consistent column ordering across all batch uploads</li>
+ * </ul>
+ *
+ * @see CsvRowDiff
  */
 @Service
 public class CsvDiffService {

--- a/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
@@ -2,9 +2,12 @@ package com.bitbi.dfm.plugin.application;
 
 import com.bitbi.dfm.plugin.domain.CsvRowDiff;
 import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -14,6 +17,20 @@ import java.util.stream.Collectors;
 @Service
 public class CsvDiffService {
 
+    private static final Logger log = LoggerFactory.getLogger(CsvDiffService.class);
+
+    /**
+     * Pattern for valid CSV column names.
+     * Allows letters, digits, underscores, spaces, and common punctuation.
+     * Maximum length 128 characters.
+     */
+    private static final Pattern VALID_COLUMN_NAME = Pattern.compile("^[\\p{L}\\p{N}_\\- .,()]{1,128}$");
+
+    /**
+     * Maximum allowed number of columns to prevent memory issues.
+     */
+    private static final int MAX_COLUMNS = 500;
+
     /**
      * Compares two lists of CSV rows and returns the differences.
      * Uses first column as row identity key for modification detection.
@@ -22,12 +39,17 @@ public class CsvDiffService {
      * @param currentRows Rows from the current batch
      * @param columnTypes Map of column name to DBF type (for type-aware comparison)
      * @return List of row differences (added, modified, deleted)
+     * @throws InvalidCsvHeaderException if column headers are invalid
      */
     public List<CsvRowDiff> compare(
             List<Map<String, String>> previousRows,
             List<Map<String, String>> currentRows,
             Map<String, DbfColumnType> columnTypes
     ) {
+        // Validate CSV headers before processing
+        validateHeaders(currentRows);
+        validateHeaders(previousRows);
+
         List<CsvRowDiff> diffs = new ArrayList<>();
 
         // Get identity column (first column) if available
@@ -169,5 +191,79 @@ public class CsvDiffService {
             .sorted(Map.Entry.comparingByKey())
             .map(e -> e.getKey() + "=" + (e.getValue() == null ? "\0NULL\0" : e.getValue()))
             .collect(Collectors.joining("|"));
+    }
+
+    /**
+     * Validates CSV headers for security and sanity.
+     * Checks:
+     * - Column count limit
+     * - Column name format (no SQL injection vectors)
+     * - No empty column names
+     *
+     * @param rows CSV rows to validate headers from
+     * @throws InvalidCsvHeaderException if headers are invalid
+     */
+    private void validateHeaders(List<Map<String, String>> rows) {
+        if (rows == null || rows.isEmpty()) {
+            return; // Empty is valid
+        }
+
+        Map<String, String> firstRow = rows.get(0);
+        if (firstRow == null || firstRow.isEmpty()) {
+            return; // Empty row is valid
+        }
+
+        Set<String> columns = firstRow.keySet();
+
+        // Check column count
+        if (columns.size() > MAX_COLUMNS) {
+            log.error("CSV has too many columns: count={}, max={}",
+                    columns.size(), MAX_COLUMNS);
+            throw new InvalidCsvHeaderException(
+                    "CSV file has " + columns.size() + " columns, exceeding limit of " + MAX_COLUMNS);
+        }
+
+        // Validate each column name
+        List<String> invalidColumns = new ArrayList<>();
+        for (String column : columns) {
+            if (column == null || column.trim().isEmpty()) {
+                invalidColumns.add("<empty>");
+                continue;
+            }
+
+            if (!VALID_COLUMN_NAME.matcher(column).matches()) {
+                invalidColumns.add(sanitizeForLogging(column));
+            }
+        }
+
+        if (!invalidColumns.isEmpty()) {
+            log.error("CSV has invalid column names: columns={}",
+                    String.join(", ", invalidColumns));
+            throw new InvalidCsvHeaderException(
+                    "CSV file has " + invalidColumns.size() + " invalid column name(s). " +
+                    "Column names must contain only letters, numbers, underscores, spaces, and common punctuation.");
+        }
+    }
+
+    /**
+     * Sanitizes a string for safe logging (prevents log injection).
+     */
+    private String sanitizeForLogging(String value) {
+        if (value == null) {
+            return "<null>";
+        }
+        // Truncate and escape control characters
+        String truncated = value.length() > 50 ? value.substring(0, 50) + "..." : value;
+        return truncated.replaceAll("[\\r\\n\\t]", " ")
+                        .replaceAll("[^\\p{Print}]", "?");
+    }
+
+    /**
+     * Exception thrown when CSV headers are invalid.
+     */
+    public static class InvalidCsvHeaderException extends RuntimeException {
+        public InvalidCsvHeaderException(String message) {
+            super(message);
+        }
     }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
@@ -1,0 +1,173 @@
+package com.bitbi.dfm.plugin.application;
+
+import com.bitbi.dfm.plugin.domain.CsvRowDiff;
+import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Service for comparing CSV files and generating row-level diffs.
+ * Used to detect added, modified, and deleted rows between batch uploads.
+ */
+@Service
+public class CsvDiffService {
+
+    /**
+     * Compares two lists of CSV rows and returns the differences.
+     * Uses first column as row identity key for modification detection.
+     *
+     * @param previousRows Rows from the previous batch (empty for first batch)
+     * @param currentRows Rows from the current batch
+     * @param columnTypes Map of column name to DBF type (for type-aware comparison)
+     * @return List of row differences (added, modified, deleted)
+     */
+    public List<CsvRowDiff> compare(
+            List<Map<String, String>> previousRows,
+            List<Map<String, String>> currentRows,
+            Map<String, DbfColumnType> columnTypes
+    ) {
+        List<CsvRowDiff> diffs = new ArrayList<>();
+
+        // Get identity column (first column) if available
+        String identityColumn = getIdentityColumn(currentRows, previousRows);
+
+        // Build lookup by identity column value
+        Map<String, Map<String, String>> previousByKey = buildKeyLookup(previousRows, identityColumn);
+        Map<String, Map<String, String>> currentByKey = buildKeyLookup(currentRows, identityColumn);
+
+        // Track which previous keys were matched (for deletion detection)
+        Set<String> matchedPreviousKeys = new HashSet<>();
+
+        // Process current rows
+        for (int i = 0; i < currentRows.size(); i++) {
+            Map<String, String> currentRow = currentRows.get(i);
+            int lineNumber = i + 1; // 1-based line number
+
+            String key = getKeyValue(currentRow, identityColumn);
+
+            if (key != null && previousByKey.containsKey(key)) {
+                // Row with same key exists in previous
+                Map<String, String> previousRow = previousByKey.get(key);
+                matchedPreviousKeys.add(key);
+
+                // Check if values differ
+                Map<String, String> changedColumns = findChangedColumns(previousRow, currentRow);
+                if (!changedColumns.isEmpty()) {
+                    diffs.add(CsvRowDiff.modified(lineNumber, currentRow, changedColumns));
+                }
+                // else: unchanged row
+            } else {
+                // New row - ADDED
+                diffs.add(CsvRowDiff.added(lineNumber, currentRow));
+            }
+        }
+
+        // Detect DELETED rows (in previous but not matched in current)
+        for (int i = 0; i < previousRows.size(); i++) {
+            Map<String, String> previousRow = previousRows.get(i);
+            int lineNumber = i + 1;
+
+            String key = getKeyValue(previousRow, identityColumn);
+
+            if (key != null && !matchedPreviousKeys.contains(key)) {
+                // Not matched - was deleted
+                diffs.add(CsvRowDiff.deleted(lineNumber, previousRow));
+            } else if (key == null && !isRowInList(previousRow, currentRows)) {
+                // No key column, use full row comparison
+                diffs.add(CsvRowDiff.deleted(lineNumber, previousRow));
+            }
+        }
+
+        return diffs;
+    }
+
+    /**
+     * Gets the identity column name (first column from the rows).
+     */
+    private String getIdentityColumn(List<Map<String, String>> currentRows, List<Map<String, String>> previousRows) {
+        if (!currentRows.isEmpty() && !currentRows.get(0).isEmpty()) {
+            return currentRows.get(0).keySet().iterator().next();
+        }
+        if (!previousRows.isEmpty() && !previousRows.get(0).isEmpty()) {
+            return previousRows.get(0).keySet().iterator().next();
+        }
+        return null;
+    }
+
+    /**
+     * Builds a lookup map from identity column value to row.
+     */
+    private Map<String, Map<String, String>> buildKeyLookup(List<Map<String, String>> rows, String identityColumn) {
+        Map<String, Map<String, String>> lookup = new HashMap<>();
+        if (identityColumn == null) {
+            return lookup;
+        }
+        for (Map<String, String> row : rows) {
+            String key = getKeyValue(row, identityColumn);
+            if (key != null) {
+                lookup.put(key, row);
+            }
+        }
+        return lookup;
+    }
+
+    /**
+     * Gets the value of the identity column from a row.
+     */
+    private String getKeyValue(Map<String, String> row, String identityColumn) {
+        if (identityColumn == null || row == null) {
+            return null;
+        }
+        return row.get(identityColumn);
+    }
+
+    /**
+     * Checks if a row exists in a list using full row comparison.
+     */
+    private boolean isRowInList(Map<String, String> row, List<Map<String, String>> rows) {
+        String fingerprint = getRowFingerprint(row);
+        for (Map<String, String> other : rows) {
+            if (fingerprint.equals(getRowFingerprint(other))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Finds columns that changed between two rows.
+     * Returns map of column name -> old value for changed columns.
+     */
+    private Map<String, String> findChangedColumns(Map<String, String> previousRow, Map<String, String> currentRow) {
+        Map<String, String> changedColumns = new LinkedHashMap<>();
+
+        for (Map.Entry<String, String> entry : currentRow.entrySet()) {
+            String column = entry.getKey();
+            String currentValue = entry.getValue();
+            String previousValue = previousRow.get(column);
+
+            // Compare values directly (empty string is different from null)
+            if (!Objects.equals(currentValue, previousValue)) {
+                changedColumns.put(column, previousValue);
+            }
+        }
+
+        return changedColumns;
+    }
+
+    /**
+     * Creates a fingerprint for a row based on all column values.
+     * Order of columns is normalized for consistent comparison.
+     */
+    private String getRowFingerprint(Map<String, String> row) {
+        if (row == null) {
+            return "";
+        }
+        return row.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e -> e.getKey() + "=" + (e.getValue() == null ? "\0NULL\0" : e.getValue()))
+            .collect(Collectors.joining("|"));
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/application/PluginApiKeyService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/PluginApiKeyService.java
@@ -1,0 +1,156 @@
+package com.bitbi.dfm.plugin.application;
+
+import com.bitbi.dfm.plugin.domain.AccountPlugin;
+import com.bitbi.dfm.plugin.domain.AccountPluginRepository;
+import com.bitbi.dfm.plugin.domain.PluginApiKey;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+/**
+ * Service for managing Plugin API Keys for Bit BI Plugin API authentication.
+ * <p>
+ * API Keys are stored in account_plugins.plugin_data JSONB field.
+ * </p>
+ */
+@Service
+public class PluginApiKeyService {
+
+    private static final Logger log = LoggerFactory.getLogger(PluginApiKeyService.class);
+    private static final String API_KEY_FIELD = "apiKey";
+    private static final String PLUGIN_ID = "bit-bi";
+
+    private final AccountPluginRepository accountPluginRepository;
+    private final MeterRegistry meterRegistry;
+
+    public PluginApiKeyService(
+            AccountPluginRepository accountPluginRepository,
+            MeterRegistry meterRegistry) {
+        this.accountPluginRepository = accountPluginRepository;
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Generates and stores a new API Key for an account's Bit BI plugin activation.
+     * If an API Key already exists, it will be replaced (rotated).
+     *
+     * @param accountPluginId The ID of the account plugin activation
+     * @return The generated API Key
+     */
+    @Transactional
+    public PluginApiKey generateApiKey(Long accountPluginId) {
+        AccountPlugin accountPlugin = accountPluginRepository.findById(accountPluginId)
+                .orElseThrow(() -> new IllegalArgumentException("AccountPlugin not found: " + accountPluginId));
+
+        PluginApiKey apiKey = PluginApiKey.generate();
+
+        // Store API key in plugin_data
+        Map<String, Object> updatedData = new HashMap<>(accountPlugin.getPluginData());
+        updatedData.put(API_KEY_FIELD, apiKey.value());
+        accountPlugin.updatePluginData(updatedData);
+
+        accountPluginRepository.save(accountPlugin);
+
+        log.info("Generated API Key for account plugin: id={}, key={}",
+                accountPluginId, apiKey); // toString() returns masked key
+
+        return apiKey;
+    }
+
+    /**
+     * Generates and stores a new API Key for an account's Bit BI plugin.
+     *
+     * @param accountId The account ID
+     * @return The generated API Key
+     */
+    @Transactional
+    public PluginApiKey generateApiKeyForAccount(UUID accountId) {
+        AccountPlugin accountPlugin = accountPluginRepository
+                .findByAccountIdAndPluginId(accountId, PLUGIN_ID)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No active Bit BI plugin for account: " + accountId));
+
+        return generateApiKey(accountPlugin.getId());
+    }
+
+    /**
+     * Validates an API Key and returns the associated AccountPlugin if valid.
+     * Performance requirement: <50ms (SC-004).
+     *
+     * @param apiKeyValue The raw API key value
+     * @return Optional containing the AccountPlugin if valid and active
+     */
+    @Transactional(readOnly = true)
+    public Optional<AccountPlugin> validateApiKey(String apiKeyValue) {
+        Timer.Sample timer = Timer.start(meterRegistry);
+
+        try {
+            // Fast path: Check format first
+            if (!PluginApiKey.isValid(apiKeyValue)) {
+                log.debug("Invalid API key format");
+                meterRegistry.counter("plugin.api.key.validation.invalid.format").increment();
+                return Optional.empty();
+            }
+
+            // Query for account plugin with this API key
+            // Uses JSONB containment query for performance
+            Optional<AccountPlugin> result = accountPluginRepository
+                    .findByPluginIdAndApiKey(PLUGIN_ID, apiKeyValue);
+
+            if (result.isEmpty()) {
+                log.debug("API key not found in any account plugin");
+                meterRegistry.counter("plugin.api.key.validation.not.found").increment();
+                return Optional.empty();
+            }
+
+            AccountPlugin accountPlugin = result.get();
+            if (!accountPlugin.isActive()) {
+                log.debug("API key belongs to inactive plugin: accountId={}",
+                        accountPlugin.getAccountId());
+                meterRegistry.counter("plugin.api.key.validation.inactive").increment();
+                return Optional.empty();
+            }
+
+            meterRegistry.counter("plugin.api.key.validation.success").increment();
+            return Optional.of(accountPlugin);
+
+        } finally {
+            timer.stop(meterRegistry.timer("plugin.api.key.validation.duration"));
+        }
+    }
+
+    /**
+     * Gets the API Key for an account's Bit BI plugin (if exists).
+     *
+     * @param accountId The account ID
+     * @return Optional containing the API key if exists
+     */
+    @Transactional(readOnly = true)
+    public Optional<PluginApiKey> getApiKey(UUID accountId) {
+        return accountPluginRepository
+                .findByAccountIdAndPluginId(accountId, PLUGIN_ID)
+                .map(ap -> ap.getPluginData().get(API_KEY_FIELD))
+                .filter(key -> key instanceof String)
+                .map(key -> (String) key)
+                .filter(PluginApiKey::isValid)
+                .map(PluginApiKey::of);
+    }
+
+    /**
+     * Rotates (regenerates) the API Key for an account's Bit BI plugin.
+     * Invalidates the old key immediately.
+     *
+     * @param accountId The account ID
+     * @return The new API Key
+     */
+    @Transactional
+    public PluginApiKey rotateApiKey(UUID accountId) {
+        log.info("Rotating API Key for account: {}", accountId);
+        return generateApiKeyForAccount(accountId);
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/application/PluginApiKeyService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/PluginApiKeyService.java
@@ -7,6 +7,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,15 +17,22 @@ import java.util.*;
 /**
  * Service for managing Plugin API Keys for Bit BI Plugin API authentication.
  * <p>
- * API Keys are stored in account_plugins.plugin_data JSONB field.
+ * API Keys are stored as BCrypt hashes in account_plugins.plugin_data JSONB field.
+ * The raw key is returned only once during generation - it cannot be retrieved later.
+ * </p>
+ * <p>
+ * Security: Uses BCrypt hashing to protect API keys at rest. Even if the database
+ * is compromised, the actual API keys cannot be recovered.
  * </p>
  */
 @Service
 public class PluginApiKeyService {
 
     private static final Logger log = LoggerFactory.getLogger(PluginApiKeyService.class);
-    private static final String API_KEY_FIELD = "apiKey";
+    private static final String API_KEY_HASH_FIELD = "apiKeyHash";
     private static final String PLUGIN_ID = "bit-bi";
+
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     private final AccountPluginRepository accountPluginRepository;
     private final MeterRegistry meterRegistry;
@@ -38,9 +47,13 @@ public class PluginApiKeyService {
     /**
      * Generates and stores a new API Key for an account's Bit BI plugin activation.
      * If an API Key already exists, it will be replaced (rotated).
+     * <p>
+     * Security: Only the BCrypt hash is stored in the database. The raw key is returned
+     * only once and cannot be retrieved later. Users must save it securely.
+     * </p>
      *
      * @param accountPluginId The ID of the account plugin activation
-     * @return The generated API Key
+     * @return The generated API Key (raw value - store securely, cannot be retrieved again)
      */
     @Transactional
     public PluginApiKey generateApiKey(Long accountPluginId) {
@@ -49,9 +62,13 @@ public class PluginApiKeyService {
 
         PluginApiKey apiKey = PluginApiKey.generate();
 
-        // Store API key in plugin_data
+        // Security: Store BCrypt hash of API key, not the raw key
+        String apiKeyHash = passwordEncoder.encode(apiKey.value());
+
         Map<String, Object> updatedData = new HashMap<>(accountPlugin.getPluginData());
-        updatedData.put(API_KEY_FIELD, apiKey.value());
+        updatedData.put(API_KEY_HASH_FIELD, apiKeyHash);
+        // Remove old plain-text key if exists (migration from old format)
+        updatedData.remove("apiKey");
         accountPlugin.updatePluginData(updatedData);
 
         accountPluginRepository.save(accountPlugin);
@@ -81,6 +98,11 @@ public class PluginApiKeyService {
     /**
      * Validates an API Key and returns the associated AccountPlugin if valid.
      * Performance requirement: <50ms (SC-004).
+     * <p>
+     * Security: Uses BCrypt comparison which is intentionally slow (~100ms) to prevent
+     * timing attacks. For better performance with many accounts, consider caching or
+     * adding an indexed key prefix lookup.
+     * </p>
      *
      * @param apiKeyValue The raw API key value
      * @return Optional containing the AccountPlugin if valid and active
@@ -97,27 +119,22 @@ public class PluginApiKeyService {
                 return Optional.empty();
             }
 
-            // Query for account plugin with this API key
-            // Uses JSONB containment query for performance
-            Optional<AccountPlugin> result = accountPluginRepository
-                    .findByPluginIdAndApiKey(PLUGIN_ID, apiKeyValue);
+            // Load all active bit-bi plugin activations and compare BCrypt hashes
+            // Note: This is O(n) where n = active accounts, but BCrypt prevents timing attacks
+            List<AccountPlugin> activePlugins = accountPluginRepository.findActiveByPluginId(PLUGIN_ID);
 
-            if (result.isEmpty()) {
-                log.debug("API key not found in any account plugin");
-                meterRegistry.counter("plugin.api.key.validation.not.found").increment();
-                return Optional.empty();
+            for (AccountPlugin accountPlugin : activePlugins) {
+                String storedHash = getStoredApiKeyHash(accountPlugin);
+                if (storedHash != null && passwordEncoder.matches(apiKeyValue, storedHash)) {
+                    log.debug("API key validated for accountId={}", accountPlugin.getAccountId());
+                    meterRegistry.counter("plugin.api.key.validation.success").increment();
+                    return Optional.of(accountPlugin);
+                }
             }
 
-            AccountPlugin accountPlugin = result.get();
-            if (!accountPlugin.isActive()) {
-                log.debug("API key belongs to inactive plugin: accountId={}",
-                        accountPlugin.getAccountId());
-                meterRegistry.counter("plugin.api.key.validation.inactive").increment();
-                return Optional.empty();
-            }
-
-            meterRegistry.counter("plugin.api.key.validation.success").increment();
-            return Optional.of(accountPlugin);
+            log.debug("API key not found or does not match any account plugin");
+            meterRegistry.counter("plugin.api.key.validation.not.found").increment();
+            return Optional.empty();
 
         } finally {
             timer.stop(meterRegistry.timer("plugin.api.key.validation.duration"));
@@ -125,20 +142,53 @@ public class PluginApiKeyService {
     }
 
     /**
-     * Gets the API Key for an account's Bit BI plugin (if exists).
+     * Extracts the stored API key hash from plugin data.
+     * Supports both new format (apiKeyHash) and legacy format (apiKey) for migration.
+     */
+    private String getStoredApiKeyHash(AccountPlugin accountPlugin) {
+        Map<String, Object> pluginData = accountPlugin.getPluginData();
+        if (pluginData == null) {
+            return null;
+        }
+
+        // Try new hash field first
+        Object hashValue = pluginData.get(API_KEY_HASH_FIELD);
+        if (hashValue instanceof String) {
+            return (String) hashValue;
+        }
+
+        // Legacy support: If old plain-text key exists, hash it on-the-fly for comparison
+        // This allows existing keys to work during migration
+        Object legacyKey = pluginData.get("apiKey");
+        if (legacyKey instanceof String legacyKeyStr && PluginApiKey.isValid(legacyKeyStr)) {
+            log.warn("Legacy plain-text API key found for accountId={}. Please rotate the key.",
+                    accountPlugin.getAccountId());
+            // For legacy keys, we compare directly (not ideal but maintains compatibility)
+            // The key will be hashed on next rotation
+            return passwordEncoder.encode(legacyKeyStr);
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if an API Key exists for an account's Bit BI plugin.
+     * <p>
+     * Security: Since API keys are stored as BCrypt hashes, the actual key cannot
+     * be retrieved. Use this method to check if a key exists, and rotateApiKey()
+     * to generate a new one if needed.
+     * </p>
      *
      * @param accountId The account ID
-     * @return Optional containing the API key if exists
+     * @return true if an API key hash exists for the account
      */
     @Transactional(readOnly = true)
-    public Optional<PluginApiKey> getApiKey(UUID accountId) {
+    public boolean hasApiKey(UUID accountId) {
         return accountPluginRepository
                 .findByAccountIdAndPluginId(accountId, PLUGIN_ID)
-                .map(ap -> ap.getPluginData().get(API_KEY_FIELD))
-                .filter(key -> key instanceof String)
-                .map(key -> (String) key)
-                .filter(PluginApiKey::isValid)
-                .map(PluginApiKey::of);
+                .map(ap -> ap.getPluginData().get(API_KEY_HASH_FIELD) != null
+                        || ap.getPluginData().get("apiKey") != null) // Legacy support
+                .orElse(false);
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/plugin/application/PluginRateLimiterService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/PluginRateLimiterService.java
@@ -1,5 +1,7 @@
 package com.bitbi.dfm.plugin.application;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.Refill;
@@ -9,15 +11,17 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Rate limiting service for Plugin API endpoints.
  * <p>
  * Implements per-account rate limiting using Token Bucket algorithm (Bucket4j).
  * Default limit: 100 requests per minute per account.
+ * </p>
+ * <p>
+ * Uses Caffeine cache with 1-hour TTL to prevent memory leaks from
+ * accumulating buckets for inactive/deleted accounts.
  * </p>
  * <p>
  * Security: Prevents API abuse and DoS attacks by limiting request rate.
@@ -34,14 +38,34 @@ public class PluginRateLimiterService {
     private static final int DEFAULT_REQUESTS_PER_MINUTE = 100;
 
     /**
-     * Cache of rate limit buckets per account ID
+     * TTL for bucket cache entries (1 hour).
+     * Buckets for inactive accounts are automatically evicted after this duration.
      */
-    private final Map<UUID, Bucket> buckets = new ConcurrentHashMap<>();
+    private static final Duration BUCKET_TTL = Duration.ofHours(1);
+
+    /**
+     * Maximum number of cached buckets to prevent unbounded growth.
+     */
+    private static final int MAX_CACHED_BUCKETS = 10_000;
+
+    /**
+     * Cache of rate limit buckets per account ID.
+     * Uses Caffeine with TTL and size limits to prevent memory leaks.
+     */
+    private final Cache<UUID, Bucket> buckets;
 
     private final MeterRegistry meterRegistry;
 
     public PluginRateLimiterService(MeterRegistry meterRegistry) {
         this.meterRegistry = meterRegistry;
+        this.buckets = Caffeine.newBuilder()
+                .expireAfterAccess(BUCKET_TTL)
+                .maximumSize(MAX_CACHED_BUCKETS)
+                .recordStats()
+                .build();
+
+        // Register cache metrics
+        meterRegistry.gauge("plugin.api.rate.limiter.cache.size", buckets, Cache::estimatedSize);
     }
 
     /**
@@ -52,7 +76,7 @@ public class PluginRateLimiterService {
      * @return true if request is allowed, false if rate limited
      */
     public boolean tryConsume(UUID accountId) {
-        Bucket bucket = buckets.computeIfAbsent(accountId, this::createBucket);
+        Bucket bucket = buckets.get(accountId, this::createBucket);
         boolean allowed = bucket.tryConsume(1);
 
         if (allowed) {
@@ -72,7 +96,7 @@ public class PluginRateLimiterService {
      * @return Estimated time in seconds until next token is available
      */
     public long getRetryAfterSeconds(UUID accountId) {
-        Bucket bucket = buckets.get(accountId);
+        Bucket bucket = buckets.getIfPresent(accountId);
         if (bucket == null) {
             return 0;
         }
@@ -105,13 +129,20 @@ public class PluginRateLimiterService {
      * @param accountId The account ID to reset
      */
     public void resetBucket(UUID accountId) {
-        buckets.remove(accountId);
+        buckets.invalidate(accountId);
     }
 
     /**
      * Gets the current bucket count (for monitoring).
      */
-    public int getBucketCount() {
-        return buckets.size();
+    public long getBucketCount() {
+        return buckets.estimatedSize();
+    }
+
+    /**
+     * Invalidates all cached buckets (useful for testing).
+     */
+    public void invalidateAll() {
+        buckets.invalidateAll();
     }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/application/PluginRateLimiterService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/PluginRateLimiterService.java
@@ -1,0 +1,117 @@
+package com.bitbi.dfm.plugin.application;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Rate limiting service for Plugin API endpoints.
+ * <p>
+ * Implements per-account rate limiting using Token Bucket algorithm (Bucket4j).
+ * Default limit: 100 requests per minute per account.
+ * </p>
+ * <p>
+ * Security: Prevents API abuse and DoS attacks by limiting request rate.
+ * </p>
+ */
+@Service
+public class PluginRateLimiterService {
+
+    private static final Logger log = LoggerFactory.getLogger(PluginRateLimiterService.class);
+
+    /**
+     * Default rate limit: 100 requests per minute
+     */
+    private static final int DEFAULT_REQUESTS_PER_MINUTE = 100;
+
+    /**
+     * Cache of rate limit buckets per account ID
+     */
+    private final Map<UUID, Bucket> buckets = new ConcurrentHashMap<>();
+
+    private final MeterRegistry meterRegistry;
+
+    public PluginRateLimiterService(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Attempts to consume a token for the given account.
+     * Returns true if the request is allowed, false if rate limited.
+     *
+     * @param accountId The account making the request
+     * @return true if request is allowed, false if rate limited
+     */
+    public boolean tryConsume(UUID accountId) {
+        Bucket bucket = buckets.computeIfAbsent(accountId, this::createBucket);
+        boolean allowed = bucket.tryConsume(1);
+
+        if (allowed) {
+            meterRegistry.counter("plugin.api.rate.limit.allowed", "accountId", accountId.toString()).increment();
+        } else {
+            meterRegistry.counter("plugin.api.rate.limit.exceeded", "accountId", accountId.toString()).increment();
+            log.warn("Rate limit exceeded for accountId={}", accountId);
+        }
+
+        return allowed;
+    }
+
+    /**
+     * Gets the number of available tokens for an account (for Retry-After header).
+     *
+     * @param accountId The account ID
+     * @return Estimated time in seconds until next token is available
+     */
+    public long getRetryAfterSeconds(UUID accountId) {
+        Bucket bucket = buckets.get(accountId);
+        if (bucket == null) {
+            return 0;
+        }
+        // Estimate based on refill rate (1 token per 0.6 seconds for 100/min)
+        long availableTokens = bucket.getAvailableTokens();
+        if (availableTokens > 0) {
+            return 0;
+        }
+        // Return time until next refill (approximately)
+        return 1; // At least 1 second
+    }
+
+    /**
+     * Creates a new rate limit bucket with default configuration.
+     * 100 requests per minute, with gradual refill.
+     */
+    private Bucket createBucket(UUID accountId) {
+        Bandwidth limit = Bandwidth.classic(
+                DEFAULT_REQUESTS_PER_MINUTE,
+                Refill.greedy(DEFAULT_REQUESTS_PER_MINUTE, Duration.ofMinutes(1))
+        );
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+
+    /**
+     * Clears the rate limit bucket for an account (useful for testing).
+     *
+     * @param accountId The account ID to reset
+     */
+    public void resetBucket(UUID accountId) {
+        buckets.remove(accountId);
+    }
+
+    /**
+     * Gets the current bucket count (for monitoring).
+     */
+    public int getBucketCount() {
+        return buckets.size();
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
@@ -1,0 +1,127 @@
+package com.bitbi.dfm.plugin.application;
+
+import com.bitbi.dfm.plugin.domain.PluginSqlGeneration;
+import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
+import com.bitbi.dfm.plugin.infrastructure.storage.S3SqlFileStorageService;
+import com.bitbi.dfm.site.domain.Site;
+import com.bitbi.dfm.site.domain.SiteRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Service for querying and retrieving SQL changes for the Bit BI Plugin API.
+ *
+ * <p>Provides functionality to:
+ * <ul>
+ *   <li>Retrieve concatenated SQL changes for a site since a given timestamp</li>
+ *   <li>List available sites for an account</li>
+ *   <li>Validate site ownership</li>
+ * </ul>
+ *
+ * @see com.bitbi.dfm.plugin.presentation.BitBiPluginApiController
+ */
+@Service
+public class SqlChangesQueryService {
+
+    private static final Logger log = LoggerFactory.getLogger(SqlChangesQueryService.class);
+
+    private final PluginSqlGenerationRepository sqlGenerationRepository;
+    private final S3SqlFileStorageService s3SqlFileStorageService;
+    private final SiteRepository siteRepository;
+    private final MeterRegistry meterRegistry;
+
+    public SqlChangesQueryService(
+            PluginSqlGenerationRepository sqlGenerationRepository,
+            S3SqlFileStorageService s3SqlFileStorageService,
+            SiteRepository siteRepository,
+            MeterRegistry meterRegistry) {
+        this.sqlGenerationRepository = sqlGenerationRepository;
+        this.s3SqlFileStorageService = s3SqlFileStorageService;
+        this.siteRepository = siteRepository;
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Retrieves concatenated SQL changes for a site since a given timestamp.
+     *
+     * <p>Validates that the site belongs to the account, then fetches all
+     * SQL generation records for the site since the specified time, retrieves
+     * their content from S3, and concatenates them in chronological order.</p>
+     *
+     * @param accountId the account ID from the API key authentication
+     * @param siteId the site ID to retrieve changes for
+     * @param since the timestamp to retrieve changes after
+     * @return concatenated SQL statements, or empty string if no changes
+     * @throws SecurityException if the site does not belong to the account
+     */
+    @Transactional(readOnly = true)
+    public String getSqlChanges(UUID accountId, UUID siteId, Instant since) {
+        Timer.Sample timer = Timer.start(meterRegistry);
+
+        try {
+            // Validate site ownership
+            Site site = siteRepository.findById(siteId)
+                    .orElseThrow(() -> new SecurityException("Site does not belong to your account"));
+
+            if (!site.getAccountId().equals(accountId)) {
+                log.warn("Site ownership mismatch: siteId={}, requestedAccountId={}, actualAccountId={}",
+                        siteId, accountId, site.getAccountId());
+                throw new SecurityException("Site does not belong to your account");
+            }
+
+            // Fetch SQL generation records - convert Instant to LocalDateTime for query
+            LocalDateTime sinceDateTime = LocalDateTime.ofInstant(since, ZoneOffset.UTC);
+            List<PluginSqlGeneration> generations = sqlGenerationRepository
+                    .findBySiteIdAndCreatedAtAfter(siteId, sinceDateTime);
+
+            if (generations.isEmpty()) {
+                log.debug("No SQL changes found for siteId={} since={}", siteId, since);
+                return "";
+            }
+
+            // Concatenate SQL content from S3
+            StringBuilder sqlContent = new StringBuilder();
+            for (PluginSqlGeneration generation : generations) {
+                String content = s3SqlFileStorageService.getSqlFileContent(generation.getS3Key());
+                sqlContent.append(content);
+                if (!content.endsWith("\n")) {
+                    sqlContent.append("\n");
+                }
+            }
+
+            log.info("Retrieved {} SQL generation(s) for siteId={} since={}",
+                    generations.size(), siteId, since);
+
+            meterRegistry.counter("plugin.api.sql.changes.retrieved",
+                    "siteId", siteId.toString(),
+                    "count", String.valueOf(generations.size())).increment();
+
+            return sqlContent.toString();
+
+        } finally {
+            timer.stop(meterRegistry.timer("plugin.api.sql.changes.duration"));
+        }
+    }
+
+    /**
+     * Lists all active sites for an account.
+     *
+     * @param accountId the account ID from the API key authentication
+     * @return list of active sites belonging to the account
+     */
+    @Transactional(readOnly = true)
+    public List<Site> listSites(UUID accountId) {
+        log.debug("Listing sites for accountId={}", accountId);
+        return siteRepository.findActiveByAccountId(accountId);
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
@@ -28,12 +28,23 @@ import java.util.UUID;
  *   <li>Validate site ownership</li>
  * </ul>
  *
+ * <p><strong>Pagination:</strong> To prevent OOM with large result sets,
+ * results are limited to {@link #MAX_SQL_GENERATIONS} records. Clients
+ * should use appropriate 'since' timestamps to fetch data incrementally.</p>
+ *
  * @see com.bitbi.dfm.plugin.presentation.BitBiPluginApiController
  */
 @Service
 public class SqlChangesQueryService {
 
     private static final Logger log = LoggerFactory.getLogger(SqlChangesQueryService.class);
+
+    /**
+     * Maximum number of SQL generation records to return in a single request.
+     * Prevents OOM when concatenating large numbers of SQL files.
+     * If more records exist, a warning comment is prepended to the response.
+     */
+    private static final int MAX_SQL_GENERATIONS = 100;
 
     private final PluginSqlGenerationRepository sqlGenerationRepository;
     private final S3SqlFileStorageService s3SqlFileStorageService;
@@ -89,8 +100,24 @@ public class SqlChangesQueryService {
                 return "";
             }
 
+            // Check if results exceed limit
+            boolean truncated = generations.size() > MAX_SQL_GENERATIONS;
+            if (truncated) {
+                log.warn("SQL changes result truncated: total={}, limit={}, siteId={}",
+                        generations.size(), MAX_SQL_GENERATIONS, siteId);
+                generations = generations.subList(0, MAX_SQL_GENERATIONS);
+            }
+
             // Concatenate SQL content from S3
             StringBuilder sqlContent = new StringBuilder();
+
+            // Add truncation warning if needed
+            if (truncated) {
+                sqlContent.append("-- WARNING: Results truncated. ")
+                        .append("Only first ").append(MAX_SQL_GENERATIONS)
+                        .append(" batches returned. Use a more recent 'since' parameter.\n\n");
+            }
+
             for (PluginSqlGeneration generation : generations) {
                 String content = s3SqlFileStorageService.getSqlFileContent(generation.getS3Key());
                 sqlContent.append(content);
@@ -99,12 +126,13 @@ public class SqlChangesQueryService {
                 }
             }
 
-            log.info("Retrieved {} SQL generation(s) for siteId={} since={}",
-                    generations.size(), siteId, since);
+            log.info("Retrieved {} SQL generation(s) for siteId={} since={}, truncated={}",
+                    generations.size(), siteId, since, truncated);
 
             meterRegistry.counter("plugin.api.sql.changes.retrieved",
                     "siteId", siteId.toString(),
-                    "count", String.valueOf(generations.size())).increment();
+                    "count", String.valueOf(generations.size()),
+                    "truncated", String.valueOf(truncated)).increment();
 
             return sqlContent.toString();
 

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
@@ -1,0 +1,312 @@
+package com.bitbi.dfm.plugin.application;
+
+import com.bitbi.dfm.batch.domain.Batch;
+import com.bitbi.dfm.batch.domain.BatchRepository;
+import com.bitbi.dfm.plugin.domain.*;
+import com.bitbi.dfm.plugin.infrastructure.storage.S3SqlFileStorageService;
+import com.bitbi.dfm.site.domain.Site;
+import com.bitbi.dfm.site.domain.SiteRepository;
+import com.bitbi.dfm.upload.domain.UploadedFile;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Service orchestrating SQL file generation from CSV batch comparisons.
+ * Compares CSV files between consecutive batches and generates SQL statements.
+ */
+@Service
+public class SqlGenerationService {
+
+    private static final Logger log = LoggerFactory.getLogger(SqlGenerationService.class);
+
+    private final BatchRepository batchRepository;
+    private final SiteRepository siteRepository;
+    private final AccountPluginRepository accountPluginRepository;
+    private final PluginSqlGenerationRepository sqlGenerationRepository;
+    private final CsvDiffService csvDiffService;
+    private final SqlStatementGenerator sqlStatementGenerator;
+    private final S3SqlFileStorageService s3SqlFileStorageService;
+    private final S3Client s3Client;
+    private final String bucketName;
+    private final MeterRegistry meterRegistry;
+
+    public SqlGenerationService(
+            BatchRepository batchRepository,
+            SiteRepository siteRepository,
+            AccountPluginRepository accountPluginRepository,
+            PluginSqlGenerationRepository sqlGenerationRepository,
+            CsvDiffService csvDiffService,
+            SqlStatementGenerator sqlStatementGenerator,
+            S3SqlFileStorageService s3SqlFileStorageService,
+            S3Client s3Client,
+            @org.springframework.beans.factory.annotation.Value("${s3.bucket.name}") String bucketName,
+            MeterRegistry meterRegistry) {
+        this.batchRepository = batchRepository;
+        this.siteRepository = siteRepository;
+        this.accountPluginRepository = accountPluginRepository;
+        this.sqlGenerationRepository = sqlGenerationRepository;
+        this.csvDiffService = csvDiffService;
+        this.sqlStatementGenerator = sqlStatementGenerator;
+        this.s3SqlFileStorageService = s3SqlFileStorageService;
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * Generates SQL file from batch comparison.
+     * Called when a batch completes for an account with active Bit BI plugin.
+     *
+     * @param batchId The completed batch ID
+     * @param accountPluginId The ID of the active account plugin
+     * @return Optional containing the generation record, or empty if no changes
+     */
+    @Transactional
+    public Optional<PluginSqlGeneration> generateSqlForBatch(UUID batchId, Long accountPluginId) {
+        Timer.Sample timer = Timer.start(meterRegistry);
+
+        try {
+            // Get batch with files
+            Batch batch = batchRepository.findById(batchId)
+                    .orElseThrow(() -> new IllegalArgumentException("Batch not found: " + batchId));
+
+            // Set MDC for structured logging
+            MDC.put("batchId", batchId.toString());
+            MDC.put("siteId", batch.getSiteId().toString());
+            MDC.put("accountId", batch.getAccountId().toString());
+
+            log.info("Starting SQL generation for batch: batchId={}", batchId);
+
+            // Check if already generated
+            if (sqlGenerationRepository.existsBySourceBatchId(batchId)) {
+                log.warn("SQL already generated for batch: batchId={}", batchId);
+                return Optional.empty();
+            }
+
+            // Get site for name
+            Site site = siteRepository.findById(batch.getSiteId())
+                    .orElseThrow(() -> new IllegalArgumentException("Site not found: " + batch.getSiteId()));
+
+            // Find previous batch for comparison
+            Optional<Batch> previousBatchOpt = batchRepository
+                    .findPreviousBatchForSite(batch.getSiteId(), batchId);
+
+            log.debug("Previous batch for comparison: {}",
+                    previousBatchOpt.map(b -> b.getId().toString()).orElse("none (first batch)"));
+
+            // Get current batch files
+            Batch batchWithFiles = batchRepository.findById(batchId)
+                    .orElseThrow(() -> new IllegalArgumentException("Batch not found: " + batchId));
+
+            List<UploadedFile> currentFiles = batchWithFiles.getUploadedFiles();
+            if (currentFiles.isEmpty()) {
+                log.warn("No files in batch, skipping SQL generation: batchId={}", batchId);
+                return Optional.empty();
+            }
+
+            // Filter to CSV files only
+            List<UploadedFile> csvFiles = currentFiles.stream()
+                    .filter(f -> f.getOriginalFileName().toLowerCase().endsWith(".csv") ||
+                                 f.getOriginalFileName().toLowerCase().endsWith(".csv.gz"))
+                    .collect(Collectors.toList());
+
+            if (csvFiles.isEmpty()) {
+                log.warn("No CSV files in batch, skipping SQL generation: batchId={}", batchId);
+                return Optional.empty();
+            }
+
+            // Get previous batch files (if exists)
+            Map<String, UploadedFile> previousFilesMap = new HashMap<>();
+            if (previousBatchOpt.isPresent()) {
+                Batch previousBatchWithFiles = batchRepository.findById(previousBatchOpt.get().getId())
+                        .orElseThrow();
+                for (UploadedFile file : previousBatchWithFiles.getUploadedFiles()) {
+                    previousFilesMap.put(normalizeFileName(file.getOriginalFileName()), file);
+                }
+            }
+
+            // Generate SQL for each CSV file
+            StringBuilder sqlContent = new StringBuilder();
+            int totalInserts = 0;
+            int totalUpdates = 0;
+            int totalDeletes = 0;
+            int filesProcessed = 0;
+
+            for (UploadedFile currentFile : csvFiles) {
+                String normalizedName = normalizeFileName(currentFile.getOriginalFileName());
+                String tableName = deriveTableName(normalizedName);
+
+                log.debug("Processing CSV file: {} -> table {}", currentFile.getOriginalFileName(), tableName);
+
+                // Read current file content
+                List<Map<String, String>> currentRows = readCsvFromS3(currentFile.getS3Key());
+
+                // Read previous file content (empty if first batch)
+                List<Map<String, String>> previousRows = new ArrayList<>();
+                UploadedFile previousFile = previousFilesMap.get(normalizedName);
+                if (previousFile != null) {
+                    previousRows = readCsvFromS3(previousFile.getS3Key());
+                }
+
+                // Generate diffs
+                List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+                // Generate SQL statements
+                for (CsvRowDiff diff : diffs) {
+                    String sql = sqlStatementGenerator.generate(diff, tableName, Map.of());
+                    sqlContent.append(sql);
+
+                    switch (diff.type()) {
+                        case ADDED -> totalInserts++;
+                        case MODIFIED -> totalUpdates++;
+                        case DELETED -> totalDeletes++;
+                    }
+                }
+
+                filesProcessed++;
+                meterRegistry.counter("sql.generation.files.processed").increment();
+            }
+
+            // Handle case where no changes were detected
+            if (sqlContent.isEmpty()) {
+                log.info("No changes detected between batches, skipping SQL file creation");
+                return Optional.empty();
+            }
+
+            // Store SQL file in S3
+            String s3Key = s3SqlFileStorageService.storeSqlFile(
+                    batch.getAccountId(),
+                    site.getDomain(),
+                    sqlContent.toString()
+            );
+
+            // Get file size
+            long fileSize = s3SqlFileStorageService.getFileSize(s3Key);
+
+            // Record generation
+            long durationMs = timer.stop(meterRegistry.timer("sql.generation.duration"));
+
+            SqlGenerationStats stats = new SqlGenerationStats(
+                    totalInserts, totalUpdates, totalDeletes, filesProcessed
+            );
+
+            PluginSqlGeneration generation = PluginSqlGeneration.create(
+                    accountPluginId,
+                    batch.getSiteId(),
+                    batchId,
+                    previousBatchOpt.map(Batch::getId).orElse(null),
+                    s3Key,
+                    fileSize,
+                    stats,
+                    durationMs / 1_000_000 // Convert nanos to ms
+            );
+
+            generation = sqlGenerationRepository.save(generation);
+
+            log.info("SQL generation completed: batchId={}, statements={}, duration={}ms",
+                    batchId, stats.total(), durationMs / 1_000_000);
+
+            // Record metrics
+            meterRegistry.counter("sql.generation.statements.inserts").increment(totalInserts);
+            meterRegistry.counter("sql.generation.statements.updates").increment(totalUpdates);
+            meterRegistry.counter("sql.generation.statements.deletes").increment(totalDeletes);
+
+            return Optional.of(generation);
+
+        } catch (IOException e) {
+            log.error("SQL generation failed for batch (I/O error): batchId={}", batchId, e);
+            meterRegistry.counter("sql.generation.errors").increment();
+            throw new SqlGenerationException("Failed to read CSV files for SQL generation", e);
+        } catch (RuntimeException e) {
+            log.error("SQL generation failed for batch: batchId={}", batchId, e);
+            meterRegistry.counter("sql.generation.errors").increment();
+            throw e;
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    /**
+     * Reads CSV content from S3 and returns rows as list of maps.
+     */
+    private List<Map<String, String>> readCsvFromS3(String s3Key) throws IOException {
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(s3Key)
+                .build();
+
+        try (ResponseInputStream<GetObjectResponse> s3Response = s3Client.getObject(request)) {
+            InputStream inputStream = s3Response;
+
+            // Handle gzipped files
+            if (s3Key.toLowerCase().endsWith(".gz")) {
+                inputStream = new GZIPInputStream(s3Response);
+            }
+
+            try (Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
+                 CSVParser parser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(reader)) {
+
+                List<Map<String, String>> rows = new ArrayList<>();
+                for (CSVRecord record : parser) {
+                    // Use LinkedHashMap to preserve column order
+                    Map<String, String> row = new LinkedHashMap<>();
+                    for (String header : parser.getHeaderNames()) {
+                        row.put(header, record.get(header));
+                    }
+                    rows.add(row);
+                }
+                return rows;
+            }
+        }
+    }
+
+    /**
+     * Normalizes file name for comparison (removes .gz extension).
+     */
+    private String normalizeFileName(String fileName) {
+        if (fileName.toLowerCase().endsWith(".gz")) {
+            return fileName.substring(0, fileName.length() - 3);
+        }
+        return fileName;
+    }
+
+    /**
+     * Derives table name from CSV filename.
+     * Example: customers.csv -> customers
+     */
+    private String deriveTableName(String fileName) {
+        String name = fileName;
+        if (name.toLowerCase().endsWith(".csv")) {
+            name = name.substring(0, name.length() - 4);
+        }
+        // Sanitize: replace invalid characters with underscore
+        return name.replaceAll("[^a-zA-Z0-9_]", "_").toLowerCase();
+    }
+
+    /**
+     * Exception thrown when SQL generation fails.
+     */
+    public static class SqlGenerationException extends RuntimeException {
+        public SqlGenerationException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
@@ -31,11 +31,25 @@ import java.util.zip.GZIPInputStream;
 /**
  * Service orchestrating SQL file generation from CSV batch comparisons.
  * Compares CSV files between consecutive batches and generates SQL statements.
+ * <p>
+ * Performance considerations:
+ * <ul>
+ *   <li>Uses JOIN FETCH to prevent N+1 queries when loading batch files</li>
+ *   <li>Limits batch size to prevent memory issues</li>
+ *   <li>S3 operations run outside transactions to avoid connection starvation</li>
+ * </ul>
+ * </p>
  */
 @Service
 public class SqlGenerationService {
 
     private static final Logger log = LoggerFactory.getLogger(SqlGenerationService.class);
+
+    /**
+     * Maximum number of CSV files allowed per batch for SQL generation.
+     * Prevents memory exhaustion from processing too many files.
+     */
+    private static final int MAX_CSV_FILES_PER_BATCH = 100;
 
     private final BatchRepository batchRepository;
     private final SiteRepository siteRepository;
@@ -74,175 +88,267 @@ public class SqlGenerationService {
     /**
      * Generates SQL file from batch comparison.
      * Called when a batch completes for an account with active Bit BI plugin.
+     * <p>
+     * Transaction strategy:
+     * <ul>
+     *   <li>Phase 1: Load data (read-only transaction)</li>
+     *   <li>Phase 2: S3 operations (outside transaction to avoid connection starvation)</li>
+     *   <li>Phase 3: Save result (separate write transaction)</li>
+     * </ul>
+     * </p>
      *
      * @param batchId The completed batch ID
      * @param accountPluginId The ID of the active account plugin
      * @return Optional containing the generation record, or empty if no changes
      */
-    @Transactional
     public Optional<PluginSqlGeneration> generateSqlForBatch(UUID batchId, Long accountPluginId) {
         Timer.Sample timer = Timer.start(meterRegistry);
+        String s3Key = null;
 
         try {
-            // Get batch with files
-            Batch batch = batchRepository.findById(batchId)
-                    .orElseThrow(() -> new IllegalArgumentException("Batch not found: " + batchId));
+            // Phase 1: Load all required data (uses JOIN FETCH to prevent N+1)
+            BatchData batchData = loadBatchData(batchId);
+            if (batchData == null) {
+                return Optional.empty();
+            }
 
             // Set MDC for structured logging
             MDC.put("batchId", batchId.toString());
-            MDC.put("siteId", batch.getSiteId().toString());
-            MDC.put("accountId", batch.getAccountId().toString());
+            MDC.put("siteId", batchData.batch.getSiteId().toString());
+            MDC.put("accountId", batchData.batch.getAccountId().toString());
 
             log.info("Starting SQL generation for batch: batchId={}", batchId);
 
-            // Check if already generated
-            if (sqlGenerationRepository.existsBySourceBatchId(batchId)) {
-                log.warn("SQL already generated for batch: batchId={}", batchId);
-                return Optional.empty();
-            }
-
-            // Get site for name
-            Site site = siteRepository.findById(batch.getSiteId())
-                    .orElseThrow(() -> new IllegalArgumentException("Site not found: " + batch.getSiteId()));
-
-            // Find previous batch for comparison
-            Optional<Batch> previousBatchOpt = batchRepository
-                    .findPreviousBatchForSite(batch.getSiteId(), batchId);
-
-            log.debug("Previous batch for comparison: {}",
-                    previousBatchOpt.map(b -> b.getId().toString()).orElse("none (first batch)"));
-
-            // Get current batch files
-            Batch batchWithFiles = batchRepository.findById(batchId)
-                    .orElseThrow(() -> new IllegalArgumentException("Batch not found: " + batchId));
-
-            List<UploadedFile> currentFiles = batchWithFiles.getUploadedFiles();
-            if (currentFiles.isEmpty()) {
-                log.warn("No files in batch, skipping SQL generation: batchId={}", batchId);
-                return Optional.empty();
-            }
-
-            // Filter to CSV files only
-            List<UploadedFile> csvFiles = currentFiles.stream()
-                    .filter(f -> f.getOriginalFileName().toLowerCase().endsWith(".csv") ||
-                                 f.getOriginalFileName().toLowerCase().endsWith(".csv.gz"))
-                    .collect(Collectors.toList());
-
-            if (csvFiles.isEmpty()) {
-                log.warn("No CSV files in batch, skipping SQL generation: batchId={}", batchId);
-                return Optional.empty();
-            }
-
-            // Get previous batch files (if exists)
-            Map<String, UploadedFile> previousFilesMap = new HashMap<>();
-            if (previousBatchOpt.isPresent()) {
-                Batch previousBatchWithFiles = batchRepository.findById(previousBatchOpt.get().getId())
-                        .orElseThrow();
-                for (UploadedFile file : previousBatchWithFiles.getUploadedFiles()) {
-                    previousFilesMap.put(normalizeFileName(file.getOriginalFileName()), file);
-                }
-            }
-
-            // Generate SQL for each CSV file
-            StringBuilder sqlContent = new StringBuilder();
-            int totalInserts = 0;
-            int totalUpdates = 0;
-            int totalDeletes = 0;
-            int filesProcessed = 0;
-
-            for (UploadedFile currentFile : csvFiles) {
-                String normalizedName = normalizeFileName(currentFile.getOriginalFileName());
-                String tableName = deriveTableName(normalizedName);
-
-                log.debug("Processing CSV file: {} -> table {}", currentFile.getOriginalFileName(), tableName);
-
-                // Read current file content
-                List<Map<String, String>> currentRows = readCsvFromS3(currentFile.getS3Key());
-
-                // Read previous file content (empty if first batch)
-                List<Map<String, String>> previousRows = new ArrayList<>();
-                UploadedFile previousFile = previousFilesMap.get(normalizedName);
-                if (previousFile != null) {
-                    previousRows = readCsvFromS3(previousFile.getS3Key());
-                }
-
-                // Generate diffs
-                List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-                // Generate SQL statements
-                for (CsvRowDiff diff : diffs) {
-                    String sql = sqlStatementGenerator.generate(diff, tableName, Map.of());
-                    sqlContent.append(sql);
-
-                    switch (diff.type()) {
-                        case ADDED -> totalInserts++;
-                        case MODIFIED -> totalUpdates++;
-                        case DELETED -> totalDeletes++;
-                    }
-                }
-
-                filesProcessed++;
-                meterRegistry.counter("sql.generation.files.processed").increment();
-            }
-
-            // Handle case where no changes were detected
-            if (sqlContent.isEmpty()) {
+            // Phase 2: Generate SQL content (S3 reads outside transaction)
+            SqlGenerationResult result = generateSqlContent(batchData);
+            if (result == null) {
                 log.info("No changes detected between batches, skipping SQL file creation");
                 return Optional.empty();
             }
 
-            // Store SQL file in S3
-            String s3Key = s3SqlFileStorageService.storeSqlFile(
-                    batch.getAccountId(),
-                    site.getDomain(),
-                    sqlContent.toString()
+            // Phase 2b: Store SQL file in S3 (outside transaction)
+            s3Key = s3SqlFileStorageService.storeSqlFile(
+                    batchData.batch.getAccountId(),
+                    batchData.site.getDomain(),
+                    result.sqlContent
             );
-
-            // Get file size
             long fileSize = s3SqlFileStorageService.getFileSize(s3Key);
 
-            // Record generation
+            // Phase 3: Save generation record (separate transaction)
             long durationMs = timer.stop(meterRegistry.timer("sql.generation.duration"));
-
-            SqlGenerationStats stats = new SqlGenerationStats(
-                    totalInserts, totalUpdates, totalDeletes, filesProcessed
-            );
-
-            PluginSqlGeneration generation = PluginSqlGeneration.create(
+            PluginSqlGeneration generation = saveGenerationRecord(
                     accountPluginId,
-                    batch.getSiteId(),
-                    batchId,
-                    previousBatchOpt.map(Batch::getId).orElse(null),
+                    batchData,
                     s3Key,
                     fileSize,
-                    stats,
-                    durationMs / 1_000_000 // Convert nanos to ms
+                    result.stats,
+                    durationMs
             );
 
-            generation = sqlGenerationRepository.save(generation);
-
             log.info("SQL generation completed: batchId={}, statements={}, duration={}ms",
-                    batchId, stats.total(), durationMs / 1_000_000);
+                    batchId, result.stats.total(), durationMs / 1_000_000);
 
             // Record metrics
-            meterRegistry.counter("sql.generation.statements.inserts").increment(totalInserts);
-            meterRegistry.counter("sql.generation.statements.updates").increment(totalUpdates);
-            meterRegistry.counter("sql.generation.statements.deletes").increment(totalDeletes);
+            meterRegistry.counter("sql.generation.statements.inserts").increment(result.stats.inserts());
+            meterRegistry.counter("sql.generation.statements.updates").increment(result.stats.updates());
+            meterRegistry.counter("sql.generation.statements.deletes").increment(result.stats.deletes());
 
             return Optional.of(generation);
 
         } catch (IOException e) {
             log.error("SQL generation failed for batch (I/O error): batchId={}", batchId, e);
             meterRegistry.counter("sql.generation.errors").increment();
+            cleanupOrphanedS3File(s3Key);
             throw new SqlGenerationException("Failed to read CSV files for SQL generation", e);
         } catch (RuntimeException e) {
             log.error("SQL generation failed for batch: batchId={}", batchId, e);
             meterRegistry.counter("sql.generation.errors").increment();
+            cleanupOrphanedS3File(s3Key);
             throw e;
         } finally {
             MDC.clear();
         }
     }
+
+    /**
+     * Phase 1: Loads all required batch data using JOIN FETCH.
+     * Returns null if generation should be skipped.
+     */
+    @Transactional(readOnly = true)
+    protected BatchData loadBatchData(UUID batchId) {
+        // Get batch with files using JOIN FETCH (prevents N+1)
+        Batch batch = batchRepository.findByIdWithFiles(batchId)
+                .orElseThrow(() -> new IllegalArgumentException("Batch not found: " + batchId));
+
+        // Check if already generated
+        if (sqlGenerationRepository.existsBySourceBatchId(batchId)) {
+            log.warn("SQL already generated for batch: batchId={}", batchId);
+            return null;
+        }
+
+        // Get site for name
+        Site site = siteRepository.findById(batch.getSiteId())
+                .orElseThrow(() -> new IllegalArgumentException("Site not found: " + batch.getSiteId()));
+
+        List<UploadedFile> currentFiles = batch.getUploadedFiles();
+        if (currentFiles.isEmpty()) {
+            log.warn("No files in batch, skipping SQL generation: batchId={}", batchId);
+            return null;
+        }
+
+        // Filter to CSV files only
+        List<UploadedFile> csvFiles = currentFiles.stream()
+                .filter(f -> f.getOriginalFileName().toLowerCase().endsWith(".csv") ||
+                             f.getOriginalFileName().toLowerCase().endsWith(".csv.gz"))
+                .collect(Collectors.toList());
+
+        if (csvFiles.isEmpty()) {
+            log.warn("No CSV files in batch, skipping SQL generation: batchId={}", batchId);
+            return null;
+        }
+
+        // Check batch file limit to prevent memory issues
+        if (csvFiles.size() > MAX_CSV_FILES_PER_BATCH) {
+            log.error("Too many CSV files in batch: count={}, max={}, batchId={}",
+                    csvFiles.size(), MAX_CSV_FILES_PER_BATCH, batchId);
+            throw new IllegalArgumentException(
+                    "Batch contains " + csvFiles.size() + " CSV files, exceeding limit of " + MAX_CSV_FILES_PER_BATCH);
+        }
+
+        // Find previous batch for comparison using JOIN FETCH
+        Optional<Batch> previousBatchOpt = batchRepository
+                .findPreviousBatchForSiteWithFiles(batch.getSiteId(), batchId);
+
+        log.debug("Previous batch for comparison: {}",
+                previousBatchOpt.map(b -> b.getId().toString()).orElse("none (first batch)"));
+
+        // Build previous files map
+        Map<String, UploadedFile> previousFilesMap = new HashMap<>();
+        if (previousBatchOpt.isPresent()) {
+            for (UploadedFile file : previousBatchOpt.get().getUploadedFiles()) {
+                previousFilesMap.put(normalizeFileName(file.getOriginalFileName()), file);
+            }
+        }
+
+        return new BatchData(batch, site, csvFiles, previousBatchOpt, previousFilesMap);
+    }
+
+    /**
+     * Phase 2: Generates SQL content by reading files from S3 and computing diffs.
+     * Runs outside transaction to avoid connection starvation during S3 I/O.
+     */
+    private SqlGenerationResult generateSqlContent(BatchData data) throws IOException {
+        StringBuilder sqlContent = new StringBuilder();
+        int totalInserts = 0;
+        int totalUpdates = 0;
+        int totalDeletes = 0;
+        int filesProcessed = 0;
+
+        for (UploadedFile currentFile : data.csvFiles) {
+            String normalizedName = normalizeFileName(currentFile.getOriginalFileName());
+            String tableName = deriveTableName(normalizedName);
+
+            log.debug("Processing CSV file: {} -> table {}", currentFile.getOriginalFileName(), tableName);
+
+            // Read current file content from S3
+            List<Map<String, String>> currentRows = readCsvFromS3(currentFile.getS3Key());
+
+            // Read previous file content (empty if first batch)
+            List<Map<String, String>> previousRows = new ArrayList<>();
+            UploadedFile previousFile = data.previousFilesMap.get(normalizedName);
+            if (previousFile != null) {
+                previousRows = readCsvFromS3(previousFile.getS3Key());
+            }
+
+            // Generate diffs
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Generate SQL statements
+            for (CsvRowDiff diff : diffs) {
+                String sql = sqlStatementGenerator.generate(diff, tableName, Map.of());
+                sqlContent.append(sql);
+
+                switch (diff.type()) {
+                    case ADDED -> totalInserts++;
+                    case MODIFIED -> totalUpdates++;
+                    case DELETED -> totalDeletes++;
+                }
+            }
+
+            filesProcessed++;
+            meterRegistry.counter("sql.generation.files.processed").increment();
+        }
+
+        // Return null if no changes detected
+        if (sqlContent.isEmpty()) {
+            return null;
+        }
+
+        return new SqlGenerationResult(
+                sqlContent.toString(),
+                new SqlGenerationStats(totalInserts, totalUpdates, totalDeletes, filesProcessed)
+        );
+    }
+
+    /**
+     * Phase 3: Saves the generation record in a separate transaction.
+     */
+    @Transactional
+    protected PluginSqlGeneration saveGenerationRecord(
+            Long accountPluginId,
+            BatchData data,
+            String s3Key,
+            long fileSize,
+            SqlGenerationStats stats,
+            long durationNanos) {
+
+        PluginSqlGeneration generation = PluginSqlGeneration.create(
+                accountPluginId,
+                data.batch.getSiteId(),
+                data.batch.getId(),
+                data.previousBatchOpt.map(Batch::getId).orElse(null),
+                s3Key,
+                fileSize,
+                stats,
+                durationNanos / 1_000_000 // Convert nanos to ms
+        );
+
+        return sqlGenerationRepository.save(generation);
+    }
+
+    /**
+     * Cleans up orphaned S3 file if database save fails.
+     */
+    private void cleanupOrphanedS3File(String s3Key) {
+        if (s3Key != null) {
+            try {
+                s3SqlFileStorageService.deleteFile(s3Key);
+                log.info("Cleaned up orphaned S3 file: {}", s3Key);
+            } catch (Exception e) {
+                log.error("Failed to cleanup orphaned S3 file: {}. Manual cleanup required.", s3Key, e);
+                meterRegistry.counter("sql.generation.orphaned.files").increment();
+            }
+        }
+    }
+
+    /**
+     * Internal record to hold batch data loaded in Phase 1.
+     */
+    private record BatchData(
+            Batch batch,
+            Site site,
+            List<UploadedFile> csvFiles,
+            Optional<Batch> previousBatchOpt,
+            Map<String, UploadedFile> previousFilesMap
+    ) {}
+
+    /**
+     * Internal record to hold SQL generation result from Phase 2.
+     */
+    private record SqlGenerationResult(
+            String sqlContent,
+            SqlGenerationStats stats
+    ) {}
 
     /**
      * Reads CSV content from S3 and returns rows as list of maps.

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlStatementGenerator.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlStatementGenerator.java
@@ -6,15 +6,26 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 import java.util.StringJoiner;
+import java.util.regex.Pattern;
 
 /**
  * Service for generating PostgreSQL SQL statements from CSV row diffs.
  * Produces INSERT, UPDATE, DELETE statements with proper formatting.
+ * <p>
+ * Security: Validates table/column names and escapes values to prevent SQL injection.
+ * </p>
  */
 @Service
 public class SqlStatementGenerator {
 
     private static final String END_OF_COMMAND_FORMAT = "--- END OF COMMAND \"%s.csv:%d\" ---";
+
+    /**
+     * Pattern for valid PostgreSQL identifiers (table/column names).
+     * Allows: letters, digits, underscores. Must start with letter or underscore.
+     * Max 63 characters per PostgreSQL limit.
+     */
+    private static final Pattern VALID_IDENTIFIER = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]{0,62}$");
 
     /**
      * Generates a SQL statement from a row diff.
@@ -23,8 +34,17 @@ public class SqlStatementGenerator {
      * @param tableName The table name (derived from CSV filename)
      * @param columnTypes Map of column name to DBF type for NULL/value handling
      * @return The SQL statement with trailing END OF COMMAND comment
+     * @throws IllegalArgumentException if table name or column names contain invalid characters
      */
     public String generate(CsvRowDiff diff, String tableName, Map<String, DbfColumnType> columnTypes) {
+        // Security: Validate table name to prevent SQL injection
+        validateIdentifier(tableName, "Table name");
+
+        // Security: Validate all column names
+        for (String column : diff.values().keySet()) {
+            validateIdentifier(column, "Column name");
+        }
+
         String sql = switch (diff.type()) {
             case ADDED -> generateInsert(diff, tableName, columnTypes);
             case MODIFIED -> generateUpdate(diff, tableName, columnTypes);
@@ -32,6 +52,34 @@ public class SqlStatementGenerator {
         };
 
         return sql + ";\n" + String.format(END_OF_COMMAND_FORMAT, tableName, diff.lineNumber()) + "\n";
+    }
+
+    /**
+     * Validates that an identifier (table/column name) is safe for SQL.
+     * Prevents SQL injection through malicious identifiers.
+     *
+     * @param identifier The identifier to validate
+     * @param description Description for error message (e.g., "Table name", "Column name")
+     * @throws IllegalArgumentException if identifier is invalid
+     */
+    private void validateIdentifier(String identifier, String description) {
+        if (identifier == null || identifier.isEmpty()) {
+            throw new IllegalArgumentException(description + " cannot be null or empty");
+        }
+        if (!VALID_IDENTIFIER.matcher(identifier).matches()) {
+            throw new IllegalArgumentException(
+                    description + " contains invalid characters: '" + sanitizeForLogging(identifier) +
+                    "'. Only letters, digits, and underscores are allowed, starting with letter or underscore.");
+        }
+    }
+
+    /**
+     * Sanitizes a string for safe logging (prevents log injection).
+     */
+    private String sanitizeForLogging(String input) {
+        if (input == null) return "null";
+        // Replace control characters and limit length
+        return input.replaceAll("[\\p{Cntrl}]", "?").substring(0, Math.min(input.length(), 50));
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlStatementGenerator.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlStatementGenerator.java
@@ -1,0 +1,156 @@
+package com.bitbi.dfm.plugin.application;
+
+import com.bitbi.dfm.plugin.domain.CsvRowDiff;
+import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.StringJoiner;
+
+/**
+ * Service for generating PostgreSQL SQL statements from CSV row diffs.
+ * Produces INSERT, UPDATE, DELETE statements with proper formatting.
+ */
+@Service
+public class SqlStatementGenerator {
+
+    private static final String END_OF_COMMAND_FORMAT = "--- END OF COMMAND \"%s.csv:%d\" ---";
+
+    /**
+     * Generates a SQL statement from a row diff.
+     *
+     * @param diff The row difference (ADDED, MODIFIED, DELETED)
+     * @param tableName The table name (derived from CSV filename)
+     * @param columnTypes Map of column name to DBF type for NULL/value handling
+     * @return The SQL statement with trailing END OF COMMAND comment
+     */
+    public String generate(CsvRowDiff diff, String tableName, Map<String, DbfColumnType> columnTypes) {
+        String sql = switch (diff.type()) {
+            case ADDED -> generateInsert(diff, tableName, columnTypes);
+            case MODIFIED -> generateUpdate(diff, tableName, columnTypes);
+            case DELETED -> generateDelete(diff, tableName, columnTypes);
+        };
+
+        return sql + ";\n" + String.format(END_OF_COMMAND_FORMAT, tableName, diff.lineNumber()) + "\n";
+    }
+
+    /**
+     * Generates an INSERT statement.
+     */
+    private String generateInsert(CsvRowDiff diff, String tableName, Map<String, DbfColumnType> columnTypes) {
+        StringBuilder sql = new StringBuilder("INSERT INTO ");
+        sql.append(tableName).append(" ");
+
+        StringJoiner columns = new StringJoiner(", ", "(", ")");
+        StringJoiner values = new StringJoiner(", ", "(", ")");
+
+        for (Map.Entry<String, String> entry : diff.values().entrySet()) {
+            String column = entry.getKey();
+            String value = entry.getValue();
+            DbfColumnType type = columnTypes.getOrDefault(column, DbfColumnType.CHARACTER);
+
+            columns.add(column);
+            values.add(formatValue(value, type));
+        }
+
+        sql.append(columns);
+        sql.append(" VALUES ");
+        sql.append(values);
+
+        return sql.toString();
+    }
+
+    /**
+     * Generates an UPDATE statement.
+     * Uses unchanged columns in WHERE clause, changed columns in SET clause.
+     */
+    private String generateUpdate(CsvRowDiff diff, String tableName, Map<String, DbfColumnType> columnTypes) {
+        StringBuilder sql = new StringBuilder("UPDATE ");
+        sql.append(tableName).append(" SET ");
+
+        // SET clause - only changed columns
+        StringJoiner setClause = new StringJoiner(", ");
+        for (String changedColumn : diff.changedColumns().keySet()) {
+            String newValue = diff.values().get(changedColumn);
+            DbfColumnType type = columnTypes.getOrDefault(changedColumn, DbfColumnType.CHARACTER);
+            setClause.add(changedColumn + " = " + formatValue(newValue, type));
+        }
+        sql.append(setClause);
+
+        // WHERE clause - unchanged columns
+        sql.append(" WHERE ");
+        StringJoiner whereClause = new StringJoiner(" AND ");
+        for (Map.Entry<String, String> entry : diff.values().entrySet()) {
+            String column = entry.getKey();
+            if (!diff.changedColumns().containsKey(column)) {
+                String value = entry.getValue();
+                DbfColumnType type = columnTypes.getOrDefault(column, DbfColumnType.CHARACTER);
+                whereClause.add(column + " = " + formatValue(value, type));
+            }
+        }
+        sql.append(whereClause);
+
+        return sql.toString();
+    }
+
+    /**
+     * Generates a DELETE statement.
+     * Uses all columns in WHERE clause.
+     */
+    private String generateDelete(CsvRowDiff diff, String tableName, Map<String, DbfColumnType> columnTypes) {
+        StringBuilder sql = new StringBuilder("DELETE FROM ");
+        sql.append(tableName).append(" WHERE ");
+
+        StringJoiner whereClause = new StringJoiner(" AND ");
+        for (Map.Entry<String, String> entry : diff.values().entrySet()) {
+            String column = entry.getKey();
+            String value = entry.getValue();
+            DbfColumnType type = columnTypes.getOrDefault(column, DbfColumnType.CHARACTER);
+            whereClause.add(column + " = " + formatValue(value, type));
+        }
+        sql.append(whereClause);
+
+        return sql.toString();
+    }
+
+    /**
+     * Formats a value for SQL based on its DBF type.
+     * Handles NULL for empty values, quoting for strings, no quotes for numbers.
+     */
+    private String formatValue(String value, DbfColumnType type) {
+        // Handle empty values
+        if (value == null || value.isEmpty()) {
+            if (type.isEmptyNull()) {
+                return "NULL";
+            } else {
+                return "0"; // INTEGER and CURRENCY types
+            }
+        }
+
+        // Numeric types - no quotes
+        if (isNumericType(type)) {
+            return value;
+        }
+
+        // String types - escape and quote
+        return "'" + escapeString(value) + "'";
+    }
+
+    /**
+     * Checks if a type is numeric (no quoting needed).
+     */
+    private boolean isNumericType(DbfColumnType type) {
+        return type == DbfColumnType.INTEGER ||
+               type == DbfColumnType.CURRENCY ||
+               type == DbfColumnType.NUMERIC ||
+               type == DbfColumnType.FLOAT;
+    }
+
+    /**
+     * Escapes a string value for PostgreSQL.
+     * Doubles single quotes as per SQL standard.
+     */
+    private String escapeString(String value) {
+        return value.replace("'", "''");
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/AccountPluginRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/AccountPluginRepository.java
@@ -72,4 +72,21 @@ public interface AccountPluginRepository {
      * @param accountPlugin the activation to delete
      */
     void delete(AccountPlugin accountPlugin);
+
+    /**
+     * Finds an account plugin by ID.
+     * @param id the account plugin ID
+     * @return the activation record if found
+     */
+    Optional<AccountPlugin> findById(Long id);
+
+    /**
+     * Finds an active account plugin by plugin ID and API key.
+     * Uses JSONB containment query for performance.
+     *
+     * @param pluginId the plugin identifier
+     * @param apiKey the API key value
+     * @return the activation record if found and active
+     */
+    Optional<AccountPlugin> findByPluginIdAndApiKey(String pluginId, String apiKey);
 }

--- a/src/main/java/com/bitbi/dfm/plugin/domain/CsvRowDiff.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/CsvRowDiff.java
@@ -1,0 +1,81 @@
+package com.bitbi.dfm.plugin.domain;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Value object representing a single row difference between CSV files.
+ * Used to track added, modified, or deleted rows for SQL generation.
+ *
+ * @param type The type of difference (ADDED, MODIFIED, DELETED)
+ * @param lineNumber The line number in the source CSV file (1-based, excluding header)
+ * @param values The column values for this row (column name -> value, may contain null values)
+ * @param changedColumns For MODIFIED rows only: the old values of changed columns
+ */
+public record CsvRowDiff(
+    DiffType type,
+    int lineNumber,
+    Map<String, String> values,
+    Map<String, String> changedColumns
+) {
+    /**
+     * Types of row differences.
+     */
+    public enum DiffType {
+        /** Row exists in current batch but not in previous - generates INSERT */
+        ADDED,
+        /** Row exists in both batches but with different values - generates UPDATE */
+        MODIFIED,
+        /** Row exists in previous batch but not in current - generates DELETE */
+        DELETED
+    }
+
+    /**
+     * Creates a diff representing an added row (INSERT).
+     */
+    public static CsvRowDiff added(int lineNumber, Map<String, String> values) {
+        return new CsvRowDiff(DiffType.ADDED, lineNumber, copyMapNullSafe(values), Map.of());
+    }
+
+    /**
+     * Creates a diff representing a deleted row (DELETE).
+     */
+    public static CsvRowDiff deleted(int lineNumber, Map<String, String> values) {
+        return new CsvRowDiff(DiffType.DELETED, lineNumber, copyMapNullSafe(values), Map.of());
+    }
+
+    /**
+     * Creates a diff representing a modified row (UPDATE).
+     *
+     * @param lineNumber The line number in the current CSV
+     * @param newValues The new column values
+     * @param changedColumns Map of column name -> old value for columns that changed
+     */
+    public static CsvRowDiff modified(int lineNumber, Map<String, String> newValues, Map<String, String> changedColumns) {
+        return new CsvRowDiff(DiffType.MODIFIED, lineNumber, copyMapNullSafe(newValues), copyMapNullSafe(changedColumns));
+    }
+
+    /**
+     * Creates an unmodifiable copy of a map that may contain null values.
+     * Map.copyOf() doesn't allow null values, so we use LinkedHashMap + unmodifiableMap.
+     */
+    private static Map<String, String> copyMapNullSafe(Map<String, String> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+
+    /**
+     * Returns the columns that were NOT changed (used for WHERE clause in UPDATE).
+     */
+    public Map<String, String> unchangedColumns() {
+        if (type != DiffType.MODIFIED) {
+            return values;
+        }
+        return values.entrySet().stream()
+            .filter(e -> !changedColumns.containsKey(e.getKey()))
+            .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/DbfColumnType.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/DbfColumnType.java
@@ -1,0 +1,82 @@
+package com.bitbi.dfm.plugin.domain;
+
+/**
+ * DBF (dBASE) column types for determining NULL handling in SQL generation.
+ * <p>
+ * Per specification:
+ * - Character, Numeric, Logical, Date, Float, DateTime: empty string = NULL
+ * - Integer, Currency: empty string = 0
+ */
+public enum DbfColumnType {
+    /** Character field - empty = NULL */
+    CHARACTER("C", true),
+    /** Numeric field - empty = NULL */
+    NUMERIC("N", true),
+    /** Logical/Boolean field - empty = NULL */
+    LOGICAL("L", true),
+    /** Date field - empty = NULL */
+    DATE("D", true),
+    /** Float field - empty = NULL */
+    FLOAT("F", true),
+    /** DateTime field - empty = NULL */
+    DATETIME("T", true),
+    /** Integer field - empty = 0 */
+    INTEGER("I", false),
+    /** Currency field - empty = 0 */
+    CURRENCY("Y", false);
+
+    private final String code;
+    private final boolean emptyIsNull;
+
+    DbfColumnType(String code, boolean emptyIsNull) {
+        this.code = code;
+        this.emptyIsNull = emptyIsNull;
+    }
+
+    /**
+     * Returns the single-character DBF type code.
+     */
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     * Returns true if empty strings should be converted to NULL for this type.
+     * Returns false if empty strings should be converted to 0.
+     */
+    public boolean isEmptyNull() {
+        return emptyIsNull;
+    }
+
+    /**
+     * Parses a DBF type code to enum value.
+     * Returns CHARACTER as default if code is not recognized.
+     *
+     * @param code Single-character DBF type code (e.g., "C", "N", "I")
+     * @return The corresponding DbfColumnType
+     */
+    public static DbfColumnType fromCode(String code) {
+        if (code == null || code.isEmpty()) {
+            return CHARACTER;
+        }
+        for (DbfColumnType type : values()) {
+            if (type.code.equalsIgnoreCase(code)) {
+                return type;
+            }
+        }
+        return CHARACTER;  // Default to CHARACTER (empty = NULL)
+    }
+
+    /**
+     * Converts an empty string value according to this type's rules.
+     *
+     * @param value The value to convert
+     * @return null if empty and type uses NULL, "0" if empty and type uses 0, original value otherwise
+     */
+    public String convertEmptyValue(String value) {
+        if (value == null || value.isEmpty()) {
+            return emptyIsNull ? null : "0";
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/PluginApiKey.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/PluginApiKey.java
@@ -1,0 +1,76 @@
+package com.bitbi.dfm.plugin.domain;
+
+import java.security.SecureRandom;
+import java.util.Objects;
+
+/**
+ * Value object representing a Plugin API Key for Bit BI Plugin API authentication.
+ * <p>
+ * Format: "plk_" prefix + 32 alphanumeric characters = 36 characters total
+ * Example: "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+ */
+public record PluginApiKey(String value) {
+    private static final String PREFIX = "plk_";
+    private static final int KEY_LENGTH = 32;
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final String ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final String PATTERN = "^plk_[a-zA-Z0-9]{32}$";
+
+    /**
+     * Validates the API key format on construction.
+     */
+    public PluginApiKey {
+        Objects.requireNonNull(value, "API key value cannot be null");
+        if (!value.matches(PATTERN)) {
+            throw new IllegalArgumentException("Invalid API key format. Expected: plk_ + 32 alphanumeric characters");
+        }
+    }
+
+    /**
+     * Generates a new random Plugin API Key.
+     */
+    public static PluginApiKey generate() {
+        StringBuilder key = new StringBuilder(PREFIX);
+        for (int i = 0; i < KEY_LENGTH; i++) {
+            key.append(ALPHABET.charAt(RANDOM.nextInt(ALPHABET.length())));
+        }
+        return new PluginApiKey(key.toString());
+    }
+
+    /**
+     * Creates a PluginApiKey from an existing value string.
+     * Validates format before returning.
+     *
+     * @param value The API key string
+     * @return PluginApiKey instance
+     * @throws IllegalArgumentException if format is invalid
+     */
+    public static PluginApiKey of(String value) {
+        return new PluginApiKey(value);
+    }
+
+    /**
+     * Checks if a string is a valid Plugin API Key format.
+     *
+     * @param value The string to check
+     * @return true if valid format
+     */
+    public static boolean isValid(String value) {
+        return value != null && value.matches(PATTERN);
+    }
+
+    /**
+     * Returns masked representation for logging (shows only last 4 characters).
+     */
+    @Override
+    public String toString() {
+        return PREFIX + "****" + value.substring(value.length() - 4);
+    }
+
+    /**
+     * Returns the full API key value (use with caution - avoid logging).
+     */
+    public String rawValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGeneration.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGeneration.java
@@ -1,0 +1,119 @@
+package com.bitbi.dfm.plugin.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Entity tracking SQL file generation events for the Bit BI plugin.
+ * Each record represents one SQL file generated from comparing two batches.
+ */
+@Entity
+@Table(name = "plugin_sql_generations")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PluginSqlGeneration {
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "account_plugin_id", nullable = false)
+    private Long accountPluginId;
+
+    @Column(name = "site_id", nullable = false)
+    private UUID siteId;
+
+    @Column(name = "source_batch_id", nullable = false)
+    private UUID sourceBatchId;
+
+    @Column(name = "comparison_batch_id")
+    private UUID comparisonBatchId;  // nullable for first batch
+
+    @Column(name = "s3_key", nullable = false, length = 1000)
+    private String s3Key;
+
+    @Column(name = "file_size_bytes", nullable = false)
+    private Long fileSizeBytes;
+
+    @Column(name = "statement_count", nullable = false)
+    private Integer statementCount;
+
+    @Column(name = "insert_count", nullable = false)
+    private Integer insertCount;
+
+    @Column(name = "update_count", nullable = false)
+    private Integer updateCount;
+
+    @Column(name = "delete_count", nullable = false)
+    private Integer deleteCount;
+
+    @Column(name = "files_processed", nullable = false)
+    private Integer filesProcessed;
+
+    @Column(name = "generation_duration_ms", nullable = false)
+    private Long generationDurationMs;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * Factory method for creating a new SQL generation record.
+     *
+     * @param accountPluginId The ID of the active account plugin
+     * @param siteId The ID of the site
+     * @param sourceBatchId The ID of the current batch (source of diff)
+     * @param comparisonBatchId The ID of the previous batch (null for first batch)
+     * @param s3Key The S3 key where the SQL file is stored
+     * @param fileSizeBytes The size of the generated SQL file
+     * @param stats The generation statistics
+     * @param durationMs The time taken to generate the SQL
+     * @return A new PluginSqlGeneration entity
+     */
+    public static PluginSqlGeneration create(
+            Long accountPluginId,
+            UUID siteId,
+            UUID sourceBatchId,
+            UUID comparisonBatchId,
+            String s3Key,
+            long fileSizeBytes,
+            SqlGenerationStats stats,
+            long durationMs
+    ) {
+        PluginSqlGeneration entity = new PluginSqlGeneration();
+        entity.id = UUID.randomUUID();
+        entity.accountPluginId = accountPluginId;
+        entity.siteId = siteId;
+        entity.sourceBatchId = sourceBatchId;
+        entity.comparisonBatchId = comparisonBatchId;
+        entity.s3Key = s3Key;
+        entity.fileSizeBytes = fileSizeBytes;
+        entity.statementCount = stats.total();
+        entity.insertCount = stats.inserts();
+        entity.updateCount = stats.updates();
+        entity.deleteCount = stats.deletes();
+        entity.filesProcessed = stats.filesProcessed();
+        entity.generationDurationMs = durationMs;
+        entity.createdAt = LocalDateTime.now();
+        return entity;
+    }
+
+    /**
+     * Returns true if this is a first-batch generation (no comparison batch).
+     * First batch generations contain only INSERT statements.
+     */
+    public boolean isFirstBatch() {
+        return comparisonBatchId == null;
+    }
+
+    /**
+     * Returns the statistics as a SqlGenerationStats record.
+     */
+    public SqlGenerationStats toStats() {
+        return new SqlGenerationStats(insertCount, updateCount, deleteCount, filesProcessed);
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
@@ -1,0 +1,68 @@
+package com.bitbi.dfm.plugin.domain;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository interface for PluginSqlGeneration entities.
+ * Follows DDD pattern with interface in domain layer.
+ */
+public interface PluginSqlGenerationRepository {
+
+    /**
+     * Saves a new SQL generation record.
+     */
+    PluginSqlGeneration save(PluginSqlGeneration generation);
+
+    /**
+     * Finds a SQL generation by its ID.
+     */
+    Optional<PluginSqlGeneration> findById(UUID id);
+
+    /**
+     * Finds all SQL generations for a site created after a given timestamp.
+     * Used by the Plugin API to retrieve SQL changes.
+     * Results are ordered by creation time ascending (oldest first).
+     *
+     * @param siteId The site ID to filter by
+     * @param since The timestamp to filter by (exclusive)
+     * @return List of SQL generations ordered by created_at ASC
+     */
+    List<PluginSqlGeneration> findBySiteIdAndCreatedAtAfter(UUID siteId, LocalDateTime since);
+
+    /**
+     * Finds a SQL generation by source batch ID.
+     * Each source batch can have at most one SQL generation (unique constraint).
+     *
+     * @param sourceBatchId The source batch ID
+     * @return Optional containing the generation if found
+     */
+    Optional<PluginSqlGeneration> findBySourceBatchId(UUID sourceBatchId);
+
+    /**
+     * Checks if a SQL generation already exists for a given source batch.
+     *
+     * @param sourceBatchId The source batch ID to check
+     * @return true if a generation exists
+     */
+    boolean existsBySourceBatchId(UUID sourceBatchId);
+
+    /**
+     * Finds all SQL generations for a site.
+     * Used for testing and debugging.
+     *
+     * @param siteId The site ID to filter by
+     * @return List of SQL generations for the site
+     */
+    List<PluginSqlGeneration> findBySiteId(UUID siteId);
+
+    /**
+     * Finds all SQL generations.
+     * Used for testing.
+     *
+     * @return List of all SQL generations
+     */
+    List<PluginSqlGeneration> findAll();
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/SqlGenerationStats.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/SqlGenerationStats.java
@@ -1,0 +1,45 @@
+package com.bitbi.dfm.plugin.domain;
+
+/**
+ * Value object for tracking SQL generation statistics.
+ * Immutable record for aggregating INSERT, UPDATE, DELETE counts.
+ */
+public record SqlGenerationStats(
+    int inserts,
+    int updates,
+    int deletes,
+    int filesProcessed
+) {
+    /**
+     * Returns total statement count (inserts + updates + deletes).
+     */
+    public int total() {
+        return inserts + updates + deletes;
+    }
+
+    /**
+     * Creates an empty stats object with all zeros.
+     */
+    public static SqlGenerationStats empty() {
+        return new SqlGenerationStats(0, 0, 0, 0);
+    }
+
+    /**
+     * Merges this stats with another, summing all counts.
+     */
+    public SqlGenerationStats merge(SqlGenerationStats other) {
+        return new SqlGenerationStats(
+            this.inserts + other.inserts,
+            this.updates + other.updates,
+            this.deletes + other.deletes,
+            this.filesProcessed + other.filesProcessed
+        );
+    }
+
+    /**
+     * Creates stats for a single file's results.
+     */
+    public static SqlGenerationStats forFile(int inserts, int updates, int deletes) {
+        return new SqlGenerationStats(inserts, updates, deletes, 1);
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaAccountPluginRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaAccountPluginRepository.java
@@ -45,4 +45,27 @@ public interface JpaAccountPluginRepository extends JpaRepository<AccountPlugin,
     boolean existsActiveByAccountIdAndPluginId(
             @Param("accountId") UUID accountId,
             @Param("pluginId") String pluginId);
+
+    /**
+     * Internal method for JSONB containment query.
+     * Uses PostgreSQL JSONB containment operator @> for efficient key lookup.
+     */
+    @Query(value = """
+        SELECT * FROM account_plugins
+        WHERE plugin_id = :pluginId
+          AND plugin_data @> CAST(:apiKeyJson AS jsonb)
+        """, nativeQuery = true)
+    Optional<AccountPlugin> findByPluginIdAndApiKeyJson(
+            @Param("pluginId") String pluginId,
+            @Param("apiKeyJson") String apiKeyJson);
+
+    /**
+     * Finds an active account plugin by plugin ID and API key.
+     * Formats the API key as JSON and delegates to the native query.
+     */
+    @Override
+    default Optional<AccountPlugin> findByPluginIdAndApiKey(String pluginId, String apiKey) {
+        String apiKeyJson = String.format("{\"apiKey\": \"%s\"}", apiKey);
+        return findByPluginIdAndApiKeyJson(pluginId, apiKeyJson);
+    }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
@@ -1,0 +1,45 @@
+package com.bitbi.dfm.plugin.infrastructure.persistence;
+
+import com.bitbi.dfm.plugin.domain.PluginSqlGeneration;
+import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * JPA implementation of PluginSqlGenerationRepository.
+ */
+@Repository
+public interface JpaPluginSqlGenerationRepository extends JpaRepository<PluginSqlGeneration, UUID>, PluginSqlGenerationRepository {
+
+    /**
+     * Finds all SQL generations for a site created after a given timestamp.
+     * Orders by created_at ascending (oldest first) for chronological concatenation.
+     */
+    @Query("SELECT g FROM PluginSqlGeneration g WHERE g.siteId = :siteId AND g.createdAt > :since ORDER BY g.createdAt ASC")
+    List<PluginSqlGeneration> findBySiteIdAndCreatedAtAfter(
+        @Param("siteId") UUID siteId,
+        @Param("since") LocalDateTime since
+    );
+
+    /**
+     * Finds a SQL generation by source batch ID.
+     */
+    Optional<PluginSqlGeneration> findBySourceBatchId(UUID sourceBatchId);
+
+    /**
+     * Checks if a SQL generation exists for a given source batch.
+     */
+    boolean existsBySourceBatchId(UUID sourceBatchId);
+
+    /**
+     * Finds all SQL generations for a site.
+     */
+    List<PluginSqlGeneration> findBySiteId(UUID siteId);
+}

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java
@@ -128,6 +128,29 @@ public class S3SqlFileStorageService {
     }
 
     /**
+     * Deletes a SQL file from S3.
+     * Used to clean up orphaned files when database save fails.
+     *
+     * @param s3Key The S3 key to delete
+     */
+    public void deleteFile(String s3Key) {
+        log.debug("Deleting SQL file from S3: bucket={}, key={}", bucketName, s3Key);
+
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            s3Client.deleteObject(request);
+            log.info("Successfully deleted SQL file: key={}", s3Key);
+
+        } catch (S3Exception e) {
+            throw new SqlFileStorageException("Failed to delete SQL file from S3: " + s3Key, e);
+        }
+    }
+
+    /**
      * Generates S3 key for SQL file.
      * Format: plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
      */

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java
@@ -1,0 +1,168 @@
+package com.bitbi.dfm.plugin.infrastructure.storage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+/**
+ * S3 storage service for plugin-generated SQL files.
+ * Stores SQL files at path: plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
+ */
+@Service
+public class S3SqlFileStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(S3SqlFileStorageService.class);
+    private static final DateTimeFormatter PATH_DATETIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+
+    private final S3Client s3Client;
+    private final String bucketName;
+
+    public S3SqlFileStorageService(
+            S3Client s3Client,
+            @Value("${s3.bucket.name}") String bucketName) {
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+    }
+
+    /**
+     * Stores generated SQL content in S3.
+     *
+     * @param accountId The account ID
+     * @param siteName The site name (used in path)
+     * @param sqlContent The SQL content to store
+     * @return The S3 key where the file was stored
+     */
+    public String storeSqlFile(UUID accountId, String siteName, String sqlContent) {
+        String s3Key = generateS3Key(accountId, siteName);
+        byte[] contentBytes = sqlContent.getBytes(StandardCharsets.UTF_8);
+
+        log.debug("Storing SQL file to S3: bucket={}, key={}, size={}",
+                bucketName, s3Key, contentBytes.length);
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .contentType("text/plain; charset=utf-8")
+                    .contentLength((long) contentBytes.length)
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromBytes(contentBytes));
+
+            log.info("Successfully stored SQL file: key={}, size={}", s3Key, contentBytes.length);
+            return s3Key;
+
+        } catch (S3Exception e) {
+            throw new SqlFileStorageException("Failed to store SQL file in S3: " + s3Key, e);
+        }
+    }
+
+    /**
+     * Retrieves SQL content from S3.
+     *
+     * @param s3Key The S3 key of the SQL file
+     * @return The SQL content as a string
+     */
+    public String getSqlFileContent(String s3Key) {
+        log.debug("Retrieving SQL file from S3: bucket={}, key={}", bucketName, s3Key);
+
+        try {
+            GetObjectRequest request = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            try (ResponseInputStream<GetObjectResponse> response = s3Client.getObject(request)) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                byte[] buffer = new byte[8192];
+                int bytesRead;
+                while ((bytesRead = response.read(buffer)) != -1) {
+                    baos.write(buffer, 0, bytesRead);
+                }
+                return baos.toString(StandardCharsets.UTF_8);
+            }
+
+        } catch (NoSuchKeyException e) {
+            throw new SqlFileNotFoundException("SQL file not found: " + s3Key, e);
+        } catch (S3Exception e) {
+            throw new SqlFileStorageException("Failed to retrieve SQL file from S3: " + s3Key, e);
+        } catch (IOException e) {
+            throw new SqlFileStorageException("Failed to read SQL file content: " + s3Key, e);
+        }
+    }
+
+    /**
+     * Gets the file size in bytes for an S3 object.
+     *
+     * @param s3Key The S3 key
+     * @return File size in bytes
+     */
+    public long getFileSize(String s3Key) {
+        try {
+            HeadObjectRequest request = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Key)
+                    .build();
+
+            HeadObjectResponse response = s3Client.headObject(request);
+            return response.contentLength();
+
+        } catch (NoSuchKeyException e) {
+            throw new SqlFileNotFoundException("SQL file not found: " + s3Key, e);
+        } catch (S3Exception e) {
+            throw new SqlFileStorageException("Failed to get SQL file metadata: " + s3Key, e);
+        }
+    }
+
+    /**
+     * Generates S3 key for SQL file.
+     * Format: plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
+     */
+    private String generateS3Key(UUID accountId, String siteName) {
+        String datetime = LocalDateTime.now().format(PATH_DATETIME_FORMATTER);
+        return String.format("plugins/bit-bi/%s/%s/%s.sql",
+                accountId, sanitizeSiteName(siteName), datetime);
+    }
+
+    /**
+     * Sanitizes site name for use in S3 key.
+     * Replaces problematic characters with hyphens.
+     */
+    private String sanitizeSiteName(String siteName) {
+        if (siteName == null || siteName.isEmpty()) {
+            return "unknown-site";
+        }
+        return siteName.replaceAll("[^a-zA-Z0-9.-]", "-").toLowerCase();
+    }
+
+    /**
+     * Exception thrown when SQL file storage operations fail.
+     */
+    public static class SqlFileStorageException extends RuntimeException {
+        public SqlFileStorageException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    /**
+     * Exception thrown when SQL file is not found.
+     */
+    public static class SqlFileNotFoundException extends RuntimeException {
+        public SqlFileNotFoundException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
@@ -1,0 +1,173 @@
+package com.bitbi.dfm.plugin.presentation;
+
+import com.bitbi.dfm.plugin.application.SqlChangesQueryService;
+import com.bitbi.dfm.plugin.presentation.dto.SiteDto;
+import com.bitbi.dfm.plugin.presentation.dto.SiteListResponseDto;
+import com.bitbi.dfm.shared.api.ApiRoutes;
+import com.bitbi.dfm.site.domain.Site;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * REST controller for the Bit BI Plugin API.
+ *
+ * <p>This API provides endpoints for Bit BI to retrieve SQL changes generated
+ * from batch upload comparisons. Authentication is via Plugin API Key in the
+ * X-Plugin-Api-Key header.</p>
+ *
+ * <p>Endpoints:
+ * <ul>
+ *   <li>GET /sql-changes - Retrieve SQL changes for a site since a given date</li>
+ *   <li>GET /sites - List available sites for the account</li>
+ * </ul>
+ *
+ * @see PluginApiKeyAuthenticationFilter
+ * @see SqlChangesQueryService
+ */
+@RestController
+@RequestMapping(ApiRoutes.BITBI_PLUGIN_API)
+@Tag(name = "Bit BI Plugin API", description = "Plugin API for Bit BI integration")
+@SecurityRequirement(name = "PluginApiKey")
+public class BitBiPluginApiController {
+
+    private static final Logger log = LoggerFactory.getLogger(BitBiPluginApiController.class);
+
+    private final SqlChangesQueryService sqlChangesQueryService;
+
+    public BitBiPluginApiController(SqlChangesQueryService sqlChangesQueryService) {
+        this.sqlChangesQueryService = sqlChangesQueryService;
+    }
+
+    /**
+     * Retrieves SQL changes for a site since a given date.
+     *
+     * <p>Returns concatenated SQL statements (INSERT, UPDATE, DELETE) generated
+     * from batch comparisons for the specified site after the given timestamp.</p>
+     *
+     * @param siteId the UUID of the site to retrieve changes for
+     * @param since ISO8601 timestamp to retrieve changes after
+     * @param authentication the Plugin API Key authentication context
+     * @return SQL statements as plain text, or empty body if no changes
+     */
+    @GetMapping(value = "/sql-changes", produces = MediaType.TEXT_PLAIN_VALUE)
+    @Operation(
+        summary = "Retrieve SQL changes for a site",
+        description = "Returns all SQL changes (INSERT, UPDATE, DELETE statements) for a specific site after a given date"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "SQL changes retrieved successfully"),
+        @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
+        @ApiResponse(responseCode = "401", description = "Invalid or missing API key"),
+        @ApiResponse(responseCode = "403", description = "Site does not belong to account")
+    })
+    public ResponseEntity<String> getSqlChanges(
+            @Parameter(description = "UUID of the site to retrieve changes for", required = true)
+            @RequestParam UUID siteId,
+            @Parameter(description = "ISO8601 timestamp. Returns changes after this date.", required = true)
+            @RequestParam String since,
+            Authentication authentication) {
+
+        UUID accountId = extractAccountId(authentication);
+
+        // Set MDC context for structured logging
+        MDC.put("accountId", accountId.toString());
+        MDC.put("siteId", siteId.toString());
+
+        try {
+            log.debug("Getting SQL changes for siteId={}, since={}, accountId={}", siteId, since, accountId);
+
+            // Parse the since timestamp
+            Instant sinceInstant;
+            try {
+                sinceInstant = Instant.parse(since);
+            } catch (DateTimeParseException e) {
+                log.warn("Invalid date format for 'since' parameter: {}", since);
+                throw new IllegalArgumentException("Invalid date format for 'since' parameter. Expected ISO8601 format (e.g., 2025-01-01T00:00:00Z)");
+            }
+
+            String sqlContent = sqlChangesQueryService.getSqlChanges(accountId, siteId, sinceInstant);
+            return ResponseEntity.ok(sqlContent);
+
+        } catch (SecurityException e) {
+            log.warn("Site access denied: siteId={}, accountId={}, message={}", siteId, accountId, e.getMessage());
+            throw e;
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    /**
+     * Lists all available sites for the account.
+     *
+     * <p>Returns all active sites belonging to the account associated with
+     * the API key.</p>
+     *
+     * @param authentication the Plugin API Key authentication context
+     * @return list of sites with their IDs, domains, and display names
+     */
+    @GetMapping(value = "/sites", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+        summary = "List available sites",
+        description = "Returns a list of all sites belonging to the account associated with the API key"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Sites retrieved successfully",
+            content = @Content(schema = @Schema(implementation = SiteListResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "401", description = "Invalid or missing API key")
+    })
+    public ResponseEntity<SiteListResponseDto> listSites(Authentication authentication) {
+
+        UUID accountId = extractAccountId(authentication);
+
+        // Set MDC context for structured logging
+        MDC.put("accountId", accountId.toString());
+
+        try {
+            log.debug("Listing sites for accountId={}", accountId);
+
+            List<Site> sites = sqlChangesQueryService.listSites(accountId);
+
+            List<SiteDto> siteDtos = sites.stream()
+                    .map(site -> new SiteDto(
+                            site.getId(),
+                            site.getDomain(),
+                            site.getDisplayName()))
+                    .toList();
+
+            return ResponseEntity.ok(new SiteListResponseDto(siteDtos));
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    /**
+     * Extracts the account ID from the authentication context.
+     */
+    private UUID extractAccountId(Authentication authentication) {
+        if (authentication instanceof PluginApiKeyAuthenticationFilter.PluginApiKeyAuthenticationToken token) {
+            return token.getAccountId();
+        }
+        throw new IllegalStateException("Expected PluginApiKeyAuthenticationToken but got: " + authentication.getClass().getName());
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
@@ -1,5 +1,6 @@
 package com.bitbi.dfm.plugin.presentation;
 
+import com.bitbi.dfm.plugin.application.PluginRateLimiterService;
 import com.bitbi.dfm.plugin.application.SqlChangesQueryService;
 import com.bitbi.dfm.plugin.presentation.dto.SiteDto;
 import com.bitbi.dfm.plugin.presentation.dto.SiteListResponseDto;
@@ -16,6 +17,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -51,9 +54,13 @@ public class BitBiPluginApiController {
     private static final Logger log = LoggerFactory.getLogger(BitBiPluginApiController.class);
 
     private final SqlChangesQueryService sqlChangesQueryService;
+    private final PluginRateLimiterService rateLimiterService;
 
-    public BitBiPluginApiController(SqlChangesQueryService sqlChangesQueryService) {
+    public BitBiPluginApiController(
+            SqlChangesQueryService sqlChangesQueryService,
+            PluginRateLimiterService rateLimiterService) {
         this.sqlChangesQueryService = sqlChangesQueryService;
+        this.rateLimiterService = rateLimiterService;
     }
 
     /**
@@ -76,7 +83,8 @@ public class BitBiPluginApiController {
         @ApiResponse(responseCode = "200", description = "SQL changes retrieved successfully"),
         @ApiResponse(responseCode = "400", description = "Invalid request parameters"),
         @ApiResponse(responseCode = "401", description = "Invalid or missing API key"),
-        @ApiResponse(responseCode = "403", description = "Site does not belong to account")
+        @ApiResponse(responseCode = "403", description = "Site does not belong to account"),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
     })
     public ResponseEntity<String> getSqlChanges(
             @Parameter(description = "UUID of the site to retrieve changes for", required = true)
@@ -86,6 +94,14 @@ public class BitBiPluginApiController {
             Authentication authentication) {
 
         UUID accountId = extractAccountId(authentication);
+
+        // Check rate limit
+        if (!rateLimiterService.tryConsume(accountId)) {
+            long retryAfter = rateLimiterService.getRetryAfterSeconds(accountId);
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .header(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter))
+                    .body("Rate limit exceeded. Please retry after " + retryAfter + " seconds.");
+        }
 
         // Set MDC context for structured logging
         MDC.put("accountId", accountId.toString());
@@ -134,11 +150,20 @@ public class BitBiPluginApiController {
             description = "Sites retrieved successfully",
             content = @Content(schema = @Schema(implementation = SiteListResponseDto.class))
         ),
-        @ApiResponse(responseCode = "401", description = "Invalid or missing API key")
+        @ApiResponse(responseCode = "401", description = "Invalid or missing API key"),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
     })
     public ResponseEntity<SiteListResponseDto> listSites(Authentication authentication) {
 
         UUID accountId = extractAccountId(authentication);
+
+        // Check rate limit
+        if (!rateLimiterService.tryConsume(accountId)) {
+            long retryAfter = rateLimiterService.getRetryAfterSeconds(accountId);
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .header(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter))
+                    .build();
+        }
 
         // Set MDC context for structured logging
         MDC.put("accountId", accountId.toString());

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java
@@ -1,0 +1,154 @@
+package com.bitbi.dfm.plugin.presentation;
+
+import com.bitbi.dfm.plugin.application.PluginApiKeyService;
+import com.bitbi.dfm.plugin.domain.AccountPlugin;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Authentication filter for Plugin API Key authentication.
+ *
+ * <p>This filter processes requests to the Bit BI Plugin API (/api/v1/plugins/bit-bi/**)
+ * and validates the API key provided in the X-Plugin-Api-Key header.</p>
+ *
+ * <p>If the API key is valid, it sets the security context with a PluginApiKeyAuthenticationToken
+ * containing the account ID associated with the API key.</p>
+ *
+ * @see PluginApiKeyService
+ */
+@Component
+public class PluginApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(PluginApiKeyAuthenticationFilter.class);
+    private static final String API_KEY_HEADER = "X-Plugin-Api-Key";
+    private static final String PLUGIN_API_PATH = "/api/v1/plugins/bit-bi";
+
+    private final PluginApiKeyService pluginApiKeyService;
+    private final ObjectMapper objectMapper;
+
+    public PluginApiKeyAuthenticationFilter(
+            PluginApiKeyService pluginApiKeyService,
+            ObjectMapper objectMapper) {
+        this.pluginApiKeyService = pluginApiKeyService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return !path.startsWith(PLUGIN_API_PATH);
+    }
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String path = request.getRequestURI();
+
+        // Extract API key from header
+        String apiKey = request.getHeader(API_KEY_HEADER);
+        if (apiKey == null || apiKey.isBlank()) {
+            log.debug("No API key found in request to {}", path);
+            writeUnauthorizedResponse(response, path);
+            return;
+        }
+
+        try {
+            // Validate API key
+            Optional<AccountPlugin> accountPluginOpt = pluginApiKeyService.validateApiKey(apiKey);
+
+            if (accountPluginOpt.isEmpty()) {
+                log.warn("Invalid API key used for path {}", path);
+                writeUnauthorizedResponse(response, path);
+                return;
+            }
+
+            AccountPlugin accountPlugin = accountPluginOpt.get();
+
+            // Create authentication token
+            PluginApiKeyAuthenticationToken authentication = new PluginApiKeyAuthenticationToken(
+                    accountPlugin.getAccountId(),
+                    accountPlugin.getId(),
+                    Collections.singletonList(new SimpleGrantedAuthority("ROLE_PLUGIN_CLIENT"))
+            );
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            // Set authentication in security context
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            log.debug("Plugin API key authentication successful: accountId={}, accountPluginId={}",
+                    accountPlugin.getAccountId(), accountPlugin.getId());
+
+            filterChain.doFilter(request, response);
+
+        } catch (Exception e) {
+            log.error("Error during Plugin API key authentication: {}", e.getMessage(), e);
+            writeUnauthorizedResponse(response, path);
+        }
+    }
+
+    private void writeUnauthorizedResponse(HttpServletResponse response, String path) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        Map<String, Object> errorBody = Map.of(
+                "timestamp", Instant.now().toString(),
+                "status", 401,
+                "error", "Unauthorized",
+                "message", "Invalid or missing API key",
+                "path", path
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorBody));
+    }
+
+    /**
+     * Authentication token for Plugin API Key authenticated requests.
+     *
+     * <p>Stores accountId and accountPluginId for authorization checks.</p>
+     */
+    public static class PluginApiKeyAuthenticationToken extends UsernamePasswordAuthenticationToken {
+        private final UUID accountId;
+        private final Long accountPluginId;
+
+        public PluginApiKeyAuthenticationToken(
+                UUID accountId,
+                Long accountPluginId,
+                java.util.List<SimpleGrantedAuthority> authorities) {
+            super(accountId, null, authorities);
+            this.accountId = accountId;
+            this.accountPluginId = accountPluginId;
+        }
+
+        public UUID getAccountId() {
+            return accountId;
+        }
+
+        public Long getAccountPluginId() {
+            return accountPluginId;
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java
@@ -42,7 +42,16 @@ public class PluginApiKeyAuthenticationFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(PluginApiKeyAuthenticationFilter.class);
     private static final String API_KEY_HEADER = "X-Plugin-Api-Key";
-    private static final String PLUGIN_API_PATH = "/api/v1/plugins/bit-bi";
+
+    /**
+     * Paths that require Plugin API Key authentication.
+     * These are the Bit BI Plugin API endpoints consumed by external clients.
+     * Note: /api/v1/plugins/bit-bi/activate and /deactivate use OAuth2 instead.
+     */
+    private static final String[] PLUGIN_API_PATHS = {
+        "/api/v1/plugins/bit-bi/sql-changes",
+        "/api/v1/plugins/bit-bi/sites"
+    };
 
     private final PluginApiKeyService pluginApiKeyService;
     private final ObjectMapper objectMapper;
@@ -57,7 +66,13 @@ public class PluginApiKeyAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return !path.startsWith(PLUGIN_API_PATH);
+        // Only apply this filter to specific Bit BI Plugin API endpoints
+        for (String pluginApiPath : PLUGIN_API_PATHS) {
+            if (path.equals(pluginApiPath) || path.startsWith(pluginApiPath + "/") || path.startsWith(pluginApiPath + "?")) {
+                return false; // Do filter (apply authentication)
+            }
+        }
+        return true; // Skip filter for all other paths
     }
 
     @Override

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteDto.java
@@ -1,0 +1,31 @@
+package com.bitbi.dfm.plugin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+/**
+ * DTO representing a site in the Plugin API response.
+ *
+ * @param id Unique site identifier
+ * @param domain Site domain name
+ * @param displayName Human-readable site name
+ */
+@Schema(description = "Site information")
+public record SiteDto(
+    @Schema(description = "Unique site identifier", example = "550e8400-e29b-41d4-a716-446655440000")
+    UUID id,
+
+    @Schema(description = "Site domain name", example = "example.com")
+    String domain,
+
+    @Schema(description = "Human-readable site name", example = "Example Site")
+    String displayName
+) {
+    /**
+     * Creates a SiteDto from individual values.
+     */
+    public static SiteDto of(UUID id, String domain, String displayName) {
+        return new SiteDto(id, domain, displayName);
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteListResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteListResponseDto.java
@@ -1,0 +1,44 @@
+package com.bitbi.dfm.plugin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Response DTO for listing sites in the Plugin API.
+ *
+ * @param sites List of sites belonging to the account
+ */
+@Schema(description = "List of sites response")
+public record SiteListResponseDto(
+    @Schema(description = "List of sites belonging to the account")
+    List<SiteDto> sites
+) {
+    /**
+     * Creates a response with the given sites.
+     */
+    public static SiteListResponseDto of(List<SiteDto> sites) {
+        return new SiteListResponseDto(sites != null ? List.copyOf(sites) : List.of());
+    }
+
+    /**
+     * Creates an empty response (no sites).
+     */
+    public static SiteListResponseDto empty() {
+        return new SiteListResponseDto(List.of());
+    }
+
+    /**
+     * Returns true if there are no sites.
+     */
+    public boolean isEmpty() {
+        return sites == null || sites.isEmpty();
+    }
+
+    /**
+     * Returns the number of sites.
+     */
+    public int size() {
+        return sites != null ? sites.size() : 0;
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SqlChangesResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SqlChangesResponseDto.java
@@ -1,0 +1,42 @@
+package com.bitbi.dfm.plugin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Response DTO for SQL changes endpoint.
+ * Note: The actual response is plain text (text/plain), but this DTO
+ * documents the expected response format.
+ *
+ * @param sqlContent Concatenated SQL statements from all matching files
+ */
+@Schema(description = "SQL changes response (returned as text/plain)")
+public record SqlChangesResponseDto(
+    @Schema(description = "Concatenated SQL statements", example = """
+        INSERT INTO customers (id, name) VALUES ('1', 'John');
+        --- END OF COMMAND "customers.csv:2" ---
+        UPDATE orders SET status = 'shipped' WHERE id = '42';
+        --- END OF COMMAND "orders.csv:15" ---
+        """)
+    String sqlContent
+) {
+    /**
+     * Creates an empty response (no changes found).
+     */
+    public static SqlChangesResponseDto empty() {
+        return new SqlChangesResponseDto("");
+    }
+
+    /**
+     * Creates a response from SQL content.
+     */
+    public static SqlChangesResponseDto of(String content) {
+        return new SqlChangesResponseDto(content != null ? content : "");
+    }
+
+    /**
+     * Returns true if there are no SQL changes.
+     */
+    public boolean isEmpty() {
+        return sqlContent == null || sqlContent.isEmpty();
+    }
+}

--- a/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
+++ b/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
@@ -616,6 +616,40 @@ public final class ApiRoutes {
      */
     public static final String PLUGINS_ADMIN_AUDIT = PLUGINS_ADMIN + "/audit";
 
+    // ==================== Bit BI Plugin API ====================
+
+    /**
+     * Base path for Bit BI Plugin API endpoints.
+     * <p>
+     * This API uses Plugin API Key authentication via X-Plugin-Api-Key header.
+     * These endpoints are consumed by Bit BI to retrieve SQL changes.
+     * </p>
+     */
+    public static final String BITBI_PLUGIN_API = ADMIN_API_BASE + "/plugins/bit-bi";
+
+    /**
+     * Get SQL changes for a site endpoint.
+     * <p>
+     * Method: GET<br>
+     * Authentication: Plugin API Key (X-Plugin-Api-Key header)<br>
+     * Query Params: siteId (UUID, required), since (ISO8601 timestamp, required)<br>
+     * Content-Type: text/plain<br>
+     * Returns: Concatenated SQL statements or empty body
+     * </p>
+     */
+    public static final String BITBI_SQL_CHANGES = BITBI_PLUGIN_API + "/sql-changes";
+
+    /**
+     * List sites for account endpoint.
+     * <p>
+     * Method: GET<br>
+     * Authentication: Plugin API Key (X-Plugin-Api-Key header)<br>
+     * Content-Type: application/json<br>
+     * Returns: SiteListResponseDto
+     * </p>
+     */
+    public static final String BITBI_SITES = BITBI_PLUGIN_API + "/sites";
+
     // Private constructor to prevent instantiation
     private ApiRoutes() {
         throw new UnsupportedOperationException("Utility class - do not instantiate");

--- a/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
+++ b/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
@@ -2,6 +2,7 @@ package com.bitbi.dfm.shared.config;
 
 import com.bitbi.dfm.auth.config.Auth0Properties;
 import com.bitbi.dfm.auth.infrastructure.JwtAuthenticationFilter;
+import com.bitbi.dfm.plugin.presentation.PluginApiKeyAuthenticationFilter;
 import com.bitbi.dfm.shared.auth.AuthenticationAuditLogger;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -64,14 +65,17 @@ import java.util.stream.Collectors;
 public class SecurityConfiguration {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final PluginApiKeyAuthenticationFilter pluginApiKeyAuthenticationFilter;
     private final AuthenticationAuditLogger authenticationAuditLogger;
     private final Auth0Properties auth0Properties;
 
     public SecurityConfiguration(
             JwtAuthenticationFilter jwtAuthenticationFilter,
+            PluginApiKeyAuthenticationFilter pluginApiKeyAuthenticationFilter,
             AuthenticationAuditLogger authenticationAuditLogger,
             Auth0Properties auth0Properties) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.pluginApiKeyAuthenticationFilter = pluginApiKeyAuthenticationFilter;
         this.authenticationAuditLogger = authenticationAuditLogger;
         this.auth0Properties = auth0Properties;
     }
@@ -149,10 +153,47 @@ public class SecurityConfiguration {
     }
 
     /**
+     * Bit BI Plugin API filter chain.
+     * <p>
+     * <b>Order 3</b>: Third priority - evaluated AFTER legacy JWT filter chain<br>
+     * <b>Matches</b>: /api/v1/plugins/bit-bi/**<br>
+     * <b>Authentication</b>: Plugin API Key (X-Plugin-Api-Key header)
+     * </p>
+     * <p>
+     * This filter chain handles the Bit BI Plugin API endpoints which use
+     * a custom API Key authentication mechanism instead of OAuth2 or JWT.
+     * API Keys are generated during plugin activation and stored in account_plugins.plugin_data.
+     * </p>
+     *
+     * @since 5.0.0 (Plugin SQL Generation)
+     * @see PluginApiKeyAuthenticationFilter
+     */
+    @Bean
+    @Order(3)
+    public SecurityFilterChain bitBiPluginApiFilterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/api/v1/plugins/bit-bi/**")
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(pluginApiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((request, response, authException) -> {
+                    authenticationAuditLogger.onAuthenticationFailure(request, response, authException);
+                    response.sendError(401, "Unauthorized - Plugin API Key authentication required");
+                })
+            );
+
+        return http.build();
+    }
+
+    /**
      * UI/Admin API filter chain (NEW unified structure).
      * <p>
-     * <b>Order 3</b>: Third priority - evaluated AFTER Device API filter chain<br>
-     * <b>Matches</b>: /api/v1/** (excluding /api/v1/device/**)<br>
+     * <b>Order 4</b>: Fourth priority - evaluated AFTER Bit BI Plugin API filter chain<br>
+     * <b>Matches</b>: /api/v1/** (excluding /api/v1/device/** and /api/v1/plugins/bit-bi/**)<br>
      * <b>Authentication</b>: Keycloak OAuth2 Resource Server only
      * </p>
      * <p>
@@ -174,7 +215,7 @@ public class SecurityConfiguration {
      * @since 4.0.0 (API Unification)
      */
     @Bean
-    @Order(3)
+    @Order(4)
     public SecurityFilterChain adminApiFilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/v1/**")
@@ -182,6 +223,7 @@ public class SecurityConfiguration {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/**").denyAll() // Explicitly deny (already handled by Order 1)
+                .requestMatchers("/api/v1/plugins/bit-bi/**").denyAll() // Explicitly deny (already handled by Order 3)
                 .requestMatchers("/api/v1/accounts/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/sites/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/batches/**").hasRole("ADMIN")
@@ -218,10 +260,10 @@ public class SecurityConfiguration {
      * migration period. Will return 410 Gone after migration via DeprecatedEndpointFilter.
      * </p>
      *
-     * @deprecated Use {@link #adminApiFilterChain(HttpSecurity)} instead (Order 3)
+     * @deprecated Use {@link #adminApiFilterChain(HttpSecurity)} instead (Order 4)
      */
     @Bean
-    @Order(4)
+    @Order(5)
     @Deprecated(since = "4.0.0", forRemoval = true)
     public SecurityFilterChain legacyKeycloakFilterChain(HttpSecurity http) throws Exception {
         http
@@ -247,7 +289,7 @@ public class SecurityConfiguration {
     /**
      * Legacy user filter chain for authenticated user endpoints.
      * <p>
-     * <b>Order 5</b>: Fifth priority<br>
+     * <b>Order 6</b>: Sixth priority<br>
      * <b>Matches</b>: /api/sites/**, /api/account/**, /api/user/**<br>
      * <b>Authentication</b>: Keycloak OAuth2 Resource Server (any authenticated user)
      * </p>
@@ -260,7 +302,7 @@ public class SecurityConfiguration {
      * @deprecated Legacy paths - user endpoints migrated to /api/v1/history/**
      */
     @Bean
-    @Order(5)
+    @Order(6)
     @Deprecated(since = "4.0.0", forRemoval = true)
     public SecurityFilterChain legacyUserFilterChain(HttpSecurity http) throws Exception {
         http
@@ -286,7 +328,7 @@ public class SecurityConfiguration {
     /**
      * Default filter chain for public and remaining endpoints.
      * <p>
-     * <b>Order 6</b>: Lowest priority (catches all remaining requests)<br>
+     * <b>Order 7</b>: Lowest priority (catches all remaining requests)<br>
      * <b>Public access</b>:
      * </p>
      * <ul>
@@ -300,7 +342,7 @@ public class SecurityConfiguration {
      * </p>
      */
     @Bean
-    @Order(6)
+    @Order(7)
     public SecurityFilterChain defaultFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())

--- a/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
+++ b/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
@@ -156,13 +156,18 @@ public class SecurityConfiguration {
      * Bit BI Plugin API filter chain.
      * <p>
      * <b>Order 3</b>: Third priority - evaluated AFTER legacy JWT filter chain<br>
-     * <b>Matches</b>: /api/v1/plugins/bit-bi/**<br>
+     * <b>Matches</b>: /api/v1/plugins/bit-bi/sql-changes, /api/v1/plugins/bit-bi/sites<br>
      * <b>Authentication</b>: Plugin API Key (X-Plugin-Api-Key header)
      * </p>
      * <p>
      * This filter chain handles the Bit BI Plugin API endpoints which use
      * a custom API Key authentication mechanism instead of OAuth2 or JWT.
      * API Keys are generated during plugin activation and stored in account_plugins.plugin_data.
+     * </p>
+     * <p>
+     * <b>IMPORTANT:</b> Only specific Bit BI API endpoints use Plugin API Key auth.
+     * The /api/v1/plugins/bit-bi/activate and /api/v1/plugins/bit-bi/deactivate
+     * endpoints use OAuth2 (handled by Order 4 filter chain).
      * </p>
      *
      * @since 5.0.0 (Plugin SQL Generation)
@@ -172,7 +177,7 @@ public class SecurityConfiguration {
     @Order(3)
     public SecurityFilterChain bitBiPluginApiFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/api/v1/plugins/bit-bi/**")
+            .securityMatcher("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites")
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -223,7 +228,7 @@ public class SecurityConfiguration {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/**").denyAll() // Explicitly deny (already handled by Order 1)
-                .requestMatchers("/api/v1/plugins/bit-bi/**").denyAll() // Explicitly deny (already handled by Order 3)
+                .requestMatchers("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites").denyAll() // Explicitly deny (already handled by Order 3)
                 .requestMatchers("/api/v1/accounts/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/sites/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/batches/**").hasRole("ADMIN")

--- a/src/main/java/com/bitbi/dfm/shared/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bitbi/dfm/shared/exception/GlobalExceptionHandler.java
@@ -16,8 +16,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -129,6 +131,58 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handle MissingServletRequestParameterException (400 Bad Request).
+     * <p>
+     * This handler is triggered when a required @RequestParam is missing.
+     * </p>
+     */
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponseDto> handleMissingServletRequestParameter(
+            MissingServletRequestParameterException ex,
+            HttpServletRequest request) {
+
+        String errorMessage = String.format("Required parameter '%s' is missing", ex.getParameterName());
+        logger.warn("Missing request parameter: {}", errorMessage);
+
+        ErrorResponseDto error = new ErrorResponseDto(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
+     * Handle MethodArgumentTypeMismatchException (400 Bad Request).
+     * <p>
+     * This handler is triggered when a @RequestParam or @PathVariable value
+     * cannot be converted to the expected type (e.g., invalid UUID format).
+     * </p>
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentTypeMismatch(
+            MethodArgumentTypeMismatchException ex,
+            HttpServletRequest request) {
+
+        String errorMessage = String.format("Invalid value for parameter '%s': %s",
+                ex.getName(), ex.getValue());
+        logger.warn("Type mismatch for parameter: {}", errorMessage);
+
+        ErrorResponseDto error = new ErrorResponseDto(
+                Instant.now(),
+                HttpStatus.BAD_REQUEST.value(),
+                "Bad Request",
+                errorMessage,
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
+    }
+
+    /**
      * Handle AccessDeniedException (403 Forbidden).
      */
     @ExceptionHandler(AccessDeniedException.class)
@@ -137,6 +191,31 @@ public class GlobalExceptionHandler {
             HttpServletRequest request) {
 
         logger.warn("Access denied: {}", ex.getMessage());
+
+        ErrorResponseDto error = new ErrorResponseDto(
+                Instant.now(),
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                ex.getMessage(),
+                request.getRequestURI()
+        );
+
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(error);
+    }
+
+    /**
+     * Handle SecurityException (403 Forbidden).
+     * <p>
+     * Thrown when a resource access is denied due to ownership/authorization issues.
+     * Used by Plugin API when a site doesn't belong to the authenticated account.
+     * </p>
+     */
+    @ExceptionHandler(SecurityException.class)
+    public ResponseEntity<ErrorResponseDto> handleSecurityException(
+            SecurityException ex,
+            HttpServletRequest request) {
+
+        logger.warn("Security exception: {}", ex.getMessage());
 
         ErrorResponseDto error = new ErrorResponseDto(
                 Instant.now(),

--- a/src/main/resources/db/migration/U10__revert_bitbi_client_id.sql
+++ b/src/main/resources/db/migration/U10__revert_bitbi_client_id.sql
@@ -1,0 +1,8 @@
+-- U10__revert_bitbi_client_id.sql
+-- Undo migration for V10__update_bitbi_plugin_client_id.sql
+-- Reverts Bit BI plugin client_id to placeholder value
+
+UPDATE plugin_configs
+SET client_id = 'BITBI_CLIENT_ID_PLACEHOLDER',
+    updated_at = NOW()
+WHERE plugin_id = 'bit-bi';

--- a/src/main/resources/db/migration/U11__drop_plugin_sql_generations_table.sql
+++ b/src/main/resources/db/migration/U11__drop_plugin_sql_generations_table.sql
@@ -1,0 +1,10 @@
+-- U11__drop_plugin_sql_generations_table.sql
+-- Undo migration for V11__create_plugin_sql_generations_table.sql
+-- WARNING: This will delete all plugin SQL generation data!
+
+-- Drop indexes first
+DROP INDEX IF EXISTS idx_sql_gen_site_created;
+DROP INDEX IF EXISTS idx_sql_gen_account_plugin;
+
+-- Drop the table (CASCADE will handle dependent constraints)
+DROP TABLE IF EXISTS plugin_sql_generations CASCADE;

--- a/src/main/resources/db/migration/U8__drop_plugin_tables.sql
+++ b/src/main/resources/db/migration/U8__drop_plugin_tables.sql
@@ -1,0 +1,11 @@
+-- U8__drop_plugin_tables.sql
+-- Undo migration for V8__create_plugin_tables.sql
+-- WARNING: This will delete all plugin configuration and activation data!
+
+-- Note: Must run U11, U10, U9 first if those migrations were applied
+
+-- Drop account_plugins first (has foreign key to plugin_configs)
+DROP TABLE IF EXISTS account_plugins CASCADE;
+
+-- Drop plugin_configs
+DROP TABLE IF EXISTS plugin_configs CASCADE;

--- a/src/main/resources/db/migration/U9__drop_plugin_audit_logs.sql
+++ b/src/main/resources/db/migration/U9__drop_plugin_audit_logs.sql
@@ -1,0 +1,9 @@
+-- U9__drop_plugin_audit_logs.sql
+-- Undo migration for V9__create_plugin_audit_logs_partitioned.sql
+-- WARNING: This will delete all plugin audit log data!
+
+-- Drop the partition creation function
+DROP FUNCTION IF EXISTS create_plugin_audit_logs_partition(DATE);
+
+-- Drop the partitioned table (automatically drops all partitions)
+DROP TABLE IF EXISTS plugin_audit_logs CASCADE;

--- a/src/main/resources/db/migration/V11__create_plugin_sql_generations_table.sql
+++ b/src/main/resources/db/migration/V11__create_plugin_sql_generations_table.sql
@@ -1,0 +1,54 @@
+-- V11__create_plugin_sql_generations_table.sql
+-- Plugin SQL Generation Extension - Tracks SQL file generation events for Bit BI plugin
+
+CREATE TABLE plugin_sql_generations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Foreign keys
+    account_plugin_id BIGINT NOT NULL,
+    site_id UUID NOT NULL,
+    source_batch_id UUID NOT NULL,
+    comparison_batch_id UUID,  -- NULL for first batch
+
+    -- S3 storage
+    s3_key VARCHAR(1000) NOT NULL,
+    file_size_bytes BIGINT NOT NULL,
+
+    -- Statistics
+    statement_count INTEGER NOT NULL DEFAULT 0,
+    insert_count INTEGER NOT NULL DEFAULT 0,
+    update_count INTEGER NOT NULL DEFAULT 0,
+    delete_count INTEGER NOT NULL DEFAULT 0,
+    files_processed INTEGER NOT NULL DEFAULT 0,
+
+    -- Performance tracking
+    generation_duration_ms BIGINT NOT NULL DEFAULT 0,
+
+    -- Timestamps
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT fk_sql_gen_account_plugin
+        FOREIGN KEY (account_plugin_id)
+        REFERENCES account_plugins(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sql_gen_site
+        FOREIGN KEY (site_id)
+        REFERENCES sites(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sql_gen_source_batch
+        FOREIGN KEY (source_batch_id)
+        REFERENCES batches(id) ON DELETE CASCADE,
+    CONSTRAINT fk_sql_gen_comparison_batch
+        FOREIGN KEY (comparison_batch_id)
+        REFERENCES batches(id) ON DELETE SET NULL,
+
+    -- Ensure unique generation per source batch
+    CONSTRAINT uk_sql_gen_source_batch UNIQUE (source_batch_id)
+);
+
+-- Indexes for common queries
+CREATE INDEX idx_sql_gen_site_created ON plugin_sql_generations(site_id, created_at DESC);
+CREATE INDEX idx_sql_gen_account_plugin ON plugin_sql_generations(account_plugin_id);
+
+COMMENT ON TABLE plugin_sql_generations IS 'Tracks SQL file generation events for Bit BI plugin';
+COMMENT ON COLUMN plugin_sql_generations.comparison_batch_id IS 'NULL for first batch (all INSERTs)';
+COMMENT ON COLUMN plugin_sql_generations.s3_key IS 'Full S3 key path: plugins/bit-bi/{accountId}/{siteName}/{timestamp}.sql';

--- a/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
+++ b/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import com.bitbi.dfm.plugin.presentation.PluginApiKeyAuthenticationFilter;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -73,6 +74,9 @@ public class TestSecurityConfig {
 
     @Autowired(required = false)
     private TokenService tokenService;
+
+    @Autowired(required = false)
+    private PluginApiKeyAuthenticationFilter pluginApiKeyAuthenticationFilter;
 
     /**
      * Mock Auth0 ManagementAPI bean for tests.
@@ -269,14 +273,41 @@ public class TestSecurityConfig {
     }
 
     /**
-     * UI/Admin API filter chain (NEW unified structure).
+     * Bit BI Plugin API filter chain.
      * <p>
-     * Order 3: Third priority - matches /api/v1/** (excluding /api/v1/device/**).
-     * Auth0 OAuth2 Resource Server only.
+     * Order 3: Third priority - matches /api/v1/plugins/bit-bi/**.
+     * Plugin API Key authentication via PluginApiKeyAuthenticationFilter.
      * </p>
      */
     @Bean
     @org.springframework.core.annotation.Order(3)
+    public SecurityFilterChain bitBiPluginApiFilterChain(HttpSecurity http) throws Exception {
+        http
+            .securityMatcher("/api/v1/plugins/bit-bi/**")
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().authenticated()
+            )
+            .addFilterBefore(pluginApiKeyAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint((request, response, authException) -> {
+                    response.sendError(401, "Unauthorized - Plugin API Key authentication required");
+                })
+            );
+
+        return http.build();
+    }
+
+    /**
+     * UI/Admin API filter chain (NEW unified structure).
+     * <p>
+     * Order 4: Fourth priority - matches /api/v1/** (excluding /api/v1/device/** and /api/v1/plugins/bit-bi/**).
+     * Auth0 OAuth2 Resource Server only.
+     * </p>
+     */
+    @Bean
+    @org.springframework.core.annotation.Order(4)
     public SecurityFilterChain adminApiFilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/v1/**")
@@ -284,6 +315,7 @@ public class TestSecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/**").denyAll() // Explicitly deny (handled by Order 1)
+                .requestMatchers("/api/v1/plugins/bit-bi/**").denyAll() // Explicitly deny (handled by Order 3)
                 .requestMatchers("/api/v1/accounts/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/sites/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/batches/**").hasRole("ADMIN")
@@ -304,12 +336,12 @@ public class TestSecurityConfig {
     /**
      * Legacy Auth0 filter chain for old admin endpoints.
      * <p>
-     * Order 4: Fourth priority - matches /api/admin/** (deprecated).
+     * Order 5: Fifth priority - matches /api/admin/** (deprecated).
      * Auth0 OAuth2 Resource Server only - ROLE_ADMIN required.
      * </p>
      */
     @Bean
-    @org.springframework.core.annotation.Order(4)
+    @org.springframework.core.annotation.Order(5)
     public SecurityFilterChain legacyAuth0FilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/admin/**")
@@ -330,12 +362,12 @@ public class TestSecurityConfig {
     /**
      * Legacy user filter chain for authenticated user endpoints.
      * <p>
-     * Order 5: Fifth priority - matches /api/sites**, /api/account/**, /api/user/** (deprecated).
+     * Order 6: Sixth priority - matches /api/sites**, /api/account/**, /api/user/** (deprecated).
      * OAuth2 Resource Server - any authenticated user allowed.
      * </p>
      */
     @Bean
-    @org.springframework.core.annotation.Order(5)
+    @org.springframework.core.annotation.Order(6)
     public SecurityFilterChain legacyUserFilterChain(HttpSecurity http) throws Exception {
         http
             .securityMatcher("/api/sites/**", "/api/account/**", "/api/user/**")
@@ -356,12 +388,12 @@ public class TestSecurityConfig {
     /**
      * Default security filter chain for remaining endpoints.
      * <p>
-     * Order 6: Lowest priority - catches all remaining requests.
+     * Order 7: Lowest priority - catches all remaining requests.
      * Allows public access to actuator, swagger, and auth token endpoints.
      * </p>
      */
     @Bean
-    @org.springframework.core.annotation.Order(6)
+    @org.springframework.core.annotation.Order(7)
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())

--- a/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
+++ b/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
@@ -275,15 +275,20 @@ public class TestSecurityConfig {
     /**
      * Bit BI Plugin API filter chain.
      * <p>
-     * Order 3: Third priority - matches /api/v1/plugins/bit-bi/**.
+     * Order 3: Third priority - matches specific Bit BI Plugin API endpoints.
      * Plugin API Key authentication via PluginApiKeyAuthenticationFilter.
+     * </p>
+     * <p>
+     * IMPORTANT: Only specific Bit BI API endpoints use Plugin API Key auth.
+     * The /api/v1/plugins/bit-bi/activate and /api/v1/plugins/bit-bi/deactivate
+     * endpoints use OAuth2 (handled by Order 4 filter chain).
      * </p>
      */
     @Bean
     @org.springframework.core.annotation.Order(3)
     public SecurityFilterChain bitBiPluginApiFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/api/v1/plugins/bit-bi/**")
+            .securityMatcher("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites")
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -315,11 +320,14 @@ public class TestSecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/**").denyAll() // Explicitly deny (handled by Order 1)
-                .requestMatchers("/api/v1/plugins/bit-bi/**").denyAll() // Explicitly deny (handled by Order 3)
+                .requestMatchers("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites").denyAll() // Explicitly deny (handled by Order 3)
                 .requestMatchers("/api/v1/accounts/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/sites/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/batches/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/errors/**").hasRole("ADMIN")
+                .requestMatchers("/api/v1/admin/plugins/**").hasRole("ADMIN") // Plugin admin endpoints
+                .requestMatchers("/api/v1/plugins/**").authenticated() // Plugin activation endpoints (any authenticated user)
+                .requestMatchers("/api/v1/account/plugins/**").authenticated() // Account plugins list
                 .requestMatchers("/api/v1/history/**").authenticated() // Any authenticated user
                 .requestMatchers("/api/v1/comparisons/**").authenticated() // Any authenticated user
                 .anyRequest().authenticated()

--- a/src/test/java/com/bitbi/dfm/integration/TestContainersManager.java
+++ b/src/test/java/com/bitbi/dfm/integration/TestContainersManager.java
@@ -92,11 +92,11 @@ public class TestContainersManager {
                 .withCommand("redis-server", "--requirepass", "test_password");
 
         // Initialize LocalStack container
+        // Using LocalStack 3.x which is compatible with Testcontainers 1.20+
         localStackContainer = new LocalStackContainer(
-                DockerImageName.parse("localstack/localstack:0.11.2")
+                DockerImageName.parse("localstack/localstack:3.8")
         )
                 .withServices(LocalStackContainer.Service.S3)
-                .withExposedPorts(4566)
                 .withStartupTimeout(Duration.ofMinutes(2));
 
         try {

--- a/src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java
@@ -1,0 +1,323 @@
+package com.bitbi.dfm.plugin.contract;
+
+import com.bitbi.dfm.integration.BaseIntegrationTest;
+import com.bitbi.dfm.plugin.application.PluginApiKeyService;
+import com.bitbi.dfm.plugin.application.SqlChangesQueryService;
+import com.bitbi.dfm.plugin.domain.AccountPlugin;
+import com.bitbi.dfm.plugin.domain.PluginApiKey;
+import com.bitbi.dfm.shared.api.ApiRoutes;
+import com.bitbi.dfm.site.domain.Site;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Contract tests for Bit BI Plugin API endpoints.
+ *
+ * <p>Tests GET /api/v1/plugins/bit-bi/sql-changes endpoint:
+ * <ul>
+ *   <li>TC01: Valid request returns 200 OK with SQL content (text/plain)</li>
+ *   <li>TC02: Valid request with no changes returns 200 OK with empty body</li>
+ *   <li>TC03: Missing siteId parameter returns 400 Bad Request</li>
+ *   <li>TC04: Invalid siteId format returns 400 Bad Request</li>
+ *   <li>TC05: Missing since parameter returns 400 Bad Request</li>
+ *   <li>TC06: Invalid since format returns 400 Bad Request</li>
+ *   <li>TC07: Missing API key returns 401 Unauthorized</li>
+ *   <li>TC08: Invalid API key returns 401 Unauthorized</li>
+ *   <li>TC09: Site not owned by account returns 403 Forbidden</li>
+ * </ul>
+ *
+ * <p>Tests GET /api/v1/plugins/bit-bi/sites endpoint:
+ * <ul>
+ *   <li>TC10: Valid request returns 200 OK with site list</li>
+ *   <li>TC11: Valid request with no sites returns 200 OK with empty array</li>
+ *   <li>TC12: Missing API key returns 401 Unauthorized</li>
+ *   <li>TC13: Invalid API key returns 401 Unauthorized</li>
+ * </ul>
+ *
+ * @see com.bitbi.dfm.plugin.presentation.BitBiPluginApiController
+ */
+@DisplayName("Bit BI Plugin API Contract Tests")
+class BitBiPluginApiContractTest extends BaseIntegrationTest {
+
+    private static final String API_KEY_HEADER = "X-Plugin-Api-Key";
+    private static final String VALID_API_KEY = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6";
+    private static final String INVALID_API_KEY = "plk_invalid1234567890123456789012";
+    private static final UUID TEST_ACCOUNT_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    private static final UUID TEST_SITE_ID = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final UUID OTHER_SITE_ID = UUID.fromString("660f9500-f39c-52e5-b827-557766551111");
+
+    @MockitoBean
+    private PluginApiKeyService pluginApiKeyService;
+
+    @MockitoBean
+    private SqlChangesQueryService sqlChangesQueryService;
+
+    private AccountPlugin mockAccountPlugin;
+
+    @BeforeEach
+    void setUp() {
+        // Setup mock account plugin
+        mockAccountPlugin = mock(AccountPlugin.class);
+        when(mockAccountPlugin.getId()).thenReturn(1L);  // Required by PluginApiKeyAuthenticationFilter
+        when(mockAccountPlugin.getAccountId()).thenReturn(TEST_ACCOUNT_ID);
+        when(mockAccountPlugin.isActive()).thenReturn(true);
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/plugins/bit-bi/sql-changes")
+    class GetSqlChanges {
+
+        @Test
+        @DisplayName("TC01: Should return 200 OK with SQL content for valid request")
+        void shouldReturn200WithSqlContent() throws Exception {
+            // Given
+            String expectedSql = """
+                INSERT INTO customers (id, name) VALUES ('1', 'John');
+                --- END OF COMMAND "customers.csv:2" ---
+                UPDATE orders SET status = 'shipped' WHERE id = '42';
+                --- END OF COMMAND "orders.csv:15" ---
+                """;
+
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+            when(sqlChangesQueryService.getSqlChanges(eq(TEST_ACCOUNT_ID), eq(TEST_SITE_ID), any(Instant.class)))
+                .thenReturn(expectedSql);
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("siteId", TEST_SITE_ID.toString())
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string(expectedSql));
+
+            verify(pluginApiKeyService).validateApiKey(VALID_API_KEY);
+            verify(sqlChangesQueryService).getSqlChanges(eq(TEST_ACCOUNT_ID), eq(TEST_SITE_ID), any(Instant.class));
+        }
+
+        @Test
+        @DisplayName("TC02: Should return 200 OK with empty body when no changes")
+        void shouldReturn200WithEmptyBodyWhenNoChanges() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+            when(sqlChangesQueryService.getSqlChanges(eq(TEST_ACCOUNT_ID), eq(TEST_SITE_ID), any(Instant.class)))
+                .thenReturn("");
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("siteId", TEST_SITE_ID.toString())
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+        }
+
+        @Test
+        @DisplayName("TC03: Should return 400 Bad Request when siteId is missing")
+        void shouldReturn400WhenSiteIdMissing() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").exists())
+                .andExpect(jsonPath("$.path").value(ApiRoutes.BITBI_SQL_CHANGES));
+        }
+
+        @Test
+        @DisplayName("TC04: Should return 400 Bad Request when siteId is invalid UUID")
+        void shouldReturn400WhenSiteIdInvalid() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("siteId", "not-a-uuid")
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message", containsString("siteId")));
+        }
+
+        @Test
+        @DisplayName("TC05: Should return 400 Bad Request when since is missing")
+        void shouldReturn400WhenSinceMissing() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("siteId", TEST_SITE_ID.toString()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").exists());
+        }
+
+        @Test
+        @DisplayName("TC06: Should return 400 Bad Request when since format is invalid")
+        void shouldReturn400WhenSinceFormatInvalid() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("siteId", TEST_SITE_ID.toString())
+                    .param("since", "not-a-date"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message", containsString("since")));
+        }
+
+        @Test
+        @DisplayName("TC07: Should return 401 Unauthorized when API key is missing")
+        void shouldReturn401WhenApiKeyMissing() throws Exception {
+            // When / Then - no API key header
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .param("siteId", TEST_SITE_ID.toString())
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("Invalid or missing API key"));
+
+            verify(pluginApiKeyService, never()).validateApiKey(any());
+        }
+
+        @Test
+        @DisplayName("TC08: Should return 401 Unauthorized when API key is invalid")
+        void shouldReturn401WhenApiKeyInvalid() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(INVALID_API_KEY))
+                .thenReturn(Optional.empty());
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, INVALID_API_KEY)
+                    .param("siteId", TEST_SITE_ID.toString())
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("Invalid or missing API key"));
+
+            verify(pluginApiKeyService).validateApiKey(INVALID_API_KEY);
+        }
+
+        @Test
+        @DisplayName("TC09: Should return 403 Forbidden when site is not owned by account")
+        void shouldReturn403WhenSiteNotOwned() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+            when(sqlChangesQueryService.getSqlChanges(eq(TEST_ACCOUNT_ID), eq(OTHER_SITE_ID), any(Instant.class)))
+                .thenThrow(new SecurityException("Site does not belong to your account"));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SQL_CHANGES)
+                    .header(API_KEY_HEADER, VALID_API_KEY)
+                    .param("siteId", OTHER_SITE_ID.toString())
+                    .param("since", "2025-01-01T00:00:00Z"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.status").value(403))
+                .andExpect(jsonPath("$.error").value("Forbidden"))
+                .andExpect(jsonPath("$.message").value("Site does not belong to your account"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/plugins/bit-bi/sites")
+    class ListSites {
+
+        @Test
+        @DisplayName("TC10: Should return 200 OK with site list for valid request")
+        void shouldReturn200WithSiteList() throws Exception {
+            // Given - SqlChangesQueryService will return sites for the account
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SITES)
+                    .header(API_KEY_HEADER, VALID_API_KEY))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.sites").isArray());
+
+            verify(pluginApiKeyService).validateApiKey(VALID_API_KEY);
+        }
+
+        @Test
+        @DisplayName("TC11: Should return 200 OK with empty array when no sites")
+        void shouldReturn200WithEmptyArrayWhenNoSites() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SITES)
+                    .header(API_KEY_HEADER, VALID_API_KEY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sites").isArray())
+                .andExpect(jsonPath("$.sites", hasSize(greaterThanOrEqualTo(0))));
+        }
+
+        @Test
+        @DisplayName("TC12: Should return 401 Unauthorized when API key is missing")
+        void shouldReturn401WhenApiKeyMissing() throws Exception {
+            // When / Then - no API key header
+            mockMvc.perform(get(ApiRoutes.BITBI_SITES))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"));
+
+            verify(pluginApiKeyService, never()).validateApiKey(any());
+        }
+
+        @Test
+        @DisplayName("TC13: Should return 401 Unauthorized when API key is invalid")
+        void shouldReturn401WhenApiKeyInvalid() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(INVALID_API_KEY))
+                .thenReturn(Optional.empty());
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_SITES)
+                    .header(API_KEY_HEADER, INVALID_API_KEY))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("Invalid or missing API key"));
+
+            verify(pluginApiKeyService).validateApiKey(INVALID_API_KEY);
+        }
+    }
+}

--- a/src/test/java/com/bitbi/dfm/plugin/integration/SqlGenerationIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/integration/SqlGenerationIntegrationTest.java
@@ -1,0 +1,352 @@
+package com.bitbi.dfm.plugin.integration;
+
+import com.bitbi.dfm.batch.domain.Batch;
+import com.bitbi.dfm.batch.domain.BatchRepository;
+import com.bitbi.dfm.integration.AbstractIntegrationTest;
+import com.bitbi.dfm.plugin.domain.AccountPlugin;
+import com.bitbi.dfm.plugin.domain.AccountPluginRepository;
+import com.bitbi.dfm.plugin.domain.PluginSqlGeneration;
+import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
+import com.bitbi.dfm.shared.domain.events.BatchCompletedEvent;
+import com.bitbi.dfm.upload.domain.FileChecksum;
+import com.bitbi.dfm.upload.domain.UploadedFile;
+import com.bitbi.dfm.upload.domain.UploadedFileRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.jdbc.Sql;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for SQL generation triggered by batch completion events.
+ *
+ * <p>Tests the end-to-end flow:</p>
+ * <ul>
+ *   <li>BatchCompletedEvent triggers SqlGenerationService</li>
+ *   <li>CSV files are compared between batches</li>
+ *   <li>SQL statements are generated and stored</li>
+ *   <li>PluginSqlGeneration records are created</li>
+ * </ul>
+ *
+ * <p>TDD: Written FIRST, expected to FAIL until implementation.</p>
+ */
+@DisplayName("SQL Generation Integration Tests")
+@Sql("/test-data.sql")
+class SqlGenerationIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private AccountPluginRepository accountPluginRepository;
+
+    @Autowired
+    private PluginSqlGenerationRepository pluginSqlGenerationRepository;
+
+    @Autowired
+    private BatchRepository batchRepository;
+
+    @Autowired
+    private UploadedFileRepository uploadedFileRepository;
+
+    @Autowired
+    private S3Client s3Client;
+
+    // Use account from test-data.sql that owns admin-site.example.com
+    private static final UUID TEST_ACCOUNT_ID = UUID.fromString("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    // Use existing site from test-data.sql: admin-site.example.com (has pre-existing batch)
+    private static final UUID TEST_SITE_ID = UUID.fromString("b2c3d4e5-f6a7-8901-bcde-f12345678901");
+    private static final String TEST_SITE_DOMAIN = "admin-site.example.com";
+    // Site without pre-existing batches (for "first batch" tests)
+    private static final UUID FRESH_SITE_ID = UUID.fromString("0199bab0-1111-1111-1111-111111111111");
+    private static final String FRESH_SITE_DOMAIN = "test-store.example.com";
+
+    @BeforeEach
+    void setUp() {
+        // Activate Bit BI plugin for test account
+        AccountPlugin activation = AccountPlugin.activate(TEST_ACCOUNT_ID, "bit-bi",
+                Map.of("tenantId", "test-tenant"));
+        accountPluginRepository.save(activation);
+    }
+
+    @Nested
+    @DisplayName("Batch Completion Trigger")
+    class BatchCompletionTrigger {
+
+        @Test
+        @DisplayName("Should trigger SQL generation on BATCH_COMPLETED event")
+        void shouldTriggerSqlGenerationOnBatchCompletedEvent() throws Exception {
+            // Given - First batch with CSV files in S3 and database
+            Batch firstBatch = createBatchWithCsvFile(null, "customers.csv",
+                    "id,name,email\n1,Alice,alice@example.com\n2,Bob,bob@example.com");
+
+            // Second batch with modified data
+            Batch secondBatch = createBatchWithCsvFile(null, "customers.csv",
+                    "id,name,email\n1,Alice,alice@new.com\n3,Charlie,charlie@example.com");
+
+            // When - Publish batch completed event for second batch
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    secondBatch.getId(), TEST_ACCOUNT_ID, 1, 1024L
+            );
+            eventPublisher.publishEvent(event);
+
+            // Wait for async processing
+            Thread.sleep(1000);
+
+            // Then - Verify SQL generation record was created
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findBySiteId(TEST_SITE_ID);
+            assertThat(generations).isNotEmpty();
+
+            PluginSqlGeneration generation = generations.get(0);
+            assertThat(generation.getSourceBatchId()).isEqualTo(secondBatch.getId());
+            assertThat(generation.getComparisonBatchId()).isEqualTo(firstBatch.getId());
+            assertThat(generation.getS3Key()).isNotBlank();
+            assertThat(generation.getInsertCount()).isGreaterThan(0);
+        }
+
+        @Test
+        @DisplayName("Should generate INSERT statements for first batch (no previous batch)")
+        void shouldGenerateInsertStatementsForFirstBatch() throws Exception {
+            // Given - First batch with CSV files (no previous batch) - use fresh site without pre-existing batches
+            Batch batch = createBatchWithCsvFileForSite(FRESH_SITE_ID, FRESH_SITE_DOMAIN, "products.csv",
+                    "id,name,price\n1,Widget,9.99\n2,Gadget,19.99");
+
+            // When - Publish batch completed event
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    batch.getId(), TEST_ACCOUNT_ID, 1, 512L
+            );
+            eventPublisher.publishEvent(event);
+
+            // Wait for async processing
+            Thread.sleep(1000);
+
+            // Then - Verify all rows become INSERT statements (fresh site has no previous batch)
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findBySiteId(FRESH_SITE_ID);
+            assertThat(generations).isNotEmpty();
+
+            PluginSqlGeneration generation = generations.get(0);
+            assertThat(generation.getComparisonBatchId()).isNull(); // No previous batch
+            assertThat(generation.getInsertCount()).isEqualTo(2); // 2 rows
+            assertThat(generation.getUpdateCount()).isEqualTo(0);
+            assertThat(generation.getDeleteCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Should not trigger SQL generation for accounts without Bit BI plugin")
+        void shouldNotTriggerSqlGenerationForAccountsWithoutPlugin() throws Exception {
+            // Given - Different account without Bit BI plugin
+            UUID otherAccountId = UUID.randomUUID();
+            UUID batchId = UUID.randomUUID();
+
+            // When - Publish batch completed event
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    batchId, otherAccountId, 1, 512L
+            );
+            eventPublisher.publishEvent(event);
+
+            // Wait for async processing
+            Thread.sleep(500);
+
+            // Then - No SQL generation records
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findAll();
+            assertThat(generations).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("Diff Detection")
+    class DiffDetection {
+
+        @Test
+        @DisplayName("Should detect modified rows between batches")
+        void shouldDetectModifiedRowsBetweenBatches() throws Exception {
+            // Given - First batch
+            createBatchWithCsvFile(null, "users.csv",
+                    "id,name,status\n1,Alice,active\n2,Bob,active");
+
+            // Second batch with Bob's status changed
+            Batch secondBatch = createBatchWithCsvFile(null, "users.csv",
+                    "id,name,status\n1,Alice,active\n2,Bob,inactive");
+
+            // When
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    secondBatch.getId(), TEST_ACCOUNT_ID, 1, 512L
+            );
+            eventPublisher.publishEvent(event);
+            Thread.sleep(1000);
+
+            // Then
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findBySiteId(TEST_SITE_ID);
+            assertThat(generations).hasSize(1);
+
+            PluginSqlGeneration generation = generations.get(0);
+            assertThat(generation.getUpdateCount()).isEqualTo(1); // Bob was modified
+            assertThat(generation.getInsertCount()).isEqualTo(0);
+            assertThat(generation.getDeleteCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Should detect deleted rows between batches")
+        void shouldDetectDeletedRowsBetweenBatches() throws Exception {
+            // Given - First batch with 3 rows
+            createBatchWithCsvFile(null, "items.csv",
+                    "id,name\n1,Item1\n2,Item2\n3,Item3");
+
+            // Second batch with row 3 removed
+            Batch secondBatch = createBatchWithCsvFile(null, "items.csv",
+                    "id,name\n1,Item1\n2,Item2");
+
+            // When
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    secondBatch.getId(), TEST_ACCOUNT_ID, 1, 256L
+            );
+            eventPublisher.publishEvent(event);
+            Thread.sleep(1000);
+
+            // Then
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findBySiteId(TEST_SITE_ID);
+            assertThat(generations).hasSize(1);
+
+            PluginSqlGeneration generation = generations.get(0);
+            assertThat(generation.getDeleteCount()).isEqualTo(1); // Item3 was deleted
+            assertThat(generation.getInsertCount()).isEqualTo(0);
+            assertThat(generation.getUpdateCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("Should handle multiple changes in single batch")
+        void shouldHandleMultipleChangesInSingleBatch() throws Exception {
+            // Given - First batch
+            createBatchWithCsvFile(null, "data.csv",
+                    "id,value\n1,A\n2,B\n3,C");
+
+            // Second batch: 1 modified, 3 deleted, 4 added
+            Batch secondBatch = createBatchWithCsvFile(null, "data.csv",
+                    "id,value\n1,A-UPDATED\n2,B\n4,D");
+
+            // When
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    secondBatch.getId(), TEST_ACCOUNT_ID, 1, 256L
+            );
+            eventPublisher.publishEvent(event);
+            Thread.sleep(1000);
+
+            // Then
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findBySiteId(TEST_SITE_ID);
+            assertThat(generations).hasSize(1);
+
+            PluginSqlGeneration generation = generations.get(0);
+            assertThat(generation.getInsertCount()).isEqualTo(1); // 4,D added
+            assertThat(generation.getUpdateCount()).isEqualTo(1); // 1,A→A-UPDATED
+            assertThat(generation.getDeleteCount()).isEqualTo(1); // 3,C deleted
+        }
+    }
+
+    @Nested
+    @DisplayName("S3 Storage")
+    class S3Storage {
+
+        @Test
+        @DisplayName("Should store generated SQL in S3 with correct path structure")
+        void shouldStoreGeneratedSqlInS3WithCorrectPathStructure() throws Exception {
+            // Given
+            Batch batch = createBatchWithCsvFile(null, "orders.csv",
+                    "id,customer,total\n1,Alice,100.00");
+
+            // When
+            BatchCompletedEvent event = new BatchCompletedEvent(
+                    batch.getId(), TEST_ACCOUNT_ID, 1, 256L
+            );
+            eventPublisher.publishEvent(event);
+            Thread.sleep(1000);
+
+            // Then - Verify S3 key follows expected pattern
+            List<PluginSqlGeneration> generations = pluginSqlGenerationRepository.findBySiteId(TEST_SITE_ID);
+            assertThat(generations).hasSize(1);
+
+            String s3Key = generations.get(0).getS3Key();
+            // Path format: plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
+            assertThat(s3Key).startsWith("plugins/bit-bi/");
+            assertThat(s3Key).contains(TEST_ACCOUNT_ID.toString());
+            assertThat(s3Key).endsWith(".sql");
+        }
+    }
+
+    /**
+     * Helper method to create a batch with CSV file uploaded to S3.
+     * Creates both the Batch entity in the database and uploads the file to S3.
+     * Uses batch ID in path to ensure uniqueness. Uses default TEST_SITE_ID.
+     *
+     * @param ignored unused parameter (kept for API compatibility)
+     * @param filename the CSV filename
+     * @param content the CSV content
+     * @return the created and saved Batch entity
+     */
+    @SuppressWarnings("unused")
+    private Batch createBatchWithCsvFile(UUID ignored, String filename, String content) {
+        return createBatchWithCsvFileForSite(TEST_SITE_ID, TEST_SITE_DOMAIN, filename, content);
+    }
+
+    /**
+     * Helper method to create a batch with CSV file uploaded to S3 for a specific site.
+     * Creates both the Batch entity in the database and uploads the file to S3.
+     * Uses batch ID in path to ensure uniqueness.
+     *
+     * @param siteId the site ID to create batch for
+     * @param siteDomain the site domain
+     * @param filename the CSV filename
+     * @param content the CSV content
+     * @return the created and saved Batch entity
+     */
+    private Batch createBatchWithCsvFileForSite(UUID siteId, String siteDomain, String filename, String content) {
+        byte[] contentBytes = content.getBytes(StandardCharsets.UTF_8);
+
+        // Create Batch entity using the factory method
+        Batch batch = Batch.start(TEST_ACCOUNT_ID, siteId, siteDomain);
+
+        // Save batch first to get its ID
+        batch = batchRepository.save(batch);
+
+        // Create unique s3Key using batch ID to avoid conflicts
+        String s3Path = batch.getS3Path();
+        // Include batch ID in the s3Key to ensure uniqueness
+        String s3Key = s3Path + batch.getId() + "/" + filename;
+
+        // Upload file to S3
+        s3Client.putObject(
+                PutObjectRequest.builder()
+                        .bucket("data-forge-test-bucket")
+                        .key(s3Key)
+                        .contentType("text/csv")
+                        .build(),
+                RequestBody.fromBytes(contentBytes)
+        );
+
+        // Create UploadedFile entity with unique s3Key
+        FileChecksum checksum = FileChecksum.calculateMD5(contentBytes);
+        UploadedFile uploadedFile = UploadedFile.create(
+                batch.getId(),
+                filename,
+                s3Path + batch.getId() + "/",  // Include batch ID in path
+                (long) contentBytes.length,
+                "text/csv",
+                checksum
+        );
+        uploadedFileRepository.save(uploadedFile);
+
+        // Mark batch as completed
+        batch.complete();
+
+        // Save updated batch
+        return batchRepository.save(batch);
+    }
+}

--- a/src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java
@@ -1,0 +1,373 @@
+package com.bitbi.dfm.plugin.unit;
+
+import com.bitbi.dfm.plugin.application.CsvDiffService;
+import com.bitbi.dfm.plugin.domain.CsvRowDiff;
+import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for CsvDiffService.
+ * Tests row-level CSV comparison logic for SQL generation.
+ *
+ * TDD: These tests are written FIRST and should FAIL until implementation.
+ */
+@DisplayName("CsvDiffService")
+class CsvDiffServiceTest {
+
+    private CsvDiffService csvDiffService;
+
+    @BeforeEach
+    void setUp() {
+        csvDiffService = new CsvDiffService();
+    }
+
+    @Nested
+    @DisplayName("Row Comparison")
+    class RowComparison {
+
+        @Test
+        @DisplayName("should detect added rows in current batch")
+        void shouldDetectAddedRowsInCurrentBatch() {
+            // Given - previous batch has 2 rows, current has 3
+            List<Map<String, String>> previousRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob")
+            );
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob"),
+                Map.of("id", "3", "name", "Charlie")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.ADDED);
+            assertThat(diffs.get(0).values()).containsEntry("id", "3");
+            assertThat(diffs.get(0).values()).containsEntry("name", "Charlie");
+        }
+
+        @Test
+        @DisplayName("should detect deleted rows from previous batch")
+        void shouldDetectDeletedRowsFromPreviousBatch() {
+            // Given - previous batch has 3 rows, current has 2
+            List<Map<String, String>> previousRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob"),
+                Map.of("id", "3", "name", "Charlie")
+            );
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.DELETED);
+            assertThat(diffs.get(0).values()).containsEntry("id", "3");
+        }
+
+        @Test
+        @DisplayName("should detect modified rows with changed values")
+        void shouldDetectModifiedRowsWithChangedValues() {
+            // Given - same rows but one has different value
+            // Use LinkedHashMap to ensure "id" is the first column (identity key)
+            Map<String, String> prevRow = new LinkedHashMap<>();
+            prevRow.put("id", "1");
+            prevRow.put("name", "Alice");
+            prevRow.put("email", "alice@old.com");
+            List<Map<String, String>> previousRows = List.of(prevRow);
+
+            Map<String, String> currRow = new LinkedHashMap<>();
+            currRow.put("id", "1");
+            currRow.put("name", "Alice");
+            currRow.put("email", "alice@new.com");
+            List<Map<String, String>> currentRows = List.of(currRow);
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.MODIFIED);
+            assertThat(diffs.get(0).values()).containsEntry("email", "alice@new.com");
+            assertThat(diffs.get(0).changedColumns()).containsEntry("email", "alice@old.com");
+        }
+
+        @Test
+        @DisplayName("should return empty list for identical files")
+        void shouldReturnEmptyListForIdenticalFiles() {
+            // Given - identical rows
+            List<Map<String, String>> previousRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob")
+            );
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should handle first batch with no previous rows")
+        void shouldHandleFirstBatchWithNoPreviousRows() {
+            // Given - no previous batch
+            List<Map<String, String>> previousRows = List.of();
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then - all rows should be ADDED
+            assertThat(diffs).hasSize(2);
+            assertThat(diffs).allMatch(d -> d.type() == CsvRowDiff.DiffType.ADDED);
+        }
+
+        @Test
+        @DisplayName("should detect multiple changes in single comparison")
+        void shouldDetectMultipleChangesInSingleComparison() {
+            // Given - use LinkedHashMap to ensure "id" is first column
+            Map<String, String> prev1 = new LinkedHashMap<>();
+            prev1.put("id", "1");
+            prev1.put("name", "Alice");
+            Map<String, String> prev2 = new LinkedHashMap<>();
+            prev2.put("id", "2");
+            prev2.put("name", "Bob");
+            Map<String, String> prev3 = new LinkedHashMap<>();
+            prev3.put("id", "3");
+            prev3.put("name", "Charlie");
+            List<Map<String, String>> previousRows = List.of(prev1, prev2, prev3);
+
+            Map<String, String> curr1 = new LinkedHashMap<>();
+            curr1.put("id", "1");
+            curr1.put("name", "Alice Updated");  // MODIFIED
+            Map<String, String> curr2 = new LinkedHashMap<>();
+            curr2.put("id", "2");
+            curr2.put("name", "Bob");            // UNCHANGED
+            Map<String, String> curr3 = new LinkedHashMap<>();
+            curr3.put("id", "4");
+            curr3.put("name", "David");           // ADDED (3 is DELETED)
+            List<Map<String, String>> currentRows = List.of(curr1, curr2, curr3);
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(3);
+            assertThat(diffs).extracting(CsvRowDiff::type)
+                .containsExactlyInAnyOrder(
+                    CsvRowDiff.DiffType.MODIFIED,
+                    CsvRowDiff.DiffType.DELETED,
+                    CsvRowDiff.DiffType.ADDED
+                );
+        }
+    }
+
+    @Nested
+    @DisplayName("Row Identity")
+    class RowIdentity {
+
+        @Test
+        @DisplayName("should use all columns for row identity comparison")
+        void shouldUseAllColumnsForRowIdentityComparison() {
+            // Given - same id but different email = MODIFIED row
+            // Use LinkedHashMap to ensure "id" is the first column (identity key)
+            Map<String, String> prevRow = new LinkedHashMap<>();
+            prevRow.put("id", "1");
+            prevRow.put("name", "Alice");
+            prevRow.put("email", "alice@example.com");
+            List<Map<String, String>> previousRows = List.of(prevRow);
+
+            Map<String, String> currRow = new LinkedHashMap<>();
+            currRow.put("id", "1");
+            currRow.put("name", "Alice");
+            currRow.put("email", "bob@example.com");
+            List<Map<String, String>> currentRows = List.of(currRow);
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then - should detect as MODIFIED, not as delete+add
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.MODIFIED);
+        }
+
+        @Test
+        @DisplayName("should handle row order changes correctly")
+        void shouldHandleRowOrderChangesCorrectly() {
+            // Given - same rows in different order
+            List<Map<String, String>> previousRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob")
+            );
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "2", "name", "Bob"),
+                Map.of("id", "1", "name", "Alice")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then - no changes (order doesn't matter)
+            assertThat(diffs).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("DBF Type Handling")
+    class DbfTypeHandling {
+
+        @Test
+        @DisplayName("should track column types from header info")
+        void shouldTrackColumnTypesFromHeaderInfo() {
+            // Given - column types map
+            Map<String, DbfColumnType> columnTypes = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "name", DbfColumnType.CHARACTER,
+                "amount", DbfColumnType.CURRENCY
+            );
+            List<Map<String, String>> previousRows = List.of();
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice", "amount", "100.50")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, columnTypes);
+
+            // Then - should include type info for SQL generation
+            assertThat(diffs).hasSize(1);
+            // The diff values should be preserved as-is (type conversion happens in SQL generator)
+        }
+
+        @Test
+        @DisplayName("should default to CHARACTER type when type not specified")
+        void shouldDefaultToCharacterTypeWhenTypeNotSpecified() {
+            // Given - no column types map
+            List<Map<String, String>> previousRows = List.of();
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then - should work without type information
+            assertThat(diffs).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Line Numbers")
+    class LineNumbers {
+
+        @Test
+        @DisplayName("should assign correct line numbers to added rows")
+        void shouldAssignCorrectLineNumbersToAddedRows() {
+            // Given
+            List<Map<String, String>> previousRows = List.of();
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "Alice"),
+                Map.of("id", "2", "name", "Bob"),
+                Map.of("id", "3", "name", "Charlie")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then - line numbers should be 1-based (row 1, 2, 3 excluding header)
+            assertThat(diffs).hasSize(3);
+            assertThat(diffs).extracting(CsvRowDiff::lineNumber)
+                .containsExactly(1, 2, 3);
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("should handle empty values correctly")
+        void shouldHandleEmptyValuesCorrectly() {
+            // Given - use LinkedHashMap to ensure "id" is first column
+            Map<String, String> prevRow = new LinkedHashMap<>();
+            prevRow.put("id", "1");
+            prevRow.put("name", "Alice");
+            prevRow.put("email", "alice@example.com");
+            List<Map<String, String>> previousRows = List.of(prevRow);
+
+            Map<String, String> currRow = new LinkedHashMap<>();
+            currRow.put("id", "1");
+            currRow.put("name", "Alice");
+            currRow.put("email", "");
+            List<Map<String, String>> currentRows = List.of(currRow);
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.MODIFIED);
+            assertThat(diffs.get(0).values()).containsEntry("email", "");
+        }
+
+        @Test
+        @DisplayName("should handle special characters in values")
+        void shouldHandleSpecialCharactersInValues() {
+            // Given
+            List<Map<String, String>> previousRows = List.of();
+            List<Map<String, String>> currentRows = List.of(
+                Map.of("id", "1", "name", "O'Brien", "note", "Line1\nLine2")
+            );
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).values()).containsEntry("name", "O'Brien");
+            assertThat(diffs.get(0).values()).containsEntry("note", "Line1\nLine2");
+        }
+
+        @Test
+        @DisplayName("should handle null column values")
+        void shouldHandleNullColumnValues() {
+            // Given - map with null value (simulating missing column)
+            // Use LinkedHashMap to ensure "id" is the first column
+            Map<String, String> rowWithNull = new LinkedHashMap<>();
+            rowWithNull.put("id", "1");
+            rowWithNull.put("name", null);
+
+            List<Map<String, String>> previousRows = List.of();
+            List<Map<String, String>> currentRows = List.of(rowWithNull);
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+
+            // Then
+            assertThat(diffs).hasSize(1);
+        }
+    }
+}

--- a/src/test/java/com/bitbi/dfm/plugin/unit/PluginApiKeyTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/PluginApiKeyTest.java
@@ -1,0 +1,276 @@
+package com.bitbi.dfm.plugin.unit;
+
+import com.bitbi.dfm.plugin.domain.PluginApiKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for PluginApiKey value object.
+ * Tests key format validation, generation, and security features.
+ *
+ * TDD: These tests are written FIRST and should FAIL until implementation.
+ */
+@DisplayName("PluginApiKey")
+class PluginApiKeyTest {
+
+    @Nested
+    @DisplayName("Key Format Validation")
+    class KeyFormatValidation {
+
+        @Test
+        @DisplayName("should accept valid key format (plk_ + 32 alphanumeric)")
+        void shouldAcceptValidKeyFormat() {
+            // Given
+            String validKey = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6";
+
+            // When
+            PluginApiKey apiKey = PluginApiKey.of(validKey);
+
+            // Then
+            assertThat(apiKey.value()).isEqualTo(validKey);
+        }
+
+        @Test
+        @DisplayName("should reject key without plk_ prefix")
+        void shouldRejectKeyWithoutPrefix() {
+            // Given
+            String invalidKey = "a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6xx";
+
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(invalidKey))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid API key format");
+        }
+
+        @Test
+        @DisplayName("should reject key with wrong prefix")
+        void shouldRejectKeyWithWrongPrefix() {
+            // Given
+            String invalidKey = "api_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6";
+
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(invalidKey))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("should reject key that is too short")
+        void shouldRejectKeyThatIsTooShort() {
+            // Given
+            String shortKey = "plk_abc123";
+
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(shortKey))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("should reject key that is too long")
+        void shouldRejectKeyThatIsTooLong() {
+            // Given
+            String longKey = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6EXTRA";
+
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(longKey))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("should reject key with special characters")
+        void shouldRejectKeyWithSpecialCharacters() {
+            // Given
+            String keyWithSpecial = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5!@";
+
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(keyWithSpecial))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("should reject null key value")
+        void shouldRejectNullKeyValue() {
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(null))
+                .isInstanceOf(NullPointerException.class);
+        }
+
+        @Test
+        @DisplayName("should reject empty key value")
+        void shouldRejectEmptyKeyValue() {
+            // When / Then
+            assertThatThrownBy(() -> PluginApiKey.of(""))
+                .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Key Generation")
+    class KeyGeneration {
+
+        @Test
+        @DisplayName("should generate key with plk_ prefix")
+        void shouldGenerateKeyWithPrefix() {
+            // When
+            PluginApiKey apiKey = PluginApiKey.generate();
+
+            // Then
+            assertThat(apiKey.value()).startsWith("plk_");
+        }
+
+        @Test
+        @DisplayName("should generate key with exactly 36 characters")
+        void shouldGenerateKeyWithExactLength() {
+            // When
+            PluginApiKey apiKey = PluginApiKey.generate();
+
+            // Then
+            assertThat(apiKey.value()).hasSize(36); // "plk_" (4) + 32 = 36
+        }
+
+        @Test
+        @DisplayName("should generate valid key format")
+        void shouldGenerateValidKeyFormat() {
+            // When
+            PluginApiKey apiKey = PluginApiKey.generate();
+
+            // Then
+            assertThat(apiKey.value()).matches("^plk_[a-zA-Z0-9]{32}$");
+        }
+
+        @Test
+        @DisplayName("should generate unique keys on each call")
+        void shouldGenerateUniqueKeysOnEachCall() {
+            // Given
+            Set<String> keys = new HashSet<>();
+
+            // When
+            for (int i = 0; i < 100; i++) {
+                keys.add(PluginApiKey.generate().value());
+            }
+
+            // Then - all keys should be unique
+            assertThat(keys).hasSize(100);
+        }
+
+        @Test
+        @DisplayName("should generate key with alphanumeric characters only")
+        void shouldGenerateKeyWithAlphanumericOnly() {
+            // When
+            PluginApiKey apiKey = PluginApiKey.generate();
+            String keyPart = apiKey.value().substring(4); // Remove "plk_" prefix
+
+            // Then
+            assertThat(keyPart).matches("[a-zA-Z0-9]+");
+        }
+    }
+
+    @Nested
+    @DisplayName("isValid() Static Method")
+    class IsValidMethod {
+
+        @Test
+        @DisplayName("should return true for valid key")
+        void shouldReturnTrueForValidKey() {
+            // Given
+            String validKey = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6";
+
+            // When / Then
+            assertThat(PluginApiKey.isValid(validKey)).isTrue();
+        }
+
+        @Test
+        @DisplayName("should return false for invalid key")
+        void shouldReturnFalseForInvalidKey() {
+            // Given
+            String invalidKey = "invalid_key";
+
+            // When / Then
+            assertThat(PluginApiKey.isValid(invalidKey)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return false for null")
+        void shouldReturnFalseForNull() {
+            // When / Then
+            assertThat(PluginApiKey.isValid(null)).isFalse();
+        }
+
+        @Test
+        @DisplayName("should return false for empty string")
+        void shouldReturnFalseForEmptyString() {
+            // When / Then
+            assertThat(PluginApiKey.isValid("")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Security Features")
+    class SecurityFeatures {
+
+        @Test
+        @DisplayName("toString() should mask the key value")
+        void toStringShouldMaskTheKeyValue() {
+            // Given
+            PluginApiKey apiKey = PluginApiKey.of("plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6");
+
+            // When
+            String stringRepresentation = apiKey.toString();
+
+            // Then - should show prefix + **** + last 4 chars
+            assertThat(stringRepresentation).isEqualTo("plk_****o5P6");
+            assertThat(stringRepresentation).doesNotContain("a1B2c3D4e5F6g7H8i9J0k1L2m3N4");
+        }
+
+        @Test
+        @DisplayName("rawValue() should return full key value")
+        void rawValueShouldReturnFullKeyValue() {
+            // Given
+            String fullKey = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6";
+            PluginApiKey apiKey = PluginApiKey.of(fullKey);
+
+            // When
+            String rawValue = apiKey.rawValue();
+
+            // Then
+            assertThat(rawValue).isEqualTo(fullKey);
+        }
+    }
+
+    @Nested
+    @DisplayName("Record Equality")
+    class RecordEquality {
+
+        @Test
+        @DisplayName("should be equal for same key value")
+        void shouldBeEqualForSameKeyValue() {
+            // Given
+            String key = "plk_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6";
+
+            // When
+            PluginApiKey key1 = PluginApiKey.of(key);
+            PluginApiKey key2 = PluginApiKey.of(key);
+
+            // Then
+            assertThat(key1).isEqualTo(key2);
+            assertThat(key1.hashCode()).isEqualTo(key2.hashCode());
+        }
+
+        @Test
+        @DisplayName("should not be equal for different key values")
+        void shouldNotBeEqualForDifferentKeyValues() {
+            // Given
+            PluginApiKey key1 = PluginApiKey.generate();
+            PluginApiKey key2 = PluginApiKey.generate();
+
+            // Then
+            assertThat(key1).isNotEqualTo(key2);
+        }
+    }
+}

--- a/src/test/java/com/bitbi/dfm/plugin/unit/SqlStatementGeneratorTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/SqlStatementGeneratorTest.java
@@ -1,0 +1,517 @@
+package com.bitbi.dfm.plugin.unit;
+
+import com.bitbi.dfm.plugin.application.SqlStatementGenerator;
+import com.bitbi.dfm.plugin.domain.CsvRowDiff;
+import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for SqlStatementGenerator.
+ * Tests PostgreSQL SQL statement generation from CSV diffs.
+ *
+ * TDD: These tests are written FIRST and should FAIL until implementation.
+ */
+@DisplayName("SqlStatementGenerator")
+class SqlStatementGeneratorTest {
+
+    private SqlStatementGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        generator = new SqlStatementGenerator();
+    }
+
+    @Nested
+    @DisplayName("INSERT Statement Generation")
+    class InsertStatementGeneration {
+
+        @Test
+        @DisplayName("should generate INSERT for added row")
+        void shouldGenerateInsertForAddedRow() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name", "Alice");
+            values.put("email", "alice@example.com");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "customers", Map.of());
+
+            // Then
+            assertThat(sql).contains("INSERT INTO customers");
+            assertThat(sql).contains("(id, name, email)");
+            assertThat(sql).contains("VALUES ('1', 'Alice', 'alice@example.com')");
+            assertThat(sql).endsWith(";\n--- END OF COMMAND \"customers.csv:2\" ---\n");
+        }
+
+        @Test
+        @DisplayName("should generate INSERT with NULL for empty CHARACTER field")
+        void shouldGenerateInsertWithNullForEmptyCharacterField() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name", "Alice");
+            values.put("email", ""); // Empty CHARACTER field
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "name", DbfColumnType.CHARACTER,
+                "email", DbfColumnType.CHARACTER
+            );
+
+            // When
+            String sql = generator.generate(diff, "customers", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, 'Alice', NULL)");
+        }
+
+        @Test
+        @DisplayName("should generate INSERT with 0 for empty INTEGER field")
+        void shouldGenerateInsertWithZeroForEmptyIntegerField() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("quantity", ""); // Empty INTEGER field
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "quantity", DbfColumnType.INTEGER
+            );
+
+            // When
+            String sql = generator.generate(diff, "orders", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, 0)");
+        }
+
+        @Test
+        @DisplayName("should generate INSERT with 0 for empty CURRENCY field")
+        void shouldGenerateInsertWithZeroForEmptyCurrencyField() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("amount", ""); // Empty CURRENCY field
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "amount", DbfColumnType.CURRENCY
+            );
+
+            // When
+            String sql = generator.generate(diff, "payments", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, 0)");
+        }
+    }
+
+    @Nested
+    @DisplayName("UPDATE Statement Generation")
+    class UpdateStatementGeneration {
+
+        @Test
+        @DisplayName("should generate UPDATE for modified row")
+        void shouldGenerateUpdateForModifiedRow() {
+            // Given
+            Map<String, String> newValues = new LinkedHashMap<>();
+            newValues.put("id", "1");
+            newValues.put("name", "Alice");
+            newValues.put("email", "alice@new.com");
+            Map<String, String> changedColumns = Map.of("email", "alice@old.com");
+            CsvRowDiff diff = CsvRowDiff.modified(2, newValues, changedColumns);
+
+            // When
+            String sql = generator.generate(diff, "customers", Map.of());
+
+            // Then
+            assertThat(sql).contains("UPDATE customers SET email = 'alice@new.com'");
+            assertThat(sql).contains("WHERE id = '1' AND name = 'Alice'");
+            assertThat(sql).endsWith(";\n--- END OF COMMAND \"customers.csv:2\" ---\n");
+        }
+
+        @Test
+        @DisplayName("should use unchanged columns in WHERE clause")
+        void shouldUseUnchangedColumnsInWhereClause() {
+            // Given
+            Map<String, String> newValues = new LinkedHashMap<>();
+            newValues.put("id", "1");
+            newValues.put("name", "Alice Updated");
+            newValues.put("status", "active");
+            Map<String, String> changedColumns = Map.of("name", "Alice");
+            CsvRowDiff diff = CsvRowDiff.modified(5, newValues, changedColumns);
+
+            // When
+            String sql = generator.generate(diff, "users", Map.of());
+
+            // Then
+            assertThat(sql).contains("SET name = 'Alice Updated'");
+            assertThat(sql).contains("WHERE id = '1' AND status = 'active'");
+            assertThat(sql).doesNotContain("name = 'Alice'"); // Old value should not be in WHERE
+        }
+
+        @Test
+        @DisplayName("should handle UPDATE with multiple changed columns")
+        void shouldHandleUpdateWithMultipleChangedColumns() {
+            // Given
+            Map<String, String> newValues = new LinkedHashMap<>();
+            newValues.put("id", "1");
+            newValues.put("name", "Bob");
+            newValues.put("email", "bob@new.com");
+            Map<String, String> changedColumns = new LinkedHashMap<>();
+            changedColumns.put("name", "Alice");
+            changedColumns.put("email", "alice@old.com");
+            CsvRowDiff diff = CsvRowDiff.modified(2, newValues, changedColumns);
+
+            // When
+            String sql = generator.generate(diff, "customers", Map.of());
+
+            // Then
+            assertThat(sql).contains("SET name = 'Bob', email = 'bob@new.com'");
+            assertThat(sql).contains("WHERE id = '1'");
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE Statement Generation")
+    class DeleteStatementGeneration {
+
+        @Test
+        @DisplayName("should generate DELETE for deleted row")
+        void shouldGenerateDeleteForDeletedRow() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name", "Alice");
+            values.put("email", "alice@example.com");
+            CsvRowDiff diff = CsvRowDiff.deleted(3, values);
+
+            // When
+            String sql = generator.generate(diff, "customers", Map.of());
+
+            // Then
+            assertThat(sql).contains("DELETE FROM customers");
+            assertThat(sql).contains("WHERE id = '1' AND name = 'Alice' AND email = 'alice@example.com'");
+            assertThat(sql).endsWith(";\n--- END OF COMMAND \"customers.csv:3\" ---\n");
+        }
+
+        @Test
+        @DisplayName("should use all columns in DELETE WHERE clause")
+        void shouldUseAllColumnsInDeleteWhereClause() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("col1", "val1");
+            values.put("col2", "val2");
+            values.put("col3", "val3");
+            CsvRowDiff diff = CsvRowDiff.deleted(10, values);
+
+            // When
+            String sql = generator.generate(diff, "data", Map.of());
+
+            // Then
+            assertThat(sql).contains("WHERE col1 = 'val1' AND col2 = 'val2' AND col3 = 'val3'");
+        }
+    }
+
+    @Nested
+    @DisplayName("Value Escaping")
+    class ValueEscaping {
+
+        @Test
+        @DisplayName("should escape single quotes by doubling")
+        void shouldEscapeSingleQuotesByDoubling() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name", "O'Brien");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "customers", Map.of());
+
+            // Then
+            assertThat(sql).contains("'O''Brien'");
+        }
+
+        @Test
+        @DisplayName("should handle multiple single quotes")
+        void shouldHandleMultipleSingleQuotes() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("note", "It's John's car");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "notes", Map.of());
+
+            // Then
+            assertThat(sql).contains("'It''s John''s car'");
+        }
+
+        @Test
+        @DisplayName("should handle backslash in values")
+        void shouldHandleBackslashInValues() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("path", "C:\\Users\\Admin");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "files", Map.of());
+
+            // Then
+            // PostgreSQL doesn't require backslash escaping in standard string literals
+            assertThat(sql).contains("'C:\\Users\\Admin'");
+        }
+    }
+
+    @Nested
+    @DisplayName("End of Command Comment")
+    class EndOfCommandComment {
+
+        @Test
+        @DisplayName("should append correct comment format after INSERT")
+        void shouldAppendCorrectCommentFormatAfterInsert() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(42, values);
+
+            // When
+            String sql = generator.generate(diff, "data", Map.of());
+
+            // Then
+            assertThat(sql).endsWith(";\n--- END OF COMMAND \"data.csv:42\" ---\n");
+        }
+
+        @Test
+        @DisplayName("should append correct comment format after UPDATE")
+        void shouldAppendCorrectCommentFormatAfterUpdate() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name", "New");
+            CsvRowDiff diff = CsvRowDiff.modified(15, values, Map.of("name", "Old"));
+
+            // When
+            String sql = generator.generate(diff, "users", Map.of());
+
+            // Then
+            assertThat(sql).endsWith(";\n--- END OF COMMAND \"users.csv:15\" ---\n");
+        }
+
+        @Test
+        @DisplayName("should append correct comment format after DELETE")
+        void shouldAppendCorrectCommentFormatAfterDelete() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.deleted(7, values);
+
+            // When
+            String sql = generator.generate(diff, "records", Map.of());
+
+            // Then
+            assertThat(sql).endsWith(";\n--- END OF COMMAND \"records.csv:7\" ---\n");
+        }
+    }
+
+    @Nested
+    @DisplayName("Table Name Derivation")
+    class TableNameDerivation {
+
+        @Test
+        @DisplayName("should use provided table name")
+        void shouldUseProvidedTableName() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "my_table", Map.of());
+
+            // Then
+            assertThat(sql).contains("INSERT INTO my_table");
+        }
+    }
+
+    @Nested
+    @DisplayName("NULL Handling by Type")
+    class NullHandlingByType {
+
+        @Test
+        @DisplayName("should use NULL for empty NUMERIC field")
+        void shouldUseNullForEmptyNumericField() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("amount", "");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "amount", DbfColumnType.NUMERIC
+            );
+
+            // When
+            String sql = generator.generate(diff, "data", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, NULL)");
+        }
+
+        @Test
+        @DisplayName("should use NULL for empty DATE field")
+        void shouldUseNullForEmptyDateField() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("birth_date", "");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "birth_date", DbfColumnType.DATE
+            );
+
+            // When
+            String sql = generator.generate(diff, "people", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, NULL)");
+        }
+
+        @Test
+        @DisplayName("should use NULL for empty LOGICAL field")
+        void shouldUseNullForEmptyLogicalField() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("active", "");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "active", DbfColumnType.LOGICAL
+            );
+
+            // When
+            String sql = generator.generate(diff, "flags", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, NULL)");
+        }
+
+        @Test
+        @DisplayName("should default to NULL for unknown type with empty value")
+        void shouldDefaultToNullForUnknownType() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("unknown_col", "");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When - no type specified
+            String sql = generator.generate(diff, "data", Map.of());
+
+            // Then - should default to CHARACTER behavior (NULL)
+            assertThat(sql).contains("VALUES ('1', NULL)");
+        }
+    }
+
+    @Nested
+    @DisplayName("Integer Type Formatting")
+    class IntegerTypeFormatting {
+
+        @Test
+        @DisplayName("should format INTEGER without quotes")
+        void shouldFormatIntegerWithoutQuotes() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "42");
+            values.put("quantity", "100");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "quantity", DbfColumnType.INTEGER
+            );
+
+            // When
+            String sql = generator.generate(diff, "items", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (42, 100)");
+            assertThat(sql).doesNotContain("'42'");
+        }
+
+        @Test
+        @DisplayName("should format CURRENCY without quotes")
+        void shouldFormatCurrencyWithoutQuotes() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("price", "99.99");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "price", DbfColumnType.CURRENCY
+            );
+
+            // When
+            String sql = generator.generate(diff, "products", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, 99.99)");
+        }
+
+        @Test
+        @DisplayName("should format NUMERIC without quotes")
+        void shouldFormatNumericWithoutQuotes() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("weight", "45.5");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "weight", DbfColumnType.NUMERIC
+            );
+
+            // When
+            String sql = generator.generate(diff, "items", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, 45.5)");
+        }
+
+        @Test
+        @DisplayName("should format FLOAT without quotes")
+        void shouldFormatFloatWithoutQuotes() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("ratio", "0.75");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+            Map<String, DbfColumnType> types = Map.of(
+                "id", DbfColumnType.INTEGER,
+                "ratio", DbfColumnType.FLOAT
+            );
+
+            // When
+            String sql = generator.generate(diff, "metrics", types);
+
+            // Then
+            assertThat(sql).contains("VALUES (1, 0.75)");
+        }
+    }
+}

--- a/src/test/java/com/bitbi/dfm/plugin/unit/SqlStatementGeneratorTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/SqlStatementGeneratorTest.java
@@ -12,6 +12,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for SqlStatementGenerator.
@@ -512,6 +513,143 @@ class SqlStatementGeneratorTest {
 
             // Then
             assertThat(sql).contains("VALUES (1, 0.75)");
+        }
+    }
+
+    @Nested
+    @DisplayName("SQL Injection Prevention")
+    class SqlInjectionPrevention {
+
+        @Test
+        @DisplayName("should reject table name with SQL injection attempt")
+        void shouldRejectTableNameWithSqlInjection() {
+            // Given - malicious table name
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When / Then
+            assertThatThrownBy(() -> generator.generate(diff, "users; DROP TABLE users; --", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("contains invalid characters");
+        }
+
+        @Test
+        @DisplayName("should reject column name with SQL injection attempt")
+        void shouldRejectColumnNameWithSqlInjection() {
+            // Given - malicious column name
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name'; DROP TABLE users; --", "evil");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When / Then
+            assertThatThrownBy(() -> generator.generate(diff, "users", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("contains invalid characters");
+        }
+
+        @Test
+        @DisplayName("should reject table name with special characters")
+        void shouldRejectTableNameWithSpecialCharacters() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When / Then
+            assertThatThrownBy(() -> generator.generate(diff, "table-name", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("contains invalid characters");
+        }
+
+        @Test
+        @DisplayName("should reject table name starting with number")
+        void shouldRejectTableNameStartingWithNumber() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When / Then
+            assertThatThrownBy(() -> generator.generate(diff, "123table", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("contains invalid characters");
+        }
+
+        @Test
+        @DisplayName("should accept valid table name with underscores")
+        void shouldAcceptValidTableNameWithUnderscores() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "my_table_name", Map.of());
+
+            // Then
+            assertThat(sql).contains("INSERT INTO my_table_name");
+        }
+
+        @Test
+        @DisplayName("should accept table name starting with underscore")
+        void shouldAcceptTableNameStartingWithUnderscore() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "_temp_table", Map.of());
+
+            // Then
+            assertThat(sql).contains("INSERT INTO _temp_table");
+        }
+
+        @Test
+        @DisplayName("should properly escape SQL injection in values")
+        void shouldProperlyEscapeSqlInjectionInValues() {
+            // Given - malicious value (should be escaped, not rejected)
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            values.put("name", "John'; DROP TABLE users; --");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When
+            String sql = generator.generate(diff, "users", Map.of());
+
+            // Then - value should be escaped with doubled single quotes
+            assertThat(sql).contains("'John''; DROP TABLE users; --'");
+            assertThat(sql).doesNotContain("John'; DROP");
+        }
+
+        @Test
+        @DisplayName("should reject null table name")
+        void shouldRejectNullTableName() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When / Then
+            assertThatThrownBy(() -> generator.generate(diff, null, Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null or empty");
+        }
+
+        @Test
+        @DisplayName("should reject empty table name")
+        void shouldRejectEmptyTableName() {
+            // Given
+            Map<String, String> values = new LinkedHashMap<>();
+            values.put("id", "1");
+            CsvRowDiff diff = CsvRowDiff.added(2, values);
+
+            // When / Then
+            assertThatThrownBy(() -> generator.generate(diff, "", Map.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be null or empty");
         }
     }
 }


### PR DESCRIPTION
## Summary

- **SQL Generation for Bit BI Plugin**: Implements backend functionality to generate SQL statements from CSV file changes uploaded via batches. Bit BI can retrieve SQL changes via Plugin API using API Key authentication.
- **My Plugins Dashboard Widget**: Adds a user-facing widget on the Dashboard to view and manage activated plugins with full activation/deactivation capabilities.
- **Security Configuration Fix**: Separates Plugin API Key authentication paths from OAuth2 paths to allow proper routing for plugin activation endpoints.

## Key Changes

### Backend (SQL Generation)
- `SqlGenerationService` - Core service generating INSERT/UPDATE/DELETE SQL from CSV diffs
- `CsvDiffService` - Detects row changes between file versions using MD5 hashing
- `BitBiPluginApiController` - REST API for Bit BI to retrieve SQL changes (`/api/v1/plugins/bit-bi/sql-changes`)
- `PluginApiKeyAuthenticationFilter` - Custom authentication for Plugin API using X-Plugin-Api-Key header
- `S3SqlFileStorageService` - Stores generated SQL files in S3

### Frontend (My Plugins Widget)
- `MyPluginsWidget` - Dashboard widget showing activated and available plugins
- `PluginCard` - Individual plugin card with status badge and action buttons
- `PluginActivationDialog` - Dialog for plugin activation with tenant ID form
- `PluginList` - Grid layout for plugin cards with loading/error states
- API layer with TanStack Query hooks for plugin management

### Security
- Updated `SecurityConfiguration` and `TestSecurityConfig` to route `/api/v1/plugins/bit-bi/sql-changes` and `/api/v1/plugins/bit-bi/sites` to Plugin API Key auth
- Plugin activation endpoints (`/api/v1/plugins/{pluginId}/activate`) now correctly use OAuth2

## Test Plan

- [x] Backend unit tests for SQL generation (SqlStatementGeneratorTest, CsvDiffServiceTest)
- [x] Backend integration tests (SqlGenerationIntegrationTest with Testcontainers)
- [x] Backend contract tests (BitBiPluginApiContractTest, PluginActivationContractTest, PluginDeactivationContractTest)
- [x] Frontend unit tests for all new components (68 tests)
- [x] All existing tests pass (761 frontend, all backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)