### PR TITLE
fix(plugin): rewrite CSV diff algorithm using DiffService Myers algorithm

### DIFF
--- a/specs/001-plugin-sql-generation/contracts/openapi.yaml
+++ b/specs/001-plugin-sql-generation/contracts/openapi.yaml
@@ -20,6 +20,8 @@ tags:
     description: Retrieve SQL changes from batch comparisons
   - name: Sites
     description: List available sites for the account
+  - name: Tables
+    description: List available tables (derived from uploaded CSV files)
 
 paths:
   /sql-changes:
@@ -127,6 +129,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /tables:
+    get:
+      tags:
+        - Tables
+      summary: List available tables
+      description: |
+        Returns a list of unique table names derived from uploaded CSV files.
+        Table names are derived from the original filename (without .csv or .csv.gz extension).
+        Only returns the latest upload information for each table.
+      operationId: listTables
+      responses:
+        '200':
+          description: Tables retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TableListResponse'
+              example:
+                tables:
+                  - tableName: "customers"
+                    fileSize: 1048576
+                    lastUpdatedAt: "2025-12-28T10:30:00Z"
+                  - tableName: "orders"
+                    fileSize: 2097152
+                    lastUpdatedAt: "2025-12-28T11:45:00Z"
+        '401':
+          description: Invalid or missing API key
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
 components:
   securitySchemes:
     PluginApiKey:
@@ -148,6 +182,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Site'
+
+    TableListResponse:
+      type: object
+      required:
+        - tables
+      properties:
+        tables:
+          type: array
+          items:
+            $ref: '#/components/schemas/Table'
+
+    Table:
+      type: object
+      required:
+        - tableName
+        - fileSize
+        - lastUpdatedAt
+      properties:
+        tableName:
+          type: string
+          description: Table name derived from CSV filename (without extension)
+          example: "customers"
+        fileSize:
+          type: integer
+          format: int64
+          description: Size of the latest uploaded file in bytes
+          example: 1048576
+        lastUpdatedAt:
+          type: string
+          format: date-time
+          description: Timestamp of the latest upload for this table
+          example: "2025-12-28T10:30:00Z"
 
     Site:
       type: object

--- a/specs/001-plugin-sql-generation/plan.md
+++ b/specs/001-plugin-sql-generation/plan.md
@@ -71,7 +71,9 @@ src/main/java/com/bitbi/dfm/plugin/
     ├── BitBiPluginApiController.java  # NEW: Plugin API endpoints
     └── dto/
         ├── SqlChangesResponseDto.java # NEW
-        └── SiteListResponseDto.java   # NEW
+        ├── SiteListResponseDto.java   # NEW
+        ├── TableDto.java              # NEW: Table info with name, size, timestamp
+        └── TableListResponseDto.java  # NEW: Response wrapper for /tables
 
 src/test/java/com/bitbi/dfm/plugin/
 ├── contract/
@@ -88,6 +90,67 @@ src/main/resources/db/migration/
 ```
 
 **Structure Decision**: Extends existing `plugin` package following DDD/PbLF pattern. No new packages created, all code lives within `com.bitbi.dfm.plugin`.
+
+## Implementation Details
+
+### CsvDiffService Algorithm
+
+The CSV diff algorithm uses the existing `DiffService` (java-diff-utils with Myers algorithm) to compare CSV files between batches. This approach ensures accurate detection of row-level changes without false positives.
+
+#### Algorithm Steps
+
+1. **Sort CSV Content**: Both previous and current CSV files are sorted by all columns (lexicographic comparison) to normalize row order. This ensures consistent comparison regardless of how the client exports data.
+
+2. **Generate Diff**: Uses `DiffService.generateDiff()` with sorted CSV content (without header row) to produce a JSON diff with hunks containing ADDED/REMOVED changes.
+
+3. **Parse Diff Output**: Convert diff hunks to `CsvRowDiff` objects:
+   - **ADDED only** → New row → Generate `INSERT`
+   - **REMOVED only** → Deleted row → Generate `DELETE`
+   - **Adjacent REMOVED+ADDED with SOME unchanged columns** → Modified row → Generate `UPDATE`
+   - **Adjacent REMOVED+ADDED with ALL columns changed** → Different rows → Generate `DELETE` + `INSERT`
+
+#### Key Design Decisions
+
+- **Why Myers Algorithm**: Efficient O(ND) diff algorithm already implemented in codebase via java-diff-utils
+- **Why Pre-Sort**: Eliminates false positives from row reordering (e.g., database exports in different order)
+- **Why Check Column Changes**: Distinguishes true modifications (some columns unchanged) from unrelated delete+insert (all columns changed)
+
+#### Code Location
+
+- `CsvDiffService.java`: Main diff service using DiffService
+- `DiffService.java` / `DiffServiceImpl.java`: Existing Myers algorithm implementation in `comparison` domain
+
+### /tables Endpoint
+
+New endpoint added to support table discovery for Bit BI integration.
+
+#### Query (Native SQL)
+
+```sql
+WITH latest_uploads AS (
+    SELECT uf.original_file_name, MAX(uf.uploaded_at) AS max_uploaded_at
+    FROM uploaded_files uf
+    JOIN batches b ON uf.batch_id = b.id
+    WHERE b.account_id = :accountId
+    GROUP BY uf.original_file_name
+)
+SELECT uf.original_file_name AS originalFileName,
+       uf.file_size AS fileSize,
+       uf.uploaded_at AS uploadedAt
+FROM uploaded_files uf
+JOIN latest_uploads lu ON uf.original_file_name = lu.original_file_name
+    AND uf.uploaded_at = lu.max_uploaded_at
+JOIN batches b ON uf.batch_id = b.id
+WHERE b.account_id = :accountId
+ORDER BY uf.original_file_name
+```
+
+#### Table Name Derivation
+
+Table names are derived from CSV filenames by:
+1. Removing `.csv.gz` extension (if present)
+2. Removing `.csv` extension (if present)
+3. Prefixing with `_` if name starts with a digit
 
 ## Complexity Tracking
 

--- a/specs/001-plugin-sql-generation/spec.md
+++ b/specs/001-plugin-sql-generation/spec.md
@@ -134,6 +134,26 @@ When the Bit BI plugin is activated, a Plugin API Key is generated, returned to 
 
 ---
 
+### User Story 7 - List Available Tables via Plugin API (Priority: P2)
+
+Bit BI users can retrieve a list of unique table names derived from uploaded CSV files through the Plugin API.
+
+**Why this priority**: Helps users discover which tables are available without needing to make a SQL changes request first.
+
+**Independent Test**: Can be tested by making API request with valid API Key and verifying table list matches account's uploaded file names.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Plugin API Key, **When** requesting `GET /tables`, **Then** a list of unique table names is returned with file size and last update timestamp.
+
+2. **Given** multiple batches have uploaded the same file name, **When** the request is executed, **Then** only the latest upload information is returned for each table.
+
+3. **Given** an invalid API Key, **When** the request is executed, **Then** 401 Unauthorized is returned.
+
+4. **Given** no files have been uploaded for the account, **When** the request is executed, **Then** 200 OK with empty tables array is returned.
+
+---
+
 ### Edge Cases
 
 - **Empty diff (identical files)**: No SQL file is created, no record in plugin_sql_generations
@@ -166,6 +186,7 @@ When the Bit BI plugin is activated, a Plugin API Key is generated, returned to 
 
 - **FR-010**: System MUST provide endpoint `GET /api/v1/plugins/bit-bi/sql-changes` accepting siteId and since parameters
 - **FR-011**: System MUST provide endpoint `GET /api/v1/plugins/bit-bi/sites` returning account's sites
+- **FR-011a**: System MUST provide endpoint `GET /api/v1/plugins/bit-bi/tables` returning unique table names with latest upload info
 - **FR-012**: System MUST validate Plugin API Key on all plugin API requests
 - **FR-013**: System MUST verify siteId belongs to the API Key's account before returning data
 - **FR-014**: System MUST return 401 Unauthorized for invalid or missing API Key

--- a/specs/013-plugin-system/spec.md
+++ b/specs/013-plugin-system/spec.md
@@ -240,3 +240,42 @@ The following Admin UI features have been implemented for monitoring and viewing
 **API Integration**:
 - `GET /api/v1/admin/plugins` - List registered plugins
 - `GET /api/v1/admin/plugins/audit` - Query audit logs with filters
+
+## Bit BI Plugin API (Added 2025-12-30)
+
+The Bit BI plugin provides a dedicated API for external access to SQL changes and account data.
+
+### Authentication
+
+All endpoints require `X-Plugin-Api-Key` header with the API key generated during plugin activation.
+
+### Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/v1/plugins/bit-bi/sites` | GET | List sites for the account |
+| `/api/v1/plugins/bit-bi/tables` | GET | List unique table names with latest upload info |
+| `/api/v1/plugins/bit-bi/sql-changes` | GET | Get SQL changes (params: siteId, since) |
+
+### /tables Endpoint (New)
+
+Returns a list of unique table names derived from uploaded CSV files for the authenticated account.
+
+**Response**:
+```json
+{
+  "tables": [
+    {
+      "tableName": "customers",
+      "fileSize": 1048576,
+      "lastUpdatedAt": "2025-12-28T10:30:00Z"
+    }
+  ]
+}
+```
+
+**Table Name Derivation**:
+- `.csv.gz` and `.csv` extensions are stripped
+- Names starting with digits are prefixed with `_`
+
+See [001-plugin-sql-generation/spec.md](../001-plugin-sql-generation/spec.md) for full Plugin API specification.

--- a/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
@@ -1,48 +1,45 @@
 package com.bitbi.dfm.plugin.application;
 
+import com.bitbi.dfm.comparison.domain.ChangeType;
+import com.bitbi.dfm.comparison.domain.DiffService;
 import com.bitbi.dfm.plugin.domain.CsvRowDiff;
-import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.csv.CSVRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
  * Service for comparing CSV files and generating row-level diffs.
- * Used to detect added, modified, and deleted rows between batch uploads.
+ * Uses the existing DiffService (java-diff-utils with Myers algorithm) for comparison.
  *
- * <h2>Row Identity Detection</h2>
- * <p>
- * <strong>IMPORTANT:</strong> This service uses the <b>first column</b> of the CSV
- * as the row identity key for detecting modifications vs additions/deletions.
- * </p>
+ * <h2>Algorithm</h2>
+ * <ol>
+ *   <li>Sort both CSV files by all columns to normalize row order</li>
+ *   <li>Generate diff using DiffService (Myers algorithm)</li>
+ *   <li>Parse diff output to identify ADDED, REMOVED, and MODIFIED rows</li>
+ * </ol>
  *
- * <h3>Assumptions</h3>
+ * <h2>Interpretation of Diff Output</h2>
  * <ul>
- *   <li>The first column contains a unique identifier (e.g., id, sku, email)</li>
- *   <li>The first column values are stable between batches</li>
- *   <li>Column order remains consistent between batches</li>
+ *   <li>ADDED only → new row, generates INSERT</li>
+ *   <li>REMOVED only → deleted row, generates DELETE</li>
+ *   <li>Adjacent REMOVED + ADDED at same position → modified row, generates UPDATE</li>
  * </ul>
  *
- * <h3>Limitations</h3>
- * <ul>
- *   <li>If the first column is NOT unique (e.g., country, category), incorrect
- *       UPDATE/DELETE statements may be generated</li>
- *   <li>If a row exists with the same key in both batches but different values,
- *       it will be detected as MODIFIED</li>
- *   <li>Rows without a key value fall back to full row comparison (slower)</li>
- * </ul>
- *
- * <h3>Recommendations for CSV Structure</h3>
- * <ul>
- *   <li>Place the unique identifier column (id, primary key) as the first column</li>
- *   <li>Ensure identifier values are immutable and unique within the file</li>
- *   <li>Use consistent column ordering across all batch uploads</li>
- * </ul>
- *
+ * @see DiffService
  * @see CsvRowDiff
  */
 @Service
@@ -62,131 +59,258 @@ public class CsvDiffService {
      */
     private static final int MAX_COLUMNS = 500;
 
+    private final DiffService diffService;
+    private final ObjectMapper objectMapper;
+
+    public CsvDiffService(DiffService diffService, ObjectMapper objectMapper) {
+        this.diffService = diffService;
+        this.objectMapper = objectMapper;
+    }
+
     /**
-     * Compares two lists of CSV rows and returns the differences.
-     * Uses first column as row identity key for modification detection.
+     * Compares two CSV file contents and returns the differences.
      *
-     * @param previousRows Rows from the previous batch (empty for first batch)
-     * @param currentRows Rows from the current batch
-     * @param columnTypes Map of column name to DBF type (for type-aware comparison)
+     * @param previousCsvContent Raw CSV content from previous batch (empty string for first batch)
+     * @param currentCsvContent  Raw CSV content from current batch
+     * @param headers            Column names from the CSV header row
      * @return List of row differences (added, modified, deleted)
      * @throws InvalidCsvHeaderException if column headers are invalid
      */
     public List<CsvRowDiff> compare(
-            List<Map<String, String>> previousRows,
-            List<Map<String, String>> currentRows,
-            Map<String, DbfColumnType> columnTypes
+            String previousCsvContent,
+            String currentCsvContent,
+            List<String> headers
     ) {
-        // Validate CSV headers before processing
-        validateHeaders(currentRows);
-        validateHeaders(previousRows);
+        // Validate headers
+        validateHeaders(headers);
+
+        if (currentCsvContent == null || currentCsvContent.isBlank()) {
+            log.debug("Current CSV content is empty");
+            return Collections.emptyList();
+        }
+
+        log.debug("Comparing CSV files: previousLength={}, currentLength={}, headers={}",
+                previousCsvContent != null ? previousCsvContent.length() : 0,
+                currentCsvContent.length(),
+                headers.size());
+
+        try {
+            // Step 1: Sort both CSV files by all columns
+            String sortedPrevious = sortCsvContent(previousCsvContent, headers);
+            String sortedCurrent = sortCsvContent(currentCsvContent, headers);
+
+            // Step 2: Generate diff using existing DiffService (Myers algorithm)
+            DiffService.DiffResult diffResult = diffService.generateDiff(
+                    sortedCurrent,
+                    sortedPrevious,
+                    "current.csv",
+                    "previous.csv"
+            );
+
+            log.debug("Diff result: changeType={}, additions={}, deletions={}",
+                    diffResult.changeType(),
+                    diffResult.lineAdditions(),
+                    diffResult.lineDeletions());
+
+            // If unchanged, return empty list
+            if (diffResult.changeType() == ChangeType.UNCHANGED) {
+                return Collections.emptyList();
+            }
+
+            // Step 3: Parse diff JSON and convert to CsvRowDiff
+            return parseDiffJson(diffResult.unifiedDiffJson(), headers);
+
+        } catch (IOException e) {
+            log.error("Failed to compare CSV files", e);
+            throw new CsvDiffException("Failed to compare CSV files: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Sorts CSV content by all columns to normalize row order.
+     * This ensures consistent comparison regardless of how the client exports data.
+     *
+     * <p>Note: The output does NOT include headers - only data rows are returned.
+     * This is important because the diff algorithm treats every line as data.</p>
+     */
+    private String sortCsvContent(String csvContent, List<String> headers) throws IOException {
+        if (csvContent == null || csvContent.isBlank()) {
+            return "";
+        }
+
+        // Parse CSV content
+        List<List<String>> rows = new ArrayList<>();
+        try (CSVParser parser = CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .parse(new StringReader(csvContent))) {
+
+            for (CSVRecord record : parser) {
+                List<String> row = new ArrayList<>();
+                for (String header : headers) {
+                    row.add(record.isMapped(header) ? record.get(header) : "");
+                }
+                rows.add(row);
+            }
+        }
+
+        // Sort rows by all columns (lexicographic comparison)
+        rows.sort((row1, row2) -> {
+            for (int i = 0; i < row1.size(); i++) {
+                String val1 = row1.get(i) != null ? row1.get(i) : "";
+                String val2 = row2.get(i) != null ? row2.get(i) : "";
+                int cmp = val1.compareTo(val2);
+                if (cmp != 0) {
+                    return cmp;
+                }
+            }
+            return 0;
+        });
+
+        // Write sorted rows (NO header) - each row on its own line
+        // Using simple comma-join for consistent diff comparison
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < rows.size(); i++) {
+            List<String> row = rows.get(i);
+            // Use CSVPrinter for proper escaping of values with commas/quotes
+            StringWriter rowWriter = new StringWriter();
+            try (CSVPrinter printer = new CSVPrinter(rowWriter, CSVFormat.DEFAULT)) {
+                printer.printRecord(row);
+            }
+            // Remove trailing newline from individual row
+            String rowStr = rowWriter.toString();
+            if (rowStr.endsWith("\r\n")) {
+                rowStr = rowStr.substring(0, rowStr.length() - 2);
+            } else if (rowStr.endsWith("\n")) {
+                rowStr = rowStr.substring(0, rowStr.length() - 1);
+            }
+            result.append(rowStr);
+            if (i < rows.size() - 1) {
+                result.append("\n");
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Parses diff JSON and converts to CsvRowDiff objects.
+     * Identifies ADDED-only, REMOVED-only, and MODIFIED (adjacent REMOVED+ADDED) changes.
+     *
+     * <p>The algorithm processes changes in order, detecting modifications as
+     * adjacent REMOVED+ADDED pairs. Non-adjacent REMOVED becomes DELETED,
+     * and non-adjacent ADDED becomes ADDED (INSERT).</p>
+     */
+    private List<CsvRowDiff> parseDiffJson(String diffJson, List<String> headers) throws JsonProcessingException {
+        if (diffJson == null || diffJson.isBlank()) {
+            return Collections.emptyList();
+        }
 
         List<CsvRowDiff> diffs = new ArrayList<>();
+        JsonNode root = objectMapper.readTree(diffJson);
+        JsonNode hunks = root.get("hunks");
 
-        // Get identity column (first column) if available
-        String identityColumn = getIdentityColumn(currentRows, previousRows);
+        if (hunks == null || !hunks.isArray()) {
+            return Collections.emptyList();
+        }
 
-        // Build lookup by identity column value
-        Map<String, Map<String, String>> previousByKey = buildKeyLookup(previousRows, identityColumn);
-        Map<String, Map<String, String>> currentByKey = buildKeyLookup(currentRows, identityColumn);
+        for (JsonNode hunk : hunks) {
+            JsonNode changes = hunk.get("changes");
+            if (changes == null || !changes.isArray()) {
+                continue;
+            }
 
-        // Track which previous keys were matched (for deletion detection)
-        Set<String> matchedPreviousKeys = new HashSet<>();
+            // Process changes in order to detect adjacent REMOVED+ADDED pairs (modifications)
+            int i = 0;
+            int changesSize = changes.size();
 
-        // Process current rows
-        for (int i = 0; i < currentRows.size(); i++) {
-            Map<String, String> currentRow = currentRows.get(i);
-            int lineNumber = i + 1; // 1-based line number
+            while (i < changesSize) {
+                JsonNode change = changes.get(i);
+                String type = change.get("type").asText();
 
-            String key = getKeyValue(currentRow, identityColumn);
+                if ("REMOVED".equals(type)) {
+                    // Check if next change is ADDED (adjacent = modification)
+                    if (i + 1 < changesSize) {
+                        JsonNode nextChange = changes.get(i + 1);
+                        String nextType = nextChange.get("type").asText();
 
-            if (key != null && previousByKey.containsKey(key)) {
-                // Row with same key exists in previous
-                Map<String, String> previousRow = previousByKey.get(key);
-                matchedPreviousKeys.add(key);
+                        if ("ADDED".equals(nextType)) {
+                            // Check if this is a true modification or unrelated delete+insert
+                            int lineNumber = nextChange.get("lineNumber").asInt();
+                            String previousContent = change.get("content").asText();
+                            String currentContent = nextChange.get("content").asText();
 
-                // Check if values differ
-                Map<String, String> changedColumns = findChangedColumns(previousRow, currentRow);
-                if (!changedColumns.isEmpty()) {
-                    diffs.add(CsvRowDiff.modified(lineNumber, currentRow, changedColumns));
+                            Map<String, String> previousRow = parseCsvLine(previousContent, headers);
+                            Map<String, String> currentRow = parseCsvLine(currentContent, headers);
+
+                            Map<String, String> changedColumns = findChangedColumns(previousRow, currentRow);
+
+                            // If ALL columns changed, these are different rows (delete + insert)
+                            // If SOME columns are unchanged, it's a modification of the same row
+                            if (!changedColumns.isEmpty() && changedColumns.size() < headers.size()) {
+                                // True modification: some columns unchanged, some changed
+                                diffs.add(CsvRowDiff.modified(lineNumber, currentRow, changedColumns));
+                                i += 2; // Skip both REMOVED and ADDED
+                                continue;
+                            } else if (changedColumns.size() == headers.size()) {
+                                // All columns changed = different rows, treat as DELETE + INSERT
+                                // Fall through to process REMOVED as DELETE
+                            } else {
+                                // No changes (shouldn't happen in diff), skip both
+                                i += 2;
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Standalone REMOVED = DELETED
+                    int lineNumber = change.get("lineNumber").asInt();
+                    String content = change.get("content").asText();
+                    Map<String, String> row = parseCsvLine(content, headers);
+                    diffs.add(CsvRowDiff.deleted(lineNumber, row));
+                    i++;
+
+                } else if ("ADDED".equals(type)) {
+                    // Standalone ADDED = INSERT
+                    int lineNumber = change.get("lineNumber").asInt();
+                    String content = change.get("content").asText();
+                    Map<String, String> row = parseCsvLine(content, headers);
+                    diffs.add(CsvRowDiff.added(lineNumber, row));
+                    i++;
+
+                } else {
+                    // Skip unknown change types
+                    i++;
                 }
-                // else: unchanged row
-            } else {
-                // New row - ADDED
-                diffs.add(CsvRowDiff.added(lineNumber, currentRow));
             }
         }
 
-        // Detect DELETED rows (in previous but not matched in current)
-        for (int i = 0; i < previousRows.size(); i++) {
-            Map<String, String> previousRow = previousRows.get(i);
-            int lineNumber = i + 1;
-
-            String key = getKeyValue(previousRow, identityColumn);
-
-            if (key != null && !matchedPreviousKeys.contains(key)) {
-                // Not matched - was deleted
-                diffs.add(CsvRowDiff.deleted(lineNumber, previousRow));
-            } else if (key == null && !isRowInList(previousRow, currentRows)) {
-                // No key column, use full row comparison
-                diffs.add(CsvRowDiff.deleted(lineNumber, previousRow));
-            }
-        }
-
+        log.debug("Parsed {} diffs from diff JSON", diffs.size());
         return diffs;
     }
 
     /**
-     * Gets the identity column name (first column from the rows).
+     * Parses a CSV line into a map of column name to value.
      */
-    private String getIdentityColumn(List<Map<String, String>> currentRows, List<Map<String, String>> previousRows) {
-        if (!currentRows.isEmpty() && !currentRows.get(0).isEmpty()) {
-            return currentRows.get(0).keySet().iterator().next();
-        }
-        if (!previousRows.isEmpty() && !previousRows.get(0).isEmpty()) {
-            return previousRows.get(0).keySet().iterator().next();
-        }
-        return null;
-    }
+    private Map<String, String> parseCsvLine(String csvLine, List<String> headers) {
+        Map<String, String> row = new LinkedHashMap<>();
 
-    /**
-     * Builds a lookup map from identity column value to row.
-     */
-    private Map<String, Map<String, String>> buildKeyLookup(List<Map<String, String>> rows, String identityColumn) {
-        Map<String, Map<String, String>> lookup = new HashMap<>();
-        if (identityColumn == null) {
-            return lookup;
-        }
-        for (Map<String, String> row : rows) {
-            String key = getKeyValue(row, identityColumn);
-            if (key != null) {
-                lookup.put(key, row);
+        try (CSVParser parser = CSVFormat.DEFAULT.parse(new StringReader(csvLine))) {
+            for (CSVRecord record : parser) {
+                for (int i = 0; i < headers.size() && i < record.size(); i++) {
+                    row.put(headers.get(i), record.get(i));
+                }
+                break; // Only process first record
+            }
+        } catch (IOException e) {
+            log.warn("Failed to parse CSV line: {}", csvLine, e);
+            // Fallback: split by comma (simple case)
+            String[] values = csvLine.split(",", -1);
+            for (int i = 0; i < headers.size() && i < values.length; i++) {
+                row.put(headers.get(i), values[i]);
             }
         }
-        return lookup;
-    }
 
-    /**
-     * Gets the value of the identity column from a row.
-     */
-    private String getKeyValue(Map<String, String> row, String identityColumn) {
-        if (identityColumn == null || row == null) {
-            return null;
-        }
-        return row.get(identityColumn);
-    }
-
-    /**
-     * Checks if a row exists in a list using full row comparison.
-     */
-    private boolean isRowInList(Map<String, String> row, List<Map<String, String>> rows) {
-        String fingerprint = getRowFingerprint(row);
-        for (Map<String, String> other : rows) {
-            if (fingerprint.equals(getRowFingerprint(other))) {
-                return true;
-            }
-        }
-        return false;
+        return row;
     }
 
     /**
@@ -211,52 +335,23 @@ public class CsvDiffService {
     }
 
     /**
-     * Creates a fingerprint for a row based on all column values.
-     * Order of columns is normalized for consistent comparison.
-     */
-    private String getRowFingerprint(Map<String, String> row) {
-        if (row == null) {
-            return "";
-        }
-        return row.entrySet().stream()
-            .sorted(Map.Entry.comparingByKey())
-            .map(e -> e.getKey() + "=" + (e.getValue() == null ? "\0NULL\0" : e.getValue()))
-            .collect(Collectors.joining("|"));
-    }
-
-    /**
      * Validates CSV headers for security and sanity.
-     * Checks:
-     * - Column count limit
-     * - Column name format (no SQL injection vectors)
-     * - No empty column names
-     *
-     * @param rows CSV rows to validate headers from
-     * @throws InvalidCsvHeaderException if headers are invalid
      */
-    private void validateHeaders(List<Map<String, String>> rows) {
-        if (rows == null || rows.isEmpty()) {
-            return; // Empty is valid
+    private void validateHeaders(List<String> headers) {
+        if (headers == null || headers.isEmpty()) {
+            return; // Empty is valid for first batch
         }
-
-        Map<String, String> firstRow = rows.get(0);
-        if (firstRow == null || firstRow.isEmpty()) {
-            return; // Empty row is valid
-        }
-
-        Set<String> columns = firstRow.keySet();
 
         // Check column count
-        if (columns.size() > MAX_COLUMNS) {
-            log.error("CSV has too many columns: count={}, max={}",
-                    columns.size(), MAX_COLUMNS);
+        if (headers.size() > MAX_COLUMNS) {
+            log.error("CSV has too many columns: count={}, max={}", headers.size(), MAX_COLUMNS);
             throw new InvalidCsvHeaderException(
-                    "CSV file has " + columns.size() + " columns, exceeding limit of " + MAX_COLUMNS);
+                    "CSV file has " + headers.size() + " columns, exceeding limit of " + MAX_COLUMNS);
         }
 
         // Validate each column name
         List<String> invalidColumns = new ArrayList<>();
-        for (String column : columns) {
+        for (String column : headers) {
             if (column == null || column.trim().isEmpty()) {
                 invalidColumns.add("<empty>");
                 continue;
@@ -268,8 +363,7 @@ public class CsvDiffService {
         }
 
         if (!invalidColumns.isEmpty()) {
-            log.error("CSV has invalid column names: columns={}",
-                    String.join(", ", invalidColumns));
+            log.error("CSV has invalid column names: columns={}", String.join(", ", invalidColumns));
             throw new InvalidCsvHeaderException(
                     "CSV file has " + invalidColumns.size() + " invalid column name(s). " +
                     "Column names must contain only letters, numbers, underscores, spaces, and common punctuation.");
@@ -283,7 +377,6 @@ public class CsvDiffService {
         if (value == null) {
             return "<null>";
         }
-        // Truncate and escape control characters
         String truncated = value.length() > 50 ? value.substring(0, 50) + "..." : value;
         return truncated.replaceAll("[\\r\\n\\t]", " ")
                         .replaceAll("[^\\p{Print}]", "?");
@@ -295,6 +388,15 @@ public class CsvDiffService {
     public static class InvalidCsvHeaderException extends RuntimeException {
         public InvalidCsvHeaderException(String message) {
             super(message);
+        }
+    }
+
+    /**
+     * Exception thrown when CSV diff operation fails.
+     */
+    public static class CsvDiffException extends RuntimeException {
+        public CsvDiffException(String message, Throwable cause) {
+            super(message, cause);
         }
     }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/CsvDiffService.java
@@ -36,8 +36,17 @@ import java.util.stream.Collectors;
  * <ul>
  *   <li>ADDED only → new row, generates INSERT</li>
  *   <li>REMOVED only → deleted row, generates DELETE</li>
- *   <li>Adjacent REMOVED + ADDED at same position → modified row, generates UPDATE</li>
+ *   <li>Adjacent REMOVED + ADDED with SOME unchanged columns → modified row, generates UPDATE</li>
+ *   <li>Adjacent REMOVED + ADDED with ALL columns changed → different rows, generates DELETE + INSERT</li>
  * </ul>
+ *
+ * <h2>Performance</h2>
+ * <ul>
+ *   <li>Sorting: O(n log n) where n = number of rows</li>
+ *   <li>Myers diff: O(ND) where N = total rows, D = number of differences</li>
+ *   <li>Parsing diff: O(D) where D = number of differences</li>
+ * </ul>
+ * <p><strong>Memory:</strong> O(n × m) where n = rows, m = average row size (sorts in-memory)</p>
  *
  * @see DiffService
  * @see CsvRowDiff
@@ -84,14 +93,18 @@ public class CsvDiffService {
         // Validate headers
         validateHeaders(headers);
 
-        if (currentCsvContent == null || currentCsvContent.isBlank()) {
-            log.debug("Current CSV content is empty");
+        // Handle edge case: both empty → no changes
+        boolean currentEmpty = currentCsvContent == null || currentCsvContent.isBlank();
+        boolean previousEmpty = previousCsvContent == null || previousCsvContent.isBlank();
+
+        if (currentEmpty && previousEmpty) {
+            log.debug("Both CSV contents are empty, no changes");
             return Collections.emptyList();
         }
 
         log.debug("Comparing CSV files: previousLength={}, currentLength={}, headers={}",
-                previousCsvContent != null ? previousCsvContent.length() : 0,
-                currentCsvContent.length(),
+                previousEmpty ? 0 : previousCsvContent.length(),
+                currentEmpty ? 0 : currentCsvContent.length(),
                 headers.size());
 
         try {
@@ -167,23 +180,19 @@ public class CsvDiffService {
         });
 
         // Write sorted rows (NO header) - each row on its own line
-        // Using simple comma-join for consistent diff comparison
+        // Using CSVFormat with empty record separator to avoid manual newline stripping
+        CSVFormat csvFormat = CSVFormat.DEFAULT.builder()
+                .setRecordSeparator("")
+                .build();
+
         StringBuilder result = new StringBuilder();
         for (int i = 0; i < rows.size(); i++) {
             List<String> row = rows.get(i);
-            // Use CSVPrinter for proper escaping of values with commas/quotes
             StringWriter rowWriter = new StringWriter();
-            try (CSVPrinter printer = new CSVPrinter(rowWriter, CSVFormat.DEFAULT)) {
+            try (CSVPrinter printer = new CSVPrinter(rowWriter, csvFormat)) {
                 printer.printRecord(row);
             }
-            // Remove trailing newline from individual row
-            String rowStr = rowWriter.toString();
-            if (rowStr.endsWith("\r\n")) {
-                rowStr = rowStr.substring(0, rowStr.length() - 2);
-            } else if (rowStr.endsWith("\n")) {
-                rowStr = rowStr.substring(0, rowStr.length() - 1);
-            }
-            result.append(rowStr);
+            result.append(rowWriter.toString());
             if (i < rows.size() - 1) {
                 result.append("\n");
             }
@@ -290,6 +299,8 @@ public class CsvDiffService {
 
     /**
      * Parses a CSV line into a map of column name to value.
+     *
+     * @throws CsvDiffException if CSV parsing fails (indicates corrupted data)
      */
     private Map<String, String> parseCsvLine(String csvLine, List<String> headers) {
         Map<String, String> row = new LinkedHashMap<>();
@@ -302,12 +313,11 @@ public class CsvDiffService {
                 break; // Only process first record
             }
         } catch (IOException e) {
-            log.warn("Failed to parse CSV line: {}", csvLine, e);
-            // Fallback: split by comma (simple case)
-            String[] values = csvLine.split(",", -1);
-            for (int i = 0; i < headers.size() && i < values.length; i++) {
-                row.put(headers.get(i), values[i]);
-            }
+            // CSV parsing should never fail on valid CSV data produced by sortCsvContent.
+            // If it does, it indicates corrupted data - fail fast rather than silently corrupt the diff.
+            log.error("CRITICAL: Failed to parse CSV line, cannot safely proceed: {}",
+                    sanitizeForLogging(csvLine), e);
+            throw new CsvDiffException("Failed to parse CSV line: " + e.getMessage(), e);
         }
 
         return row;

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlChangesQueryService.java
@@ -3,8 +3,10 @@ package com.bitbi.dfm.plugin.application;
 import com.bitbi.dfm.plugin.domain.PluginSqlGeneration;
 import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
 import com.bitbi.dfm.plugin.infrastructure.storage.S3SqlFileStorageService;
+import com.bitbi.dfm.plugin.presentation.dto.TableDto;
 import com.bitbi.dfm.site.domain.Site;
 import com.bitbi.dfm.site.domain.SiteRepository;
+import com.bitbi.dfm.upload.domain.UploadedFileRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
@@ -49,16 +51,19 @@ public class SqlChangesQueryService {
     private final PluginSqlGenerationRepository sqlGenerationRepository;
     private final S3SqlFileStorageService s3SqlFileStorageService;
     private final SiteRepository siteRepository;
+    private final UploadedFileRepository uploadedFileRepository;
     private final MeterRegistry meterRegistry;
 
     public SqlChangesQueryService(
             PluginSqlGenerationRepository sqlGenerationRepository,
             S3SqlFileStorageService s3SqlFileStorageService,
             SiteRepository siteRepository,
+            UploadedFileRepository uploadedFileRepository,
             MeterRegistry meterRegistry) {
         this.sqlGenerationRepository = sqlGenerationRepository;
         this.s3SqlFileStorageService = s3SqlFileStorageService;
         this.siteRepository = siteRepository;
+        this.uploadedFileRepository = uploadedFileRepository;
         this.meterRegistry = meterRegistry;
     }
 
@@ -151,5 +156,29 @@ public class SqlChangesQueryService {
     public List<Site> listSites(UUID accountId) {
         log.debug("Listing sites for accountId={}", accountId);
         return siteRepository.findActiveByAccountId(accountId);
+    }
+
+    /**
+     * Lists all unique tables (uploaded files) for an account with their latest upload info.
+     *
+     * <p>Returns a unique list of table names derived from original file names,
+     * along with the file size and upload timestamp of the most recent upload for each.</p>
+     *
+     * @param accountId the account ID from the API key authentication
+     * @return list of table DTOs with latest upload info
+     */
+    @Transactional(readOnly = true)
+    public List<TableDto> listTables(UUID accountId) {
+        log.debug("Listing tables for accountId={}", accountId);
+
+        List<UploadedFileRepository.LatestFileInfo> latestFiles =
+                uploadedFileRepository.findLatestByOriginalFileNameForAccount(accountId);
+
+        return latestFiles.stream()
+                .map(file -> TableDto.of(
+                        TableDto.deriveTableName(file.getOriginalFileName()),
+                        file.getFileSize(),
+                        file.getUploadedAt()))
+                .toList();
     }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
@@ -304,18 +304,25 @@ public class SqlGenerationService {
 
             log.debug("Processing CSV file: {} -> table {}", currentFile.getOriginalFileName(), tableName);
 
-            // Read current file content from S3
-            List<Map<String, String>> currentRows = readCsvFromS3(currentFile.getS3Key());
+            // Read current file content from S3 as raw CSV string
+            String currentCsvContent = readCsvContentFromS3(currentFile.getS3Key());
 
-            // Read previous file content (empty if first batch)
-            List<Map<String, String>> previousRows = new ArrayList<>();
-            UploadedFile previousFile = data.previousFilesMap.get(normalizedName);
-            if (previousFile != null) {
-                previousRows = readCsvFromS3(previousFile.getS3Key());
+            // Extract headers from current CSV
+            List<String> headers = extractHeaders(currentCsvContent);
+            if (headers.isEmpty()) {
+                log.warn("Empty headers in CSV file: {}", currentFile.getOriginalFileName());
+                continue;
             }
 
-            // Generate diffs
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            // Read previous file content (empty if first batch)
+            String previousCsvContent = "";
+            UploadedFile previousFile = data.previousFilesMap.get(normalizedName);
+            if (previousFile != null) {
+                previousCsvContent = readCsvContentFromS3(previousFile.getS3Key());
+            }
+
+            // Generate diffs using the new compare method (accepts raw CSV content)
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsvContent, currentCsvContent, headers);
 
             // Generate SQL statements
             for (CsvRowDiff diff : diffs) {
@@ -405,9 +412,9 @@ public class SqlGenerationService {
     ) {}
 
     /**
-     * Reads CSV content from S3 and returns rows as list of maps.
+     * Reads CSV content from S3 and returns it as a raw string.
      */
-    private List<Map<String, String>> readCsvFromS3(String s3Key) throws IOException {
+    private String readCsvContentFromS3(String s3Key) throws IOException {
         GetObjectRequest request = GetObjectRequest.builder()
                 .bucket(bucketName)
                 .key(s3Key)
@@ -421,20 +428,30 @@ public class SqlGenerationService {
                 inputStream = new GZIPInputStream(s3Response);
             }
 
-            try (Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-                 CSVParser parser = CSVFormat.DEFAULT.withFirstRecordAsHeader().parse(reader)) {
-
-                List<Map<String, String>> rows = new ArrayList<>();
-                for (CSVRecord record : parser) {
-                    // Use LinkedHashMap to preserve column order
-                    Map<String, String> row = new LinkedHashMap<>();
-                    for (String header : parser.getHeaderNames()) {
-                        row.put(header, record.get(header));
-                    }
-                    rows.add(row);
+            try (Reader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+                StringBuilder content = new StringBuilder();
+                char[] buffer = new char[8192];
+                int bytesRead;
+                while ((bytesRead = reader.read(buffer)) != -1) {
+                    content.append(buffer, 0, bytesRead);
                 }
-                return rows;
+                return content.toString();
             }
+        }
+    }
+
+    /**
+     * Extracts headers (column names) from CSV content.
+     */
+    private List<String> extractHeaders(String csvContent) throws IOException {
+        if (csvContent == null || csvContent.isBlank()) {
+            return Collections.emptyList();
+        }
+
+        try (CSVParser parser = CSVFormat.DEFAULT
+                .withFirstRecordAsHeader()
+                .parse(new StringReader(csvContent))) {
+            return new ArrayList<>(parser.getHeaderNames());
         }
     }
 

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
@@ -4,6 +4,8 @@ import com.bitbi.dfm.plugin.application.PluginRateLimiterService;
 import com.bitbi.dfm.plugin.application.SqlChangesQueryService;
 import com.bitbi.dfm.plugin.presentation.dto.SiteDto;
 import com.bitbi.dfm.plugin.presentation.dto.SiteListResponseDto;
+import com.bitbi.dfm.plugin.presentation.dto.TableDto;
+import com.bitbi.dfm.plugin.presentation.dto.TableListResponseDto;
 import com.bitbi.dfm.shared.api.ApiRoutes;
 import com.bitbi.dfm.site.domain.Site;
 import io.swagger.v3.oas.annotations.Operation;
@@ -181,6 +183,54 @@ public class BitBiPluginApiController {
                     .toList();
 
             return ResponseEntity.ok(new SiteListResponseDto(siteDtos));
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    /**
+     * Lists all unique tables (uploaded files) for the account.
+     *
+     * <p>Returns unique table names derived from original file names,
+     * along with the file size and upload timestamp of the most recent upload for each.</p>
+     *
+     * @param authentication the Plugin API Key authentication context
+     * @return list of tables with their latest upload info
+     */
+    @GetMapping(value = "/tables", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(
+        summary = "List available tables",
+        description = "Returns a list of all unique tables (uploaded files) for the account, with latest upload info"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "Tables retrieved successfully",
+            content = @Content(schema = @Schema(implementation = TableListResponseDto.class))
+        ),
+        @ApiResponse(responseCode = "401", description = "Invalid or missing API key"),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded")
+    })
+    public ResponseEntity<TableListResponseDto> listTables(Authentication authentication) {
+
+        UUID accountId = extractAccountId(authentication);
+
+        // Check rate limit
+        if (!rateLimiterService.tryConsume(accountId)) {
+            long retryAfter = rateLimiterService.getRetryAfterSeconds(accountId);
+            return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                    .header(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter))
+                    .build();
+        }
+
+        // Set MDC context for structured logging
+        MDC.put("accountId", accountId.toString());
+
+        try {
+            log.debug("Listing tables for accountId={}", accountId);
+
+            List<TableDto> tables = sqlChangesQueryService.listTables(accountId);
+            return ResponseEntity.ok(new TableListResponseDto(tables));
         } finally {
             MDC.clear();
         }

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/PluginApiKeyAuthenticationFilter.java
@@ -50,7 +50,8 @@ public class PluginApiKeyAuthenticationFilter extends OncePerRequestFilter {
      */
     private static final String[] PLUGIN_API_PATHS = {
         "/api/v1/plugins/bit-bi/sql-changes",
-        "/api/v1/plugins/bit-bi/sites"
+        "/api/v1/plugins/bit-bi/sites",
+        "/api/v1/plugins/bit-bi/tables"
     };
 
     private final PluginApiKeyService pluginApiKeyService;

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/TableDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/TableDto.java
@@ -1,0 +1,50 @@
+package com.bitbi.dfm.plugin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+/**
+ * DTO representing a table (uploaded file) in the Plugin API response.
+ *
+ * @param tableName Table name (derived from original file name, without .csv/.csv.gz extension)
+ * @param fileSize Size of the latest uploaded file in bytes
+ * @param lastUpdatedAt Timestamp of the latest upload
+ */
+@Schema(description = "Table information")
+public record TableDto(
+    @Schema(description = "Table name (derived from original file name)", example = "customers")
+    String tableName,
+
+    @Schema(description = "Size of the latest uploaded file in bytes", example = "1048576")
+    long fileSize,
+
+    @Schema(description = "Timestamp of the latest upload", example = "2025-01-15T10:30:00Z")
+    Instant lastUpdatedAt
+) {
+    /**
+     * Creates a TableDto from individual values.
+     */
+    public static TableDto of(String tableName, long fileSize, Instant lastUpdatedAt) {
+        return new TableDto(tableName, fileSize, lastUpdatedAt);
+    }
+
+    /**
+     * Derives table name from original file name by removing file extension.
+     *
+     * @param originalFileName Original file name (e.g., "customers.csv.gz" or "products.csv")
+     * @return Table name without extension (e.g., "customers" or "products")
+     */
+    public static String deriveTableName(String originalFileName) {
+        if (originalFileName == null || originalFileName.isBlank()) {
+            return "";
+        }
+        String name = originalFileName;
+        if (name.endsWith(".csv.gz")) {
+            name = name.substring(0, name.length() - 7);
+        } else if (name.endsWith(".csv")) {
+            name = name.substring(0, name.length() - 4);
+        }
+        return name;
+    }
+}

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/TableDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/TableDto.java
@@ -30,21 +30,48 @@ public record TableDto(
     }
 
     /**
-     * Derives table name from original file name by removing file extension.
+     * Derives table name from original file name by removing file extension and sanitizing.
      *
-     * @param originalFileName Original file name (e.g., "customers.csv.gz" or "products.csv")
-     * @return Table name without extension (e.g., "customers" or "products")
+     * <p>Processing steps:
+     * <ol>
+     *   <li>Remove .csv.gz or .csv extension</li>
+     *   <li>Replace invalid characters with underscore</li>
+     *   <li>Prefix with underscore if name starts with digit</li>
+     * </ol>
+     *
+     * @param originalFileName Original file name (e.g., "customers.csv.gz" or "123_data.csv")
+     * @return Table name without extension, sanitized (e.g., "customers" or "_123_data")
+     * @throws IllegalArgumentException if original file name is blank or results in empty table name
      */
     public static String deriveTableName(String originalFileName) {
         if (originalFileName == null || originalFileName.isBlank()) {
-            return "";
+            throw new IllegalArgumentException("Original file name cannot be blank");
         }
+
         String name = originalFileName;
+
+        // Remove extensions
         if (name.endsWith(".csv.gz")) {
             name = name.substring(0, name.length() - 7);
         } else if (name.endsWith(".csv")) {
             name = name.substring(0, name.length() - 4);
         }
+
+        // Validate result is not empty
+        if (name.isBlank()) {
+            throw new IllegalArgumentException("Derived table name is empty for file: " + originalFileName);
+        }
+
+        // Sanitize: replace invalid characters with underscore (keep alphanumeric and underscore only)
+        if (!name.matches("^[a-zA-Z0-9_]+$")) {
+            name = name.replaceAll("[^a-zA-Z0-9_]", "_");
+        }
+
+        // Prefix with underscore if starts with digit (SQL table names can't start with digits)
+        if (Character.isDigit(name.charAt(0))) {
+            name = "_" + name;
+        }
+
         return name;
     }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/TableListResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/TableListResponseDto.java
@@ -1,0 +1,44 @@
+package com.bitbi.dfm.plugin.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Response DTO for listing tables in the Plugin API.
+ *
+ * @param tables List of tables (unique file names) belonging to the account
+ */
+@Schema(description = "List of tables response")
+public record TableListResponseDto(
+    @Schema(description = "List of tables belonging to the account")
+    List<TableDto> tables
+) {
+    /**
+     * Creates a response with the given tables.
+     */
+    public static TableListResponseDto of(List<TableDto> tables) {
+        return new TableListResponseDto(tables != null ? List.copyOf(tables) : List.of());
+    }
+
+    /**
+     * Creates an empty response (no tables).
+     */
+    public static TableListResponseDto empty() {
+        return new TableListResponseDto(List.of());
+    }
+
+    /**
+     * Returns true if there are no tables.
+     */
+    public boolean isEmpty() {
+        return tables == null || tables.isEmpty();
+    }
+
+    /**
+     * Returns the number of tables.
+     */
+    public int size() {
+        return tables != null ? tables.size() : 0;
+    }
+}

--- a/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
+++ b/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
@@ -650,6 +650,17 @@ public final class ApiRoutes {
      */
     public static final String BITBI_SITES = BITBI_PLUGIN_API + "/sites";
 
+    /**
+     * List tables for account endpoint.
+     * <p>
+     * Method: GET<br>
+     * Authentication: Plugin API Key (X-Plugin-Api-Key header)<br>
+     * Content-Type: application/json<br>
+     * Returns: TableListResponseDto with unique table names derived from uploaded files
+     * </p>
+     */
+    public static final String BITBI_TABLES = BITBI_PLUGIN_API + "/tables";
+
     // Private constructor to prevent instantiation
     private ApiRoutes() {
         throw new UnsupportedOperationException("Utility class - do not instantiate");

--- a/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
+++ b/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
@@ -156,7 +156,7 @@ public class SecurityConfiguration {
      * Bit BI Plugin API filter chain.
      * <p>
      * <b>Order 3</b>: Third priority - evaluated AFTER legacy JWT filter chain<br>
-     * <b>Matches</b>: /api/v1/plugins/bit-bi/sql-changes, /api/v1/plugins/bit-bi/sites<br>
+     * <b>Matches</b>: /api/v1/plugins/bit-bi/sql-changes, /api/v1/plugins/bit-bi/sites, /api/v1/plugins/bit-bi/tables<br>
      * <b>Authentication</b>: Plugin API Key (X-Plugin-Api-Key header)
      * </p>
      * <p>
@@ -177,7 +177,7 @@ public class SecurityConfiguration {
     @Order(3)
     public SecurityFilterChain bitBiPluginApiFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites")
+            .securityMatcher("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites", "/api/v1/plugins/bit-bi/tables")
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -228,7 +228,7 @@ public class SecurityConfiguration {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/**").denyAll() // Explicitly deny (already handled by Order 1)
-                .requestMatchers("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites").denyAll() // Explicitly deny (already handled by Order 3)
+                .requestMatchers("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites", "/api/v1/plugins/bit-bi/tables").denyAll() // Explicitly deny (already handled by Order 3)
                 .requestMatchers("/api/v1/accounts/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/sites/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/batches/**").hasRole("ADMIN")

--- a/src/main/java/com/bitbi/dfm/upload/domain/UploadedFileRepository.java
+++ b/src/main/java/com/bitbi/dfm/upload/domain/UploadedFileRepository.java
@@ -1,5 +1,6 @@
 package com.bitbi.dfm.upload.domain;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,4 +32,22 @@ public interface UploadedFileRepository {
     UploadedFile save(UploadedFile file);
 
     void deleteById(UUID id);
+
+    /**
+     * Finds the latest uploaded file for each unique original file name.
+     * Used by Plugin API to list available tables.
+     *
+     * @param accountId account identifier
+     * @return list of latest file info per unique file name
+     */
+    List<LatestFileInfo> findLatestByOriginalFileNameForAccount(UUID accountId);
+
+    /**
+     * Projection interface for latest file info query.
+     */
+    interface LatestFileInfo {
+        String getOriginalFileName();
+        Long getFileSize();
+        Instant getUploadedAt();
+    }
 }

--- a/src/main/java/com/bitbi/dfm/upload/infrastructure/JpaUploadedFileRepository.java
+++ b/src/main/java/com/bitbi/dfm/upload/infrastructure/JpaUploadedFileRepository.java
@@ -69,4 +69,31 @@ public interface JpaUploadedFileRepository extends JpaRepository<UploadedFile, U
      */
     @Query("SELECT COUNT(f) FROM UploadedFile f JOIN Batch b ON f.batchId = b.id WHERE b.siteId = :siteId")
     long countBySiteId(UUID siteId);
+
+    /**
+     * Finds the latest uploaded file for each unique original file name for a given account.
+     * Uses a subquery to find the maximum uploaded_at per file name.
+     *
+     * @param accountId account identifier
+     * @return list of latest file info per unique file name
+     */
+    @Query(value = """
+        WITH latest_uploads AS (
+            SELECT
+                uf.original_file_name,
+                MAX(uf.uploaded_at) AS max_uploaded_at
+            FROM uploaded_files uf
+            JOIN batches b ON uf.batch_id = b.id
+            WHERE b.account_id = :accountId
+            GROUP BY uf.original_file_name
+        )
+        SELECT uf.original_file_name AS originalFileName, uf.file_size AS fileSize, uf.uploaded_at AS uploadedAt
+        FROM uploaded_files uf
+        JOIN latest_uploads lu ON uf.original_file_name = lu.original_file_name
+            AND uf.uploaded_at = lu.max_uploaded_at
+        JOIN batches b ON uf.batch_id = b.id
+        WHERE b.account_id = :accountId
+        ORDER BY uf.original_file_name
+        """, nativeQuery = true)
+    List<LatestFileInfo> findLatestByOriginalFileNameForAccount(UUID accountId);
 }

--- a/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
+++ b/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
@@ -288,7 +288,7 @@ public class TestSecurityConfig {
     @org.springframework.core.annotation.Order(3)
     public SecurityFilterChain bitBiPluginApiFilterChain(HttpSecurity http) throws Exception {
         http
-            .securityMatcher("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites")
+            .securityMatcher("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites", "/api/v1/plugins/bit-bi/tables")
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
@@ -320,7 +320,7 @@ public class TestSecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/**").denyAll() // Explicitly deny (handled by Order 1)
-                .requestMatchers("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites").denyAll() // Explicitly deny (handled by Order 3)
+                .requestMatchers("/api/v1/plugins/bit-bi/sql-changes", "/api/v1/plugins/bit-bi/sites", "/api/v1/plugins/bit-bi/tables").denyAll() // Explicitly deny (handled by Order 3)
                 .requestMatchers("/api/v1/accounts/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/sites/**").hasRole("ADMIN")
                 .requestMatchers("/api/v1/batches/**").hasRole("ADMIN")

--- a/src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/contract/BitBiPluginApiContractTest.java
@@ -5,6 +5,7 @@ import com.bitbi.dfm.plugin.application.PluginApiKeyService;
 import com.bitbi.dfm.plugin.application.SqlChangesQueryService;
 import com.bitbi.dfm.plugin.domain.AccountPlugin;
 import com.bitbi.dfm.plugin.domain.PluginApiKey;
+import com.bitbi.dfm.plugin.presentation.dto.TableDto;
 import com.bitbi.dfm.shared.api.ApiRoutes;
 import com.bitbi.dfm.site.domain.Site;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,6 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,6 +51,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *   <li>TC11: Valid request with no sites returns 200 OK with empty array</li>
  *   <li>TC12: Missing API key returns 401 Unauthorized</li>
  *   <li>TC13: Invalid API key returns 401 Unauthorized</li>
+ * </ul>
+ *
+ * <p>Tests GET /api/v1/plugins/bit-bi/tables endpoint:
+ * <ul>
+ *   <li>TC14: Valid request returns 200 OK with table list</li>
+ *   <li>TC15: Valid request with no tables returns 200 OK with empty array</li>
+ *   <li>TC16: Missing API key returns 401 Unauthorized</li>
+ *   <li>TC17: Table names are derived from file names (extensions stripped)</li>
  * </ul>
  *
  * @see com.bitbi.dfm.plugin.presentation.BitBiPluginApiController
@@ -312,6 +323,88 @@ class BitBiPluginApiContractTest extends BaseIntegrationTest {
 
             // When / Then
             mockMvc.perform(get(ApiRoutes.BITBI_SITES)
+                    .header(API_KEY_HEADER, INVALID_API_KEY))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.message").value("Invalid or missing API key"));
+
+            verify(pluginApiKeyService).validateApiKey(INVALID_API_KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/plugins/bit-bi/tables")
+    class ListTables {
+
+        @Test
+        @DisplayName("TC14: Should return 200 OK with table list for valid request")
+        void shouldReturn200WithTableList() throws Exception {
+            // Given
+            List<TableDto> tables = List.of(
+                    TableDto.of("customers", 1048576L, Instant.parse("2025-01-15T10:30:00Z")),
+                    TableDto.of("orders", 2097152L, Instant.parse("2025-01-15T11:45:00Z"))
+            );
+
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+            when(sqlChangesQueryService.listTables(TEST_ACCOUNT_ID))
+                .thenReturn(tables);
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_TABLES)
+                    .header(API_KEY_HEADER, VALID_API_KEY))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.tables").isArray())
+                .andExpect(jsonPath("$.tables", hasSize(2)))
+                .andExpect(jsonPath("$.tables[0].tableName").value("customers"))
+                .andExpect(jsonPath("$.tables[0].fileSize").value(1048576))
+                .andExpect(jsonPath("$.tables[0].lastUpdatedAt").exists())
+                .andExpect(jsonPath("$.tables[1].tableName").value("orders"));
+
+            verify(pluginApiKeyService).validateApiKey(VALID_API_KEY);
+            verify(sqlChangesQueryService).listTables(TEST_ACCOUNT_ID);
+        }
+
+        @Test
+        @DisplayName("TC15: Should return 200 OK with empty array when no tables")
+        void shouldReturn200WithEmptyArrayWhenNoTables() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(VALID_API_KEY))
+                .thenReturn(Optional.of(mockAccountPlugin));
+            when(sqlChangesQueryService.listTables(TEST_ACCOUNT_ID))
+                .thenReturn(Collections.emptyList());
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_TABLES)
+                    .header(API_KEY_HEADER, VALID_API_KEY))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.tables").isArray())
+                .andExpect(jsonPath("$.tables", hasSize(0)));
+        }
+
+        @Test
+        @DisplayName("TC16: Should return 401 Unauthorized when API key is missing")
+        void shouldReturn401WhenApiKeyMissing() throws Exception {
+            // When / Then - no API key header
+            mockMvc.perform(get(ApiRoutes.BITBI_TABLES))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status").value(401))
+                .andExpect(jsonPath("$.error").value("Unauthorized"));
+
+            verify(pluginApiKeyService, never()).validateApiKey(any());
+        }
+
+        @Test
+        @DisplayName("TC17: Should return 401 Unauthorized when API key is invalid")
+        void shouldReturn401WhenApiKeyInvalid() throws Exception {
+            // Given
+            when(pluginApiKeyService.validateApiKey(INVALID_API_KEY))
+                .thenReturn(Optional.empty());
+
+            // When / Then
+            mockMvc.perform(get(ApiRoutes.BITBI_TABLES)
                     .header(API_KEY_HEADER, INVALID_API_KEY))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.status").value(401))

--- a/src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java
@@ -1,33 +1,43 @@
 package com.bitbi.dfm.plugin.unit;
 
+import com.bitbi.dfm.comparison.domain.ChangeType;
+import com.bitbi.dfm.comparison.domain.DiffService;
 import com.bitbi.dfm.plugin.application.CsvDiffService;
 import com.bitbi.dfm.plugin.domain.CsvRowDiff;
-import com.bitbi.dfm.plugin.domain.DbfColumnType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for CsvDiffService.
- * Tests row-level CSV comparison logic for SQL generation.
- *
- * TDD: These tests are written FIRST and should FAIL until implementation.
+ * Tests row-level CSV comparison logic using DiffService.
  */
 @DisplayName("CsvDiffService")
+@ExtendWith(MockitoExtension.class)
 class CsvDiffServiceTest {
 
+    @Mock
+    private DiffService diffService;
+
     private CsvDiffService csvDiffService;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        csvDiffService = new CsvDiffService();
+        objectMapper = new ObjectMapper();
+        csvDiffService = new CsvDiffService(diffService, objectMapper);
     }
 
     @Nested
@@ -38,18 +48,27 @@ class CsvDiffServiceTest {
         @DisplayName("should detect added rows in current batch")
         void shouldDetectAddedRowsInCurrentBatch() {
             // Given - previous batch has 2 rows, current has 3
-            List<Map<String, String>> previousRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob")
-            );
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob"),
-                Map.of("id", "3", "name", "Charlie")
-            );
+            String previousCsv = "id,name\n1,Alice\n2,Bob";
+            String currentCsv = "id,name\n1,Alice\n2,Bob\n3,Charlie";
+            List<String> headers = List.of("id", "name");
+
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 3, "oldLines": 0,
+                    "newStart": 3, "newLines": 1,
+                    "changes": [
+                      {"type": "ADDED", "lineNumber": 3, "content": "3,Charlie"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.MODIFIED, diffJson, 1, 0, 10L));
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
             // Then
             assertThat(diffs).hasSize(1);
@@ -62,18 +81,27 @@ class CsvDiffServiceTest {
         @DisplayName("should detect deleted rows from previous batch")
         void shouldDetectDeletedRowsFromPreviousBatch() {
             // Given - previous batch has 3 rows, current has 2
-            List<Map<String, String>> previousRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob"),
-                Map.of("id", "3", "name", "Charlie")
-            );
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob")
-            );
+            String previousCsv = "id,name\n1,Alice\n2,Bob\n3,Charlie";
+            String currentCsv = "id,name\n1,Alice\n2,Bob";
+            List<String> headers = List.of("id", "name");
+
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 3, "oldLines": 1,
+                    "newStart": 3, "newLines": 0,
+                    "changes": [
+                      {"type": "REMOVED", "lineNumber": 3, "content": "3,Charlie"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.MODIFIED, diffJson, 0, 1, 10L));
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
             // Then
             assertThat(diffs).hasSize(1);
@@ -84,22 +112,29 @@ class CsvDiffServiceTest {
         @Test
         @DisplayName("should detect modified rows with changed values")
         void shouldDetectModifiedRowsWithChangedValues() {
-            // Given - same rows but one has different value
-            // Use LinkedHashMap to ensure "id" is the first column (identity key)
-            Map<String, String> prevRow = new LinkedHashMap<>();
-            prevRow.put("id", "1");
-            prevRow.put("name", "Alice");
-            prevRow.put("email", "alice@old.com");
-            List<Map<String, String>> previousRows = List.of(prevRow);
+            // Given - same row but different email
+            String previousCsv = "id,name,email\n1,Alice,alice@old.com";
+            String currentCsv = "id,name,email\n1,Alice,alice@new.com";
+            List<String> headers = List.of("id", "name", "email");
 
-            Map<String, String> currRow = new LinkedHashMap<>();
-            currRow.put("id", "1");
-            currRow.put("name", "Alice");
-            currRow.put("email", "alice@new.com");
-            List<Map<String, String>> currentRows = List.of(currRow);
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 1, "oldLines": 1,
+                    "newStart": 1, "newLines": 1,
+                    "changes": [
+                      {"type": "REMOVED", "lineNumber": 1, "content": "1,Alice,alice@old.com"},
+                      {"type": "ADDED", "lineNumber": 1, "content": "1,Alice,alice@new.com"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.MODIFIED, diffJson, 1, 1, 20L));
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
             // Then
             assertThat(diffs).hasSize(1);
@@ -112,34 +147,46 @@ class CsvDiffServiceTest {
         @DisplayName("should return empty list for identical files")
         void shouldReturnEmptyListForIdenticalFiles() {
             // Given - identical rows
-            List<Map<String, String>> previousRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob")
-            );
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob")
-            );
+            String previousCsv = "id,name\n1,Alice\n2,Bob";
+            String currentCsv = "id,name\n1,Alice\n2,Bob";
+            List<String> headers = List.of("id", "name");
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.UNCHANGED, null, 0, 0, 0L));
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
             // Then
             assertThat(diffs).isEmpty();
         }
 
         @Test
-        @DisplayName("should handle first batch with no previous rows")
-        void shouldHandleFirstBatchWithNoPreviousRows() {
+        @DisplayName("should handle first batch with no previous content")
+        void shouldHandleFirstBatchWithNoPreviousContent() {
             // Given - no previous batch
-            List<Map<String, String>> previousRows = List.of();
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob")
-            );
+            String previousCsv = "";
+            String currentCsv = "id,name\n1,Alice\n2,Bob";
+            List<String> headers = List.of("id", "name");
+
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 1, "oldLines": 0,
+                    "newStart": 1, "newLines": 2,
+                    "changes": [
+                      {"type": "ADDED", "lineNumber": 1, "content": "1,Alice"},
+                      {"type": "ADDED", "lineNumber": 2, "content": "2,Bob"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.ADDED, diffJson, 2, 0, 20L));
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
             // Then - all rows should be ADDED
             assertThat(diffs).hasSize(2);
@@ -149,158 +196,63 @@ class CsvDiffServiceTest {
         @Test
         @DisplayName("should detect multiple changes in single comparison")
         void shouldDetectMultipleChangesInSingleComparison() {
-            // Given - use LinkedHashMap to ensure "id" is first column
-            Map<String, String> prev1 = new LinkedHashMap<>();
-            prev1.put("id", "1");
-            prev1.put("name", "Alice");
-            Map<String, String> prev2 = new LinkedHashMap<>();
-            prev2.put("id", "2");
-            prev2.put("name", "Bob");
-            Map<String, String> prev3 = new LinkedHashMap<>();
-            prev3.put("id", "3");
-            prev3.put("name", "Charlie");
-            List<Map<String, String>> previousRows = List.of(prev1, prev2, prev3);
-
-            Map<String, String> curr1 = new LinkedHashMap<>();
-            curr1.put("id", "1");
-            curr1.put("name", "Alice Updated");  // MODIFIED
-            Map<String, String> curr2 = new LinkedHashMap<>();
-            curr2.put("id", "2");
-            curr2.put("name", "Bob");            // UNCHANGED
-            Map<String, String> curr3 = new LinkedHashMap<>();
-            curr3.put("id", "4");
-            curr3.put("name", "David");           // ADDED (3 is DELETED)
-            List<Map<String, String>> currentRows = List.of(curr1, curr2, curr3);
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-            // Then
-            assertThat(diffs).hasSize(3);
-            assertThat(diffs).extracting(CsvRowDiff::type)
-                .containsExactlyInAnyOrder(
-                    CsvRowDiff.DiffType.MODIFIED,
-                    CsvRowDiff.DiffType.DELETED,
-                    CsvRowDiff.DiffType.ADDED
-                );
-        }
-    }
-
-    @Nested
-    @DisplayName("Row Identity")
-    class RowIdentity {
-
-        @Test
-        @DisplayName("should use all columns for row identity comparison")
-        void shouldUseAllColumnsForRowIdentityComparison() {
-            // Given - same id but different email = MODIFIED row
-            // Use LinkedHashMap to ensure "id" is the first column (identity key)
-            Map<String, String> prevRow = new LinkedHashMap<>();
-            prevRow.put("id", "1");
-            prevRow.put("name", "Alice");
-            prevRow.put("email", "alice@example.com");
-            List<Map<String, String>> previousRows = List.of(prevRow);
-
-            Map<String, String> currRow = new LinkedHashMap<>();
-            currRow.put("id", "1");
-            currRow.put("name", "Alice");
-            currRow.put("email", "bob@example.com");
-            List<Map<String, String>> currentRows = List.of(currRow);
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-            // Then - should detect as MODIFIED, not as delete+add
-            assertThat(diffs).hasSize(1);
-            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.MODIFIED);
-        }
-
-        @Test
-        @DisplayName("should handle row order changes correctly")
-        void shouldHandleRowOrderChangesCorrectly() {
-            // Given - same rows in different order
-            List<Map<String, String>> previousRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob")
-            );
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "2", "name", "Bob"),
-                Map.of("id", "1", "name", "Alice")
-            );
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-            // Then - no changes (order doesn't matter)
-            assertThat(diffs).isEmpty();
-        }
-    }
-
-    @Nested
-    @DisplayName("DBF Type Handling")
-    class DbfTypeHandling {
-
-        @Test
-        @DisplayName("should track column types from header info")
-        void shouldTrackColumnTypesFromHeaderInfo() {
-            // Given - column types map
-            Map<String, DbfColumnType> columnTypes = Map.of(
-                "id", DbfColumnType.INTEGER,
-                "name", DbfColumnType.CHARACTER,
-                "amount", DbfColumnType.CURRENCY
-            );
-            List<Map<String, String>> previousRows = List.of();
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice", "amount", "100.50")
-            );
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, columnTypes);
-
-            // Then - should include type info for SQL generation
-            assertThat(diffs).hasSize(1);
-            // The diff values should be preserved as-is (type conversion happens in SQL generator)
-        }
-
-        @Test
-        @DisplayName("should default to CHARACTER type when type not specified")
-        void shouldDefaultToCharacterTypeWhenTypeNotSpecified() {
-            // Given - no column types map
-            List<Map<String, String>> previousRows = List.of();
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice")
-            );
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-            // Then - should work without type information
-            assertThat(diffs).hasSize(1);
-        }
-    }
-
-    @Nested
-    @DisplayName("Line Numbers")
-    class LineNumbers {
-
-        @Test
-        @DisplayName("should assign correct line numbers to added rows")
-        void shouldAssignCorrectLineNumbersToAddedRows() {
             // Given
-            List<Map<String, String>> previousRows = List.of();
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "Alice"),
-                Map.of("id", "2", "name", "Bob"),
-                Map.of("id", "3", "name", "Charlie")
-            );
+            String previousCsv = "id,name\n1,Alice\n2,Bob\n3,Charlie";
+            String currentCsv = "id,name\n1,Alice Updated\n2,Bob\n4,David";
+            List<String> headers = List.of("id", "name");
+
+            // Diff output: first pair (1,Alice→1,Alice Updated) shares 'id' column → MODIFIED
+            // Second pair (3,Charlie→4,David) has ALL columns changed → DELETE + INSERT
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 1, "oldLines": 3,
+                    "newStart": 1, "newLines": 3,
+                    "changes": [
+                      {"type": "REMOVED", "lineNumber": 1, "content": "1,Alice"},
+                      {"type": "ADDED", "lineNumber": 1, "content": "1,Alice Updated"},
+                      {"type": "REMOVED", "lineNumber": 3, "content": "3,Charlie"},
+                      {"type": "ADDED", "lineNumber": 3, "content": "4,David"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.MODIFIED, diffJson, 2, 2, 40L));
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
-            // Then - line numbers should be 1-based (row 1, 2, 3 excluding header)
+            // Then - first pair = MODIFIED (id unchanged), second pair = DELETE + INSERT (all columns changed)
             assertThat(diffs).hasSize(3);
-            assertThat(diffs).extracting(CsvRowDiff::lineNumber)
-                .containsExactly(1, 2, 3);
+            assertThat(diffs.stream().filter(d -> d.type() == CsvRowDiff.DiffType.MODIFIED).count()).isEqualTo(1);
+            assertThat(diffs.stream().filter(d -> d.type() == CsvRowDiff.DiffType.DELETED).count()).isEqualTo(1);
+            assertThat(diffs.stream().filter(d -> d.type() == CsvRowDiff.DiffType.ADDED).count()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("Sorting Before Comparison")
+    class SortingBeforeComparison {
+
+        @Test
+        @DisplayName("should sort rows before comparison to normalize order")
+        void shouldSortRowsBeforeComparisonToNormalizeOrder() {
+            // Given - same rows in different order
+            String previousCsv = "id,name\n2,Bob\n1,Alice";
+            String currentCsv = "id,name\n1,Alice\n2,Bob";
+            List<String> headers = List.of("id", "name");
+
+            // After sorting, both should be identical
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.UNCHANGED, null, 0, 0, 0L));
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
+
+            // Then - no changes (order doesn't matter after sorting)
+            assertThat(diffs).isEmpty();
         }
     }
 
@@ -309,65 +261,81 @@ class CsvDiffServiceTest {
     class EdgeCases {
 
         @Test
-        @DisplayName("should handle empty values correctly")
-        void shouldHandleEmptyValuesCorrectly() {
-            // Given - use LinkedHashMap to ensure "id" is first column
-            Map<String, String> prevRow = new LinkedHashMap<>();
-            prevRow.put("id", "1");
-            prevRow.put("name", "Alice");
-            prevRow.put("email", "alice@example.com");
-            List<Map<String, String>> previousRows = List.of(prevRow);
-
-            Map<String, String> currRow = new LinkedHashMap<>();
-            currRow.put("id", "1");
-            currRow.put("name", "Alice");
-            currRow.put("email", "");
-            List<Map<String, String>> currentRows = List.of(currRow);
+        @DisplayName("should handle empty current content")
+        void shouldHandleEmptyCurrentContent() {
+            // Given
+            String previousCsv = "id,name\n1,Alice";
+            String currentCsv = "";
+            List<String> headers = List.of("id", "name");
 
             // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
+
+            // Then
+            assertThat(diffs).isEmpty();
+        }
+
+        @Test
+        @DisplayName("should handle values with commas")
+        void shouldHandleValuesWithCommas() {
+            // Given
+            String previousCsv = "";
+            String currentCsv = "id,name,note\n1,Alice,\"Hello, World\"";
+            List<String> headers = List.of("id", "name", "note");
+
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 1, "oldLines": 0,
+                    "newStart": 1, "newLines": 1,
+                    "changes": [
+                      {"type": "ADDED", "lineNumber": 1, "content": "1,Alice,\\"Hello, World\\""}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.ADDED, diffJson, 1, 0, 20L));
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
+
+            // Then
+            assertThat(diffs).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("should handle empty values")
+        void shouldHandleEmptyValues() {
+            // Given
+            String previousCsv = "id,name,email\n1,Alice,alice@example.com";
+            String currentCsv = "id,name,email\n1,Alice,";
+            List<String> headers = List.of("id", "name", "email");
+
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 1, "oldLines": 1,
+                    "newStart": 1, "newLines": 1,
+                    "changes": [
+                      {"type": "REMOVED", "lineNumber": 1, "content": "1,Alice,alice@example.com"},
+                      {"type": "ADDED", "lineNumber": 1, "content": "1,Alice,"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.MODIFIED, diffJson, 1, 1, 20L));
+
+            // When
+            List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
             // Then
             assertThat(diffs).hasSize(1);
             assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.MODIFIED);
             assertThat(diffs.get(0).values()).containsEntry("email", "");
-        }
-
-        @Test
-        @DisplayName("should handle special characters in values")
-        void shouldHandleSpecialCharactersInValues() {
-            // Given
-            List<Map<String, String>> previousRows = List.of();
-            List<Map<String, String>> currentRows = List.of(
-                Map.of("id", "1", "name", "O'Brien", "note", "Line1\nLine2")
-            );
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-            // Then
-            assertThat(diffs).hasSize(1);
-            assertThat(diffs.get(0).values()).containsEntry("name", "O'Brien");
-            assertThat(diffs.get(0).values()).containsEntry("note", "Line1\nLine2");
-        }
-
-        @Test
-        @DisplayName("should handle null column values")
-        void shouldHandleNullColumnValues() {
-            // Given - map with null value (simulating missing column)
-            // Use LinkedHashMap to ensure "id" is the first column
-            Map<String, String> rowWithNull = new LinkedHashMap<>();
-            rowWithNull.put("id", "1");
-            rowWithNull.put("name", null);
-
-            List<Map<String, String>> previousRows = List.of();
-            List<Map<String, String>> currentRows = List.of(rowWithNull);
-
-            // When
-            List<CsvRowDiff> diffs = csvDiffService.compare(previousRows, currentRows, Map.of());
-
-            // Then
-            assertThat(diffs).hasSize(1);
         }
     }
 }

--- a/src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/CsvDiffServiceTest.java
@@ -261,18 +261,37 @@ class CsvDiffServiceTest {
     class EdgeCases {
 
         @Test
-        @DisplayName("should handle empty current content")
-        void shouldHandleEmptyCurrentContent() {
-            // Given
+        @DisplayName("should detect deletions when current content is empty")
+        void shouldDetectDeletionsWhenCurrentContentIsEmpty() {
+            // Given - previous has data, current is empty (all rows deleted)
             String previousCsv = "id,name\n1,Alice";
             String currentCsv = "";
             List<String> headers = List.of("id", "name");
 
+            // When current is empty, all previous rows should be detected as DELETED
+            String diffJson = """
+                {
+                  "hunks": [{
+                    "oldStart": 1, "oldLines": 1,
+                    "newStart": 1, "newLines": 0,
+                    "changes": [
+                      {"type": "REMOVED", "lineNumber": 1, "content": "1,Alice"}
+                    ]
+                  }]
+                }
+                """;
+
+            when(diffService.generateDiff(any(), any(), any(), any()))
+                .thenReturn(new DiffService.DiffResult(ChangeType.MODIFIED, diffJson, 0, 1, 10L));
+
             // When
             List<CsvRowDiff> diffs = csvDiffService.compare(previousCsv, currentCsv, headers);
 
-            // Then
-            assertThat(diffs).isEmpty();
+            // Then - all rows should be marked as DELETED (fixes "empty CSV hides deletions" bug)
+            assertThat(diffs).hasSize(1);
+            assertThat(diffs.get(0).type()).isEqualTo(CsvRowDiff.DiffType.DELETED);
+            assertThat(diffs.get(0).values()).containsEntry("id", "1");
+            assertThat(diffs.get(0).values()).containsEntry("name", "Alice");
         }
 
         @Test

--- a/src/test/java/com/bitbi/dfm/plugin/unit/TableDtoTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/TableDtoTest.java
@@ -1,0 +1,114 @@
+package com.bitbi.dfm.plugin.unit;
+
+import com.bitbi.dfm.plugin.presentation.dto.TableDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for TableDto.
+ * Tests table name derivation from file names.
+ */
+@DisplayName("TableDto")
+class TableDtoTest {
+
+    @Nested
+    @DisplayName("deriveTableName")
+    class DeriveTableName {
+
+        @Test
+        @DisplayName("should remove .csv extension")
+        void shouldRemoveCsvExtension() {
+            assertThat(TableDto.deriveTableName("customers.csv")).isEqualTo("customers");
+        }
+
+        @Test
+        @DisplayName("should remove .csv.gz extension")
+        void shouldRemoveCsvGzExtension() {
+            assertThat(TableDto.deriveTableName("orders.csv.gz")).isEqualTo("orders");
+        }
+
+        @Test
+        @DisplayName("should keep name without extension unchanged")
+        void shouldKeepNameWithoutExtension() {
+            assertThat(TableDto.deriveTableName("products")).isEqualTo("products");
+        }
+
+        @Test
+        @DisplayName("should prefix with underscore when name starts with digit")
+        void shouldPrefixWithUnderscoreWhenStartsWithDigit() {
+            assertThat(TableDto.deriveTableName("123_data.csv")).isEqualTo("_123_data");
+        }
+
+        @Test
+        @DisplayName("should prefix with underscore for numeric-only names")
+        void shouldPrefixNumericOnlyNames() {
+            assertThat(TableDto.deriveTableName("2024.csv")).isEqualTo("_2024");
+        }
+
+        @ParameterizedTest
+        @DisplayName("should replace invalid characters with underscore")
+        @CsvSource({
+            "my-file.csv, my_file",
+            "my file.csv, my_file",
+            "my.file.csv, my_file",
+            "data@2024.csv, data_2024",
+            "report#1.csv.gz, report_1"
+        })
+        void shouldReplaceInvalidCharacters(String input, String expected) {
+            assertThat(TableDto.deriveTableName(input)).isEqualTo(expected);
+        }
+
+        @Test
+        @DisplayName("should handle complex filename with multiple issues")
+        void shouldHandleComplexFilename() {
+            // Starts with digit + has special chars
+            assertThat(TableDto.deriveTableName("123-report@data.csv.gz")).isEqualTo("_123_report_data");
+        }
+
+        @ParameterizedTest
+        @DisplayName("should throw exception for blank input")
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "\t", "\n"})
+        void shouldThrowExceptionForBlankInput(String input) {
+            assertThatThrownBy(() -> TableDto.deriveTableName(input))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot be blank");
+        }
+
+        @Test
+        @DisplayName("should throw exception when result is empty after stripping extension")
+        void shouldThrowExceptionForEmptyResult() {
+            assertThatThrownBy(() -> TableDto.deriveTableName(".csv"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("empty");
+        }
+
+        @Test
+        @DisplayName("should throw exception for .csv.gz only")
+        void shouldThrowExceptionForCsvGzOnly() {
+            assertThatThrownBy(() -> TableDto.deriveTableName(".csv.gz"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("empty");
+        }
+
+        @ParameterizedTest
+        @DisplayName("should handle various valid filenames")
+        @CsvSource({
+            "UPPERCASE.csv, UPPERCASE",
+            "MixedCase.csv.gz, MixedCase",
+            "with_underscore.csv, with_underscore",
+            "file123.csv, file123"
+        })
+        void shouldHandleVariousValidFilenames(String input, String expected) {
+            assertThat(TableDto.deriveTableName(input)).isEqualTo(expected);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Rewrites `CsvDiffService`** to use existing `DiffService` (java-diff-utils Myers algorithm) instead of HashMap-based comparison that caused 444,570 false UPDATE statements
- **Adds `/tables` endpoint** (`GET /api/v1/plugins/bit-bi/tables`) returning unique table names with latest upload info
- **Updates documentation** in specs/001-plugin-sql-generation and specs/013-plugin-system

## Problem

The previous CSV diff implementation used the first column as an identity key in a HashMap, causing:
- Duplicate keys to overwrite each other
- Unchanged rows incorrectly marked as MODIFIED
- 444,570 false UPDATE statements generated for unchanged data

## Solution

### New Algorithm
1. **Sort CSV by all columns** - normalizes row order regardless of export order
2. **Generate diff using DiffService** - Myers algorithm for accurate line-level comparison
3. **Parse diff output**:
   - ADDED only → INSERT
   - REMOVED only → DELETE
   - Adjacent REMOVED+ADDED with SOME unchanged columns → UPDATE
   - Adjacent REMOVED+ADDED with ALL columns changed → DELETE + INSERT

### New `/tables` Endpoint
Returns unique table names derived from uploaded CSV files:
```json
{
  "tables": [
    { "tableName": "customers", "fileSize": 1048576, "lastUpdatedAt": "2025-12-28T10:30:00Z" }
  ]
}
```

## Test plan

- [x] All 907 existing tests pass
- [x] Unit tests for CsvDiffService with mocked DiffService
- [x] Integration tests for SQL generation flow
- [x] Verified correct detection of ADDED, DELETED, MODIFIED rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)