### PR TITLE
Batch Retention Cleanup + DevContainer local dev fixes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,8 @@ FROM mcr.microsoft.com/devcontainers/java:1-21-bookworm
 # Install Node.js 20.x (includes npm).
 # We do this in the image build because devcontainer "features" are not applied
 # when using a plain docker-compose service with only an "image:" reference.
-RUN apt-get update \
+RUN rm -f /etc/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/yarn*.list || true \
+  && apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
   && mkdir -p /etc/apt/keyrings \
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -14,4 +15,3 @@ RUN apt-get update \
   && npm --version \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM mcr.microsoft.com/devcontainers/java:1-21-bookworm
+
+# Install Node.js 20.x (includes npm).
+# We do this in the image build because devcontainer "features" are not applied
+# when using a plain docker-compose service with only an "image:" reference.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends nodejs \
+  && node --version \
+  && npm --version \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,35 @@
+{
+  "name": "data-forge-middleware",
+  "dockerComposeFile": [
+    "../docker-compose.dev.yml",
+    "docker-compose.yml"
+  ],
+  "service": "devcontainer",
+  "workspaceFolder": "/workspaces/data-forge-middleware",
+  "shutdownAction": "stopCompose",
+  "runServices": [
+    "postgres",
+    "redis",
+    "localstack",
+    "keycloak"
+  ],
+  "forwardPorts": [8080, 3000, 8081, 4566, 5432, 6379],
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "java.configuration.updateBuildConfiguration": "automatic"
+      },
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,15 +10,9 @@
   "runServices": [
     "postgres",
     "redis",
-    "localstack",
-    "keycloak"
+    "localstack"
   ],
-  "forwardPorts": [8080, 3000, 8081, 4566, 5432, 6379],
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
-    }
-  },
+  "forwardPorts": [8080, 3000, 4566, 5432, 6379],
   "customizations": {
     "vscode": {
       "settings": {
@@ -32,4 +26,3 @@
     }
   }
 }
-

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   devcontainer:
     build:
-      context: ..
+      context: .
       dockerfile: .devcontainer/Dockerfile
     image: dfm-devcontainer:local
     container_name: dfm-devcontainer

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,7 +4,9 @@ services:
     container_name: dfm-devcontainer
     command: sleep infinity
     volumes:
-      - ..:/workspaces/data-forge-middleware:cached
+      # In devcontainer.json the first compose file is ../docker-compose.dev.yml (repo root),
+      # so compose resolves relative paths from the repo root (not from .devcontainer/).
+      - .:/workspaces/data-forge-middleware:cached
       - /var/run/docker.sock:/var/run/docker.sock
     # Required for local Auth0-backed development.
     # Keep secrets in .env (gitignored) and do not commit them.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/java:1-21-bookworm
+    container_name: dfm-devcontainer
+    command: sleep infinity
+    volumes:
+      - ..:/workspaces/data-forge-middleware:cached
+      - /var/run/docker.sock:/var/run/docker.sock
+    # Required for local Auth0-backed development.
+    # Keep secrets in .env (gitignored) and do not commit them.
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      DB_URL: jdbc:postgresql://postgres:5432/dfm
+      DB_USERNAME: dfm
+      DB_PASSWORD: dfm_password
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      SPRING_DATA_REDIS_PASSWORD: redis_password
+      AWS_S3_ENDPOINT: http://localstack:4566
+      AWS_S3_REGION: us-east-1
+      AWS_S3_BUCKET_NAME: dfm-uploads
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+    networks:
+      - dfm-network

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,9 @@
 services:
   devcontainer:
-    image: mcr.microsoft.com/devcontainers/java:1-21-bookworm
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    image: dfm-devcontainer:local
     container_name: dfm-devcontainer
     command: sleep infinity
     volumes:

--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,14 @@ AUTH0_DOMAIN=your-tenant.auth0.com
 # Auth0 Management API Credentials
 AUTH0_MGMT_CLIENT_ID=your_management_api_client_id
 AUTH0_MGMT_CLIENT_SECRET=your_management_api_client_secret
+AUTH0_MGMT_AUDIENCE=https://your-tenant.us.auth0.com/api/v2/
 
 # Auth0 API Audience (identifier for your API)
 AUTH0_AUDIENCE=https://api.dataforge.com
+
+# Auth0 Issuer (used by backend JWT validation)
+# Usually: https://<AUTH0_DOMAIN>/
+AUTH0_ISSUER=https://your-tenant.us.auth0.com/
 
 # Auth0 Custom Claims Namespace (prefix for custom claims like roles, accountId)
 # This must match the namespace used in your Auth0 Post-Login Action
@@ -59,7 +64,7 @@ IMAGE_TAG=develop
 # ============================================
 # Application Configuration
 # ============================================
-SPRING_PROFILES_ACTIVE=prod
+SPRING_PROFILES_ACTIVE=dev
 SERVER_PORT=8080
 
 # Frontend API Base URL (for local development)

--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -1,0 +1,90 @@
+name: Gemini PR Reviewer
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths:
+      - '**.java'
+      - '**.tsx'
+      - '**.ts'
+      - '**.sql'
+      - '**.yml'
+      - '**.gradle'
+      - '**.properties'
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gemini Code Review
+        uses: sshnaidm/gemini-code-review-action@v1
+        with:
+          gemini-key: ${{ secrets.GEMINI_API_KEY }}
+          model: gemini-2.5-flash
+          context-lines: '15'
+          add-files: 'false'
+          review-title: 'Gemini Code Review'
+          prompt: |
+            Ты эксперт по Java и Spring Boot. Это проект Data Forge Middleware — серверное приложение для:
+            - Приёма CSV/DBF файлов от клиентов через REST API (Device Code Flow OAuth)
+            - Хранения файлов в AWS S3 с batch-обработкой
+            - Генерации SQL-дельт через Plugin-систему (Bit BI)
+            - Управления аккаунтами и сайтами с мультитенантностью
+            - React SPA для администрирования
+
+            Технологии Backend: Java 21 LTS, Spring Boot 3.5, Spring Security 6 (Auth0 OAuth2), Spring Data JPA, PostgreSQL 16 (partitioned tables), Flyway 11, AWS SDK v2 (S3), HikariCP.
+            Технологии Frontend: React 19, TypeScript 5.6, Vite 5, TanStack Query v5, React Router v6, shadcn/ui, Tailwind CSS, @auth0/auth0-react.
+
+            Архитектура: DDD (Package by Layered Feature), агрегаты: Account, Site, Batch, ErrorLog, Plugin.
+            Аутентификация: Client API — Custom JWT (HMAC-SHA256), Admin API — Auth0 OAuth2, Plugin API — API key.
+
+            Проверь код на:
+
+            ## Java / Spring Boot
+            1. Правильное использование Spring Security filter chains (multi-chain: client JWT, Auth0 OAuth2, API key)
+            2. JPA N+1 проблемы — проверь что используется JOIN FETCH в @Query
+            3. Transaction boundaries — @Transactional на уровне сервиса, не контроллера
+            4. Immutable DTOs (Java records с fromEntity() factory methods)
+            5. Optional — возвращать из репозиториев, не использовать в параметрах
+            6. Корректный error handling (400/403/404/413/500 mapping)
+
+            ## PostgreSQL / Flyway
+            7. Миграции идемпотентны и безопасны для rollback
+            8. Правильное партиционирование (monthly range для error_logs, audit_logs)
+            9. Индексы для cursor pagination запросов
+            10. Soft delete (isActive flag) — проверь что фильтруется в запросах
+
+            ## Безопасность
+            11. Мультитенантность — accountId проверяется в каждом endpoint
+            12. JWT validation (HMAC-SHA256 для client, Auth0 RS256 для admin)
+            13. Нет утечки credentials в логах (BCrypt для API keys, DPAPI)
+            14. SQL injection prevention (параметризованные запросы)
+            15. OWASP Top 10 (XSS, CSRF, injection)
+
+            ## React / TypeScript Frontend
+            16. TanStack Query — правильные queryKey, staleTime, cache invalidation
+            17. Auth0 React SDK — корректный redirect flow, token refresh
+            18. Zod validation на формах
+            19. Feature-Sliced Design (features/widgets/pages structure)
+
+            ## Производительность
+            20. Batch operations — один активный batch на site, max 5 на account
+            21. S3 upload — retry (3 attempts, 1s delay), presigned URLs (15min)
+            22. Cursor pagination для больших datasets
+            23. 60-minute batch timeout scheduled task
+
+            Формат ответа:
+            - 🔴 **Критично**: проблемы безопасности, data leaks, баги
+            - 🟡 **Рекомендация**: улучшения качества кода
+            - 🟢 **Хорошо**: отметь удачные решения
+
+            Отвечай на русском языке. Будь конкретен — указывай номера строк и предлагай исправления.

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ target/
 .env
 *.env
 .env.local
+.env.aws-*
 application-auth0.yml
 application-dev.yml
 auth0.properties

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ Data Forge Middleware provides a RESTful API for managing batch file uploads fro
 
 ## Quick Start
 
+### Option 0: DevContainer (Local Dev Environment)
+
+This repo includes a DevContainer that starts infrastructure (PostgreSQL, Redis, LocalStack S3, Keycloak)
+via `docker-compose.dev.yml` and provides a Java 21 + Node 20 dev environment.
+
+1. Configure backend env vars in `.env` (see `.env.example`).
+2. Configure frontend env vars in `frontend/.env.local` (see `frontend/.env.local.example`).
+3. In VS Code: “Dev Containers: Reopen in Container”.
+4. Start backend: `./gradlew bootRun`
+5. Start frontend: `cd frontend && npm install && npm run dev`
+
+Notes:
+- Auth is via Auth0 (Keycloak is present in the dev compose for legacy/dev tooling, but is not the primary auth provider).
+- LocalStack bucket `dfm-uploads` is created automatically by `docker-compose.dev.yml`.
+
 ### Option 1: Development with IntelliJ IDEA (Recommended)
 
 Run infrastructure services in Docker and DFM from IDE for debugging:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ via `docker-compose.dev.yml` and provides a Java 21 + Node 20 dev environment.
 Notes:
 - Auth is via Auth0 (Keycloak is present in the dev compose for legacy/dev tooling, but is not the primary auth provider).
 - LocalStack bucket `dfm-uploads` is created automatically by `docker-compose.dev.yml`.
+- Auth0 setup details: `docs/local-auth0.md`
 
 ### Option 1: Development with IntelliJ IDEA (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Notes:
 - Auth is via Auth0 (Keycloak is present in the dev compose for legacy/dev tooling, but is not the primary auth provider).
 - LocalStack bucket `dfm-uploads` is created automatically by `docker-compose.dev.yml`.
 - Auth0 setup details: `docs/local-auth0.md`
+- If backend fails with Flyway checksum mismatch, wipe local volumes: `docker-compose -f docker-compose.dev.yml down -v` then `up -d`.
 
 ### Option 1: Development with IntelliJ IDEA (Recommended)
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ via `docker-compose.dev.yml` and provides a Java 21 + Node 20 dev environment.
 
 1. Configure backend env vars in `.env` (see `.env.example`).
 2. Configure frontend env vars in `frontend/.env.local` (see `frontend/.env.local.example`).
-3. In VS Code: “Dev Containers: Reopen in Container”.
-4. Start backend: `./gradlew bootRun`
-5. Start frontend: `cd frontend && npm install && npm run dev`
+3. Open the folder `data-forge-middleware` in VS Code (not the parent `bit-bi` folder).
+4. In VS Code: “Dev Containers: Reopen in Container”.
+5. Start backend: `./gradlew bootRun`
+6. Start frontend: `cd frontend && npm install && npm run dev`
 
 Notes:
 - Auth is via Auth0 (Keycloak is present in the dev compose for legacy/dev tooling, but is not the primary auth provider).

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,14 +10,14 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       # Multiple databases will be created via init script
-      POSTGRES_MULTIPLE_DATABASES: dfm,keycloak
+      POSTGRES_MULTIPLE_DATABASES: dfm
     ports:
       - "5432:5432"
     volumes:
       - postgres_data_dev:/var/lib/postgresql/data
       - ./docker/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d dfm && pg_isready -U postgres -d keycloak"]
+      test: ["CMD-SHELL", "pg_isready -U postgres -d dfm"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -62,50 +62,12 @@ services:
     networks:
       - dfm-network
 
-  keycloak:
-    image: quay.io/keycloak/keycloak:26.4.2
-    container_name: dfm-keycloak
-    environment:
-      # Admin credentials
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
-      # Database configuration
-      KC_DB: postgres
-      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
-      KC_DB_USERNAME: keycloak
-      KC_DB_PASSWORD: keycloak_password
-      KC_DB_SCHEMA: public
-      # HTTP configuration
-      KC_HTTP_PORT: 8080
-      KC_HTTP_ENABLED: true
-      KC_HOSTNAME_STRICT: false
-      KC_HOSTNAME_STRICT_HTTPS: false
-      KC_PROXY: edge
-      # Health checks
-      KC_HEALTH_ENABLED: true
-      KC_METRICS_ENABLED: true
-    command:
-      - start-dev
-      - --import-realm
-    ports:
-      - "8081:8080"
-    volumes:
-      - keycloak_data_dev:/opt/keycloak/data
-      - ./docker/keycloak/dfm-realm.json:/opt/keycloak/data/import/dfm-realm.json:ro
-    depends_on:
-      postgres:
-        condition: service_healthy
-    networks:
-      - dfm-network
-
 volumes:
   postgres_data_dev:
     driver: local
   redis_data_dev:
     driver: local
   localstack_data_dev:
-    driver: local
-  keycloak_data_dev:
     driver: local
 
 networks:

--- a/docs/local-auth0.md
+++ b/docs/local-auth0.md
@@ -138,6 +138,37 @@ Frontend:
 - Backend should start without Auth0 token validation errors.
 - Frontend login should succeed, and admin endpoints should return 200 for an ADMIN user.
 
+## Troubleshooting
+
+### Flyway Checksum Mismatch (Validate Failed)
+
+Symptom (example):
+- `FlywayValidateException: Migration checksum mismatch for migration version X`
+
+Cause:
+- Your local Postgres volume contains an older `flyway_schema_history` (created with older migration file contents).
+- Flyway refuses to migrate when applied checksums do not match current files.
+
+Fix options:
+
+1. Preferred for local dev: reset the local DB volume (destroys local data).
+   - From the repo root (host or devcontainer):
+   ```bash
+   docker-compose -f docker-compose.dev.yml down -v
+   docker-compose -f docker-compose.dev.yml up -d
+   ```
+   - Then start backend again:
+   ```bash
+   ./gradlew bootRun
+   ```
+
+2. Alternative (keeps data, not recommended unless you understand the impact): run Flyway repair.
+   - This updates checksums in `flyway_schema_history` to match current files.
+   ```bash
+   ./gradlew flywayRepair
+   ./gradlew bootRun
+   ```
+
 ## Optional: Pull Values From AWS (Secrets Manager)
 
 If the project is deployed in AWS and config is stored in Secrets Manager, you can pull most of the required values

--- a/docs/local-auth0.md
+++ b/docs/local-auth0.md
@@ -138,3 +138,24 @@ Frontend:
 - Backend should start without Auth0 token validation errors.
 - Frontend login should succeed, and admin endpoints should return 200 for an ADMIN user.
 
+## Optional: Pull Values From AWS (Secrets Manager)
+
+If the project is deployed in AWS and config is stored in Secrets Manager, you can pull most of the required values
+from there instead of copying from the Auth0 UI.
+
+Common locations in this AWS account:
+- `dfm-dev/auth0/credentials` (Auth0 domain, audience, management client id/secret)
+- `dfm-dev/jwt/secret` (device API JWT secret)
+- `dfm-dev/redis/password` (Redis password)
+- `dfm-dev/db/app-credentials` (DB app username/password)
+
+Example commands:
+```bash
+aws sts get-caller-identity
+aws secretsmanager get-secret-value --secret-id dfm-dev/auth0/credentials --query SecretString --output text
+```
+
+Notes:
+- Do not paste the secret values into PRs or chat.
+- For local development, keep secrets in `.env` / `frontend/.env.local` (both gitignored).
+- If you generate helper files like `.env.aws-*` or `frontend/.env.local.aws-*`, they are also gitignored by this repo.

--- a/docs/local-auth0.md
+++ b/docs/local-auth0.md
@@ -1,0 +1,140 @@
+# Local Auth0 Setup (Backend + Frontend)
+
+This document explains where each OAuth/Auth0 value comes from, and provides a checklist to run the project locally
+without AWS (using LocalStack for S3 and Docker Compose for infra).
+
+## What Comes From Where
+
+Backend reads Auth0 settings via environment variables mapped in:
+- `/Users/boris/projects/bit-bi/data-forge-middleware/src/main/resources/application.yml`
+
+Frontend reads Auth0 settings via Vite env vars:
+- `/Users/boris/projects/bit-bi/data-forge-middleware/frontend/.env.local`
+
+Auth0 Dashboard provides the actual values (domain, API identifier, client IDs, secrets).
+
+## Required Values
+
+### Backend (.env)
+
+These values must exist for the backend to start in local/dev mode.
+
+- `AUTH0_DOMAIN`
+  - Source: Auth0 Dashboard -> Tenant domain
+  - Example: `dev-dfm.us.auth0.com`
+
+- `AUTH0_ISSUER`
+  - Source: derived from `AUTH0_DOMAIN`
+  - Rule: `https://<AUTH0_DOMAIN>/`
+  - Example: `https://dev-dfm.us.auth0.com/`
+  - Note: Spring also uses `https://${auth0.domain}/` for resource server issuer; these should match.
+
+- `AUTH0_AUDIENCE`
+  - Source: Auth0 Dashboard -> Applications -> APIs -> (Data Forge API) -> `Identifier`
+  - Example: `https://dev.dfm.bitbi.io`
+
+- `AUTH0_CLAIMS_NAMESPACE`
+  - Source: Auth0 Dashboard -> Actions -> (Add Roles to Access Token) -> `const namespace = '...'`
+  - Recommendation: set equal to `AUTH0_AUDIENCE` to keep it simple.
+  - Example: `https://dev.dfm.bitbi.io`
+
+- `AUTH0_MGMT_CLIENT_ID`
+- `AUTH0_MGMT_CLIENT_SECRET`
+  - Source: Auth0 Dashboard -> Applications -> Applications -> (Data Forge Management Client, Machine to Machine)
+  - Note: keep secret only in `.env` (gitignored). Do not commit.
+
+- `AUTH0_MGMT_AUDIENCE`
+  - Source: derived from `AUTH0_DOMAIN`
+  - Rule: `https://<AUTH0_DOMAIN>/api/v2/`
+  - Example: `https://dev-dfm.us.auth0.com/api/v2/`
+
+Optional but typical:
+- `AUTH0_TOKEN_EXPIRY_BUFFER_SECONDS` (default is fine)
+
+### Frontend (frontend/.env.local)
+
+- `VITE_AUTH0_DOMAIN`
+  - Source: same as `AUTH0_DOMAIN`
+
+- `VITE_AUTH0_CLIENT_ID`
+  - Source: Auth0 Dashboard -> Applications -> Applications -> (Data Forge Admin UI, SPA) -> `Client ID`
+
+- `VITE_AUTH0_AUDIENCE`
+  - Source: same as `AUTH0_AUDIENCE` (API Identifier)
+
+- `VITE_AUTH0_CLAIMS_NAMESPACE`
+  - Source: same as `AUTH0_CLAIMS_NAMESPACE`
+
+- `VITE_API_BASE_URL`
+  - For local: `http://localhost:8080`
+
+## Auth0 Dashboard Checklist
+
+### 1) API (Audience)
+
+Auth0 Dashboard:
+- Applications -> APIs -> (Data Forge API)
+- Confirm `Identifier` equals the value you set as `AUTH0_AUDIENCE` / `VITE_AUTH0_AUDIENCE`.
+
+### 2) SPA Application (Frontend)
+
+Auth0 Dashboard:
+- Applications -> Applications -> Data Forge Admin UI (Single Page Application)
+
+Settings to verify:
+- Allowed Callback URLs includes: `http://localhost:3000`
+- Allowed Logout URLs includes: `http://localhost:3000`
+- Allowed Web Origins includes: `http://localhost:3000`
+
+Copy:
+- `Domain` -> `VITE_AUTH0_DOMAIN`
+- `Client ID` -> `VITE_AUTH0_CLIENT_ID`
+
+### 3) M2M Application (Backend)
+
+Auth0 Dashboard:
+- Applications -> Applications -> Data Forge Management Client (Machine to Machine)
+
+Copy:
+- `Client ID` -> `AUTH0_MGMT_CLIENT_ID`
+- `Client Secret` -> `AUTH0_MGMT_CLIENT_SECRET`
+
+Also ensure it has access to Auth0 Management API scopes needed by backend account operations:
+- `read:users`, `create:users`, `update:users`, `delete:users`
+- `read:roles`, `read:role_members`, `create:role_members`, `delete:role_members`
+- `read:users_app_metadata`, `update:users_app_metadata`
+
+### 4) Post-Login Actions (Roles/Claims)
+
+Auth0 Dashboard:
+- Actions -> Flows -> Login
+
+Verify:
+- `Add Roles to Access Token` is enabled
+- It sets claims using a namespace matching `AUTH0_CLAIMS_NAMESPACE`
+  - roles claim key: `<namespace>/roles`
+  - account id claim key: `<namespace>/accountId`
+
+If you keep the `Account Linking` action in the flow, ensure its secrets are set in Auth0:
+- `domain`
+- `clientId`
+- `clientSecret`
+
+If these secrets are missing, logins may fail at Post-Login time.
+
+## Local Run (No AWS)
+
+Infra (Docker):
+- Use `docker-compose.dev.yml` (Postgres, Redis, LocalStack, Keycloak)
+
+Backend:
+- `./gradlew bootRun`
+
+Frontend:
+- `cd frontend && npm install && npm run dev`
+
+## Sanity Checks
+
+- Backend should start without Auth0 token validation errors.
+- Frontend login should succeed, and admin endpoints should return 200 for an ADMIN user.
+

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -17,6 +17,9 @@ VITE_AUTH0_CLIENT_ID=your-spa-client-id-here
 # Get from: Auth0 Dashboard → Applications → APIs → Data Forge API → Identifier
 VITE_AUTH0_AUDIENCE=https://api.dataforge.com
 
+# Custom claims namespace (must match backend AUTH0_CLAIMS_NAMESPACE and your Auth0 Action)
+VITE_AUTH0_CLAIMS_NAMESPACE=https://api.dataforge.com
+
 # ============================================
 # Backend API Configuration
 # ============================================
@@ -46,4 +49,4 @@ VITE_API_BASE_URL=http://localhost:8080
 #
 # 6. Open browser: http://localhost:3000
 #
-# For backend configuration see: ../.env.dev
+# For backend configuration see: ../.env.example

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -25,6 +25,7 @@ dist-ssr
 
 # Environment files
 .env.local
+.env.local.aws-*
 .env.*.local
 
 # Test coverage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "build:analyze": "vite-bundle-visualizer",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/frontend/public/env-config.js
+++ b/frontend/public/env-config.js
@@ -1,0 +1,15 @@
+(function () {
+  // Dev fallback.
+  //
+  // In containerized "production-like" deployments we generate /env-config.js at runtime
+  // to inject environment variables into the browser (window._env_).
+  //
+  // During local Vite development this file must still exist, otherwise the request to
+  // /env-config.js falls back to index.html and the browser throws a syntax error,
+  // preventing the app from rendering (blank page).
+  //
+  // We intentionally keep this empty so code falls back to import.meta.env values
+  // sourced from frontend/.env.local.
+  window._env_ = window._env_ || {};
+})();
+

--- a/frontend/src/entities/batch/api/batchApi.ts
+++ b/frontend/src/entities/batch/api/batchApi.ts
@@ -14,14 +14,17 @@ import {
   HISTORY_FILE_DOWNLOAD,
   HISTORY_ZIP_DOWNLOAD,
   HISTORY_EXCEL_EXPORT,
-  HISTORY_ERRORS
+  HISTORY_ERRORS,
+  BATCHES_ADMIN_CLEANUP
 } from '@/shared/api/apiRoutes';
 import type {
   BatchSummary,
   BatchDetail,
   CursorPageResponse,
   PageResponse,
-  ErrorSummary
+  ErrorSummary,
+  BatchCleanupRequest,
+  BatchCleanupResult
 } from '../model/types';
 
 /**
@@ -185,5 +188,20 @@ export async function getBatchErrors(
     `${HISTORY_ERRORS(batchId)}?${params.toString()}`
   );
 
+  return response.data;
+}
+
+/**
+ * Admin: Run batch cleanup with filters.
+ *
+ * POST /api/v1/batches/cleanup
+ */
+export async function runBatchCleanup(
+  request: BatchCleanupRequest
+): Promise<BatchCleanupResult> {
+  const response = await apiClient.post<BatchCleanupResult>(
+    BATCHES_ADMIN_CLEANUP,
+    request
+  );
   return response.data;
 }

--- a/frontend/src/entities/batch/model/types.ts
+++ b/frontend/src/entities/batch/model/types.ts
@@ -162,3 +162,26 @@ export interface ErrorSummary {
   /** Error occurrence timestamp (ISO-8601) */
   occurredAt: string;
 }
+
+/**
+ * Batch cleanup request (admin).
+ */
+export interface BatchCleanupRequest {
+  siteId?: string;
+  accountId?: string;
+  retentionDays?: number;
+  olderThan?: string;
+  limit?: number;
+  dryRun?: boolean;
+}
+
+/**
+ * Batch cleanup result summary (admin).
+ */
+export interface BatchCleanupResult {
+  candidates: number;
+  deletedBatches: number;
+  deletedFiles: number;
+  deletedBytes: number;
+  errors: string[];
+}

--- a/frontend/src/entities/site/api/siteApi.ts
+++ b/frontend/src/entities/site/api/siteApi.ts
@@ -17,7 +17,8 @@ import {
   SITES_CREATE,
   SITES_ACTIVATE,
   SITES_DEACTIVATE,
-  SITES_DELETE_BY_ACCOUNT
+  SITES_DELETE_BY_ACCOUNT,
+  SITES_RETENTION
 } from '@/shared/api/apiRoutes';
 import type { Site, CreateSiteRequest, CreateSiteResponse } from '../model/types';
 
@@ -166,4 +167,18 @@ export async function activateAdminSite(accountId: string, siteId: string): Prom
  */
 export async function deleteAdminSite(accountId: string, siteId: string): Promise<void> {
   await apiClient.delete(SITES_DELETE_BY_ACCOUNT(accountId, siteId));
+}
+
+/**
+ * Update site retention policy (admin operation).
+ *
+ * PATCH /api/v1/sites/{siteId}/retention
+ *
+ * @param siteId - Site identifier
+ * @param retentionDays - Retention period in days
+ * @returns Updated site entity
+ */
+export async function updateAdminSiteRetention(siteId: string, retentionDays: number): Promise<Site> {
+  const response = await apiClient.patch<Site>(SITES_RETENTION(siteId), { retentionDays });
+  return response.data;
 }

--- a/frontend/src/entities/site/index.ts
+++ b/frontend/src/entities/site/index.ts
@@ -24,4 +24,5 @@ export {
   deactivateAdminSite,
   activateAdminSite,
   deleteAdminSite,
+  updateAdminSiteRetention,
 } from './api/siteApi';

--- a/frontend/src/entities/site/model/types.ts
+++ b/frontend/src/entities/site/model/types.ts
@@ -14,6 +14,7 @@
  * @property domain - Site domain name for display (e.g., "example.com", without accountId prefix)
  * @property name - Display name for the site
  * @property isActive - Activation status (true = active, false = inactive/deleted)
+ * @property retentionDays - Retention period in days for batch cleanup
  * @property createdAt - Creation timestamp (ISO 8601 string)
  */
 export interface Site {
@@ -22,6 +23,7 @@ export interface Site {
   domain: string; // Display domain only (FR-019)
   name: string;
   isActive: boolean;
+  retentionDays: number;
   createdAt: string;
 }
 
@@ -67,4 +69,5 @@ export enum AdminActionType {
   DEACTIVATE_SITE = 'DEACTIVATE_SITE',
   ACTIVATE_SITE = 'ACTIVATE_SITE',
   DELETE_SITE = 'DELETE_SITE',
+  UPDATE_SITE_RETENTION = 'UPDATE_SITE_RETENTION',
 }

--- a/frontend/src/features/batch-cleanup/ui/BatchCleanupPanel.test.tsx
+++ b/frontend/src/features/batch-cleanup/ui/BatchCleanupPanel.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { BatchCleanupPanel } from './BatchCleanupPanel'
+import * as siteQueries from '@/features/site-crud/model/queries'
+import * as batchApi from '@/entities/batch/api/batchApi'
+
+vi.mock('@/features/site-crud/model/queries', () => ({
+  useAdminSites: vi.fn(),
+}))
+
+vi.mock('@/entities/batch/api/batchApi', () => ({
+  runBatchCleanup: vi.fn(),
+}))
+
+const mockSites = [
+  {
+    id: 'site-1',
+    accountId: 'account-1',
+    domain: 'example.com',
+    name: 'Example',
+    isActive: true,
+    retentionDays: 45,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+  {
+    id: 'site-2',
+    accountId: 'account-1',
+    domain: 'shop.example.com',
+    name: 'Shop',
+    isActive: true,
+    retentionDays: 45,
+    createdAt: '2025-01-01T00:00:00Z',
+  },
+]
+
+describe('BatchCleanupPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(siteQueries.useAdminSites).mockReturnValue({
+      data: mockSites,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as ReturnType<typeof siteQueries.useAdminSites>)
+  })
+
+  it('runs dry run cleanup with provided filters', async () => {
+    vi.mocked(batchApi.runBatchCleanup).mockResolvedValue({
+      candidates: 2,
+      deletedBatches: 0,
+      deletedFiles: 0,
+      deletedBytes: 0,
+      errors: [],
+    })
+
+    render(<BatchCleanupPanel accountId="account-1" />)
+
+    const siteSelect = screen.getByLabelText('Site')
+    await userEvent.selectOptions(siteSelect, 'site-2')
+
+    await userEvent.type(screen.getByLabelText('Retention Days (override)'), '30')
+    await userEvent.type(screen.getByLabelText('Older Than (override)'), '2025-01-15T10:30')
+
+    const limitInput = screen.getByLabelText('Limit')
+    await userEvent.clear(limitInput)
+    await userEvent.type(limitInput, '500')
+
+    await userEvent.click(screen.getByRole('button', { name: /run dry run/i }))
+
+    await waitFor(() => {
+      expect(batchApi.runBatchCleanup).toHaveBeenCalledWith({
+        accountId: 'account-1',
+        siteId: 'site-2',
+        retentionDays: 30,
+        olderThan: '2025-01-15T10:30:00',
+        limit: 500,
+        dryRun: true,
+      })
+    })
+
+    expect(await screen.findByText('Candidates: 2')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/batch-cleanup/ui/BatchCleanupPanel.tsx
+++ b/frontend/src/features/batch-cleanup/ui/BatchCleanupPanel.tsx
@@ -1,0 +1,154 @@
+import { useMemo, useState } from 'react';
+import { useAdminSites } from '@/features/site-crud/model/queries';
+import { runBatchCleanup } from '@/entities/batch/api/batchApi';
+import type { BatchCleanupResult } from '@/entities/batch/model/types';
+import { Button } from '@/shared/ui/ui/button';
+import { Card, CardContent } from '@/shared/ui/ui/card';
+import { Label } from '@/shared/ui/ui/label';
+import { Input } from '@/shared/ui/ui/input';
+import { toast } from 'sonner';
+
+interface BatchCleanupPanelProps {
+  accountId: string;
+}
+
+export function BatchCleanupPanel({ accountId }: BatchCleanupPanelProps) {
+  const { data: sites } = useAdminSites(accountId);
+  const [siteId, setSiteId] = useState<string>('');
+  const [retentionDays, setRetentionDays] = useState<string>('');
+  const [olderThan, setOlderThan] = useState<string>('');
+  const [limit, setLimit] = useState<string>('1000');
+  const [isRunning, setIsRunning] = useState<boolean>(false);
+  const [result, setResult] = useState<BatchCleanupResult | null>(null);
+
+  const siteOptions = useMemo(() => {
+    if (!sites) return [];
+    return sites.map((site) => ({ id: site.id, label: site.domain }));
+  }, [sites]);
+
+  const runCleanup = async (executeDryRun: boolean) => {
+    setIsRunning(true);
+    setResult(null);
+
+    try {
+      const normalizedOlderThan =
+        olderThan && olderThan.length === 16 ? `${olderThan}:00` : olderThan || undefined;
+      const response = await runBatchCleanup({
+        accountId,
+        siteId: siteId || undefined,
+        retentionDays: retentionDays ? Number(retentionDays) : undefined,
+        olderThan: normalizedOlderThan,
+        limit: limit ? Number(limit) : undefined,
+        dryRun: executeDryRun,
+      });
+      setResult(response);
+      toast.success(executeDryRun ? 'Dry run completed' : 'Cleanup completed');
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || 'Cleanup failed');
+    } finally {
+      setIsRunning(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-6 space-y-4">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900">Batch Cleanup</h3>
+          <p className="text-sm text-muted-foreground">
+            Run retention cleanup for this user’s sites. Use dry run to preview candidates.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="cleanup-site">Site</Label>
+            <select
+              id="cleanup-site"
+              className="h-9 w-full rounded border border-gray-200 px-3 text-sm"
+              value={siteId}
+              onChange={(event) => setSiteId(event.target.value)}
+              disabled={isRunning}
+            >
+              <option value="">All sites</option>
+              {siteOptions.map((site) => (
+                <option key={site.id} value={site.id}>
+                  {site.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="cleanup-retention">Retention Days (override)</Label>
+            <Input
+              id="cleanup-retention"
+              type="number"
+              min={1}
+              max={3650}
+              placeholder="Use site default"
+              value={retentionDays}
+              onChange={(event) => setRetentionDays(event.target.value)}
+              disabled={isRunning}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="cleanup-older-than">Older Than (override)</Label>
+            <Input
+              id="cleanup-older-than"
+              type="datetime-local"
+              value={olderThan}
+              onChange={(event) => setOlderThan(event.target.value)}
+              disabled={isRunning}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="cleanup-limit">Limit</Label>
+            <Input
+              id="cleanup-limit"
+              type="number"
+              min={1}
+              max={10000}
+              value={limit}
+              onChange={(event) => setLimit(event.target.value)}
+              disabled={isRunning}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            variant="outline"
+            onClick={() => runCleanup(true)}
+            disabled={isRunning}
+          >
+            Run Dry Run
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => runCleanup(false)}
+            disabled={isRunning}
+          >
+            Run Cleanup
+          </Button>
+        </div>
+
+        {result && (
+          <div className="rounded border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+            <div>Candidates: {result.candidates}</div>
+            <div>Deleted batches: {result.deletedBatches}</div>
+            <div>Deleted files: {result.deletedFiles}</div>
+            <div>Deleted bytes: {result.deletedBytes.toLocaleString()}</div>
+            {result.errors.length > 0 && (
+              <div className="mt-2 text-red-600">
+                Errors: {result.errors.join(' | ')}
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/site-crud/model/queries.ts
+++ b/frontend/src/features/site-crud/model/queries.ts
@@ -19,6 +19,7 @@ import {
   deactivateAdminSite,
   activateAdminSite,
   deleteAdminSite,
+  updateAdminSiteRetention,
   type Site,
   type CreateSiteRequest,
 } from '@/entities/site';
@@ -234,6 +235,52 @@ export function useAdminDeleteSite(accountId: string) {
   return useMutation({
     mutationFn: (siteId: string) => deleteAdminSite(accountId, siteId),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: siteKeys.list(accountId) });
+    },
+  });
+}
+
+/**
+ * Update site retention policy (admin operation).
+ *
+ * @param accountId - Account identifier
+ * @returns Mutation for updating retention days
+ */
+export function useAdminUpdateSiteRetention(accountId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      siteId,
+      retentionDays,
+    }: {
+      siteId: string;
+      retentionDays: number;
+    }): Promise<Site> => {
+      return updateAdminSiteRetention(siteId, retentionDays);
+    },
+    onMutate: async ({ siteId, retentionDays }) => {
+      await queryClient.cancelQueries({ queryKey: siteKeys.list(accountId) });
+
+      const previousSites = queryClient.getQueryData<Site[]>(siteKeys.list(accountId));
+
+      if (previousSites) {
+        queryClient.setQueryData<Site[]>(
+          siteKeys.list(accountId),
+          previousSites.map((site) =>
+            site.id === siteId ? { ...site, retentionDays } : site
+          )
+        );
+      }
+
+      return { previousSites };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousSites) {
+        queryClient.setQueryData(siteKeys.list(accountId), context.previousSites);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: siteKeys.list(accountId) });
     },
   });

--- a/frontend/src/pages/admin/user-sites/UserSitesPage.tsx
+++ b/frontend/src/pages/admin/user-sites/UserSitesPage.tsx
@@ -20,6 +20,7 @@ import { CreateSiteForm } from '@/features/site-crud/ui/CreateSiteForm'
 import { SiteList } from '@/widgets/site-list/SiteList'
 import { Separator } from '@/shared/ui/ui/separator'
 import { useAccountQuery } from '@/features/user-management/api/userQueries'
+import { BatchCleanupPanel } from '@/features/batch-cleanup/ui/BatchCleanupPanel'
 
 export default function UserSitesPage() {
   const { id: accountId } = useParams({ from: '/admin/users/$id/sites' })
@@ -87,6 +88,13 @@ export default function UserSitesPage() {
         <section className="mb-8">
           <h2 className="text-xl font-semibold text-gray-900 mb-4">Create New Site</h2>
           <CreateSiteForm accountId={accountId} />
+        </section>
+
+        <Separator className="my-8" />
+
+        {/* Batch cleanup panel */}
+        <section className="mb-8">
+          <BatchCleanupPanel accountId={accountId} />
         </section>
 
         <Separator className="my-8" />

--- a/frontend/src/pages/device-verify/DeviceVerifyPage.tsx
+++ b/frontend/src/pages/device-verify/DeviceVerifyPage.tsx
@@ -42,6 +42,16 @@ export default function DeviceVerifyPage() {
   const [errorMessage, setErrorMessage] = useState<string>('');
   const [createdSiteName, setCreatedSiteName] = useState<string | null>(null);
 
+  // Sync userCode state when URL code parameter changes (e.g. navigating from one device-verify to another)
+  useEffect(() => {
+    if (userCodeFromUrl && userCodeFromUrl !== userCode) {
+      setUserCode(userCodeFromUrl);
+      setPageState('confirm');
+      setErrorMessage('');
+      setCreatedSiteName(null);
+    }
+  }, [userCodeFromUrl]);
+
   // Fetch verification info when user code is provided
   const {
     data: verifyInfo,
@@ -62,11 +72,10 @@ export default function DeviceVerifyPage() {
         ?.response?.data?.error_description ||
         (verifyInfoError as { response?: { data?: { message?: string } } })?.response?.data?.message;
 
-      // 400 = Authorization already processed (approved or denied)
+      // 400 = Authorization already processed (approved or denied) - show error, not success
       if (status === 400) {
-        setPageState('success');
-        setCreatedSiteName(null); // We don't know the site name, but it was likely already created
-        setErrorMessage('');
+        setPageState('error');
+        setErrorMessage('This authorization code has already been processed. Please start a new authorization from your device.');
         return;
       }
 

--- a/frontend/src/shared/api/apiRoutes.ts
+++ b/frontend/src/shared/api/apiRoutes.ts
@@ -74,6 +74,7 @@ export const SITES_USER_DEACTIVATE = (id: string) => `${SITES_USER}/${id}/deacti
 export const SITES = `${ADMIN_API_BASE}/sites`;
 export const SITES_ID = (id: string) => `${SITES}/${id}`;
 export const SITES_STATISTICS = (id: string) => `${SITES}/${id}/statistics`;
+export const SITES_RETENTION = (id: string) => `${SITES}/${id}/retention`;
 export const SITES_BY_ACCOUNT = (accountId: string) => `${ACCOUNTS}/${accountId}/sites`;
 export const SITES_CREATE = (accountId: string) => `${ACCOUNTS}/${accountId}/sites`;
 export const SITES_ACTIVATE = (accountId: string, siteId: string) => `${ACCOUNTS}/${accountId}/sites/${siteId}/activate`;
@@ -83,6 +84,7 @@ export const SITES_DELETE_BY_ACCOUNT = (accountId: string, siteId: string) => `$
 // Batches (Admin)
 export const BATCHES_ADMIN = `${ADMIN_API_BASE}/batches`;
 export const BATCHES_ADMIN_ID = (id: string) => `${BATCHES_ADMIN}/${id}`;
+export const BATCHES_ADMIN_CLEANUP = `${BATCHES_ADMIN}/cleanup`;
 
 // History (User-facing)
 export const HISTORY = `${ADMIN_API_BASE}/history`;

--- a/frontend/src/widgets/site-list/SiteList.tsx
+++ b/frontend/src/widgets/site-list/SiteList.tsx
@@ -19,6 +19,7 @@ import {
   useAdminSites,
   useUpdateSiteStatus,
   useAdminUpdateSiteStatus,
+  useAdminUpdateSiteRetention,
   useDeleteSite,
   useAdminDeleteSite
 } from '@/features/site-crud/model/queries';
@@ -61,6 +62,8 @@ export function SiteList({ accountId, compact = false }: SiteListProps) {
   const adminDeleteMutation = accountId ? useAdminDeleteSite(accountId) : null;
   const deleteSiteMutation = adminDeleteMutation || userDeleteMutation;
 
+  const adminRetentionMutation = accountId ? useAdminUpdateSiteRetention(accountId) : null;
+
   const handleActivate = async (siteId: string) => {
     try {
       await updateStatusMutation.mutateAsync({ siteId, isActive: true });
@@ -85,6 +88,16 @@ export function SiteList({ accountId, compact = false }: SiteListProps) {
       toast.success('Site deleted successfully');
     } catch (error: any) {
       toast.error(error?.response?.data?.message || 'Failed to delete site');
+    }
+  };
+
+  const handleRetentionUpdate = async (siteId: string, retentionDays: number) => {
+    if (!adminRetentionMutation) return;
+    try {
+      await adminRetentionMutation.mutateAsync({ siteId, retentionDays });
+      toast.success('Retention policy updated');
+    } catch (error: any) {
+      toast.error(error?.response?.data?.message || 'Failed to update retention policy');
     }
   };
 
@@ -136,7 +149,13 @@ export function SiteList({ accountId, compact = false }: SiteListProps) {
           onActivate={handleActivate}
           onDeactivate={handleDeactivate}
           onDelete={handleDelete}
-          isLoading={updateStatusMutation.isPending || deleteSiteMutation.isPending}
+          onUpdateRetention={accountId ? handleRetentionUpdate : undefined}
+          showRetentionControls={!!accountId}
+          isLoading={
+            updateStatusMutation.isPending ||
+            deleteSiteMutation.isPending ||
+            (adminRetentionMutation?.isPending ?? false)
+          }
         />
       ))}
     </div>

--- a/frontend/src/widgets/site-list/ui/SiteListItem.test.tsx
+++ b/frontend/src/widgets/site-list/ui/SiteListItem.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SiteListItem } from './SiteListItem'
+import type { Site } from '@/entities/site/model/types'
+
+describe('SiteListItem retention controls', () => {
+  const site: Site = {
+    id: 'site-1',
+    accountId: 'account-1',
+    domain: 'example.com',
+    name: 'Example',
+    isActive: true,
+    retentionDays: 45,
+    createdAt: '2025-01-01T00:00:00Z',
+  }
+
+  it('enables save when retention days change', async () => {
+    const onUpdateRetention = vi.fn()
+
+    render(
+      <SiteListItem
+        site={site}
+        showRetentionControls
+        onUpdateRetention={onUpdateRetention}
+      />
+    )
+
+    const saveButton = screen.getByRole('button', { name: /save/i })
+    expect(saveButton).toBeDisabled()
+
+    const input = screen.getByRole('spinbutton')
+    await userEvent.clear(input)
+    await userEvent.type(input, '30')
+
+    expect(saveButton).toBeEnabled()
+    await userEvent.click(saveButton)
+
+    expect(onUpdateRetention).toHaveBeenCalledWith('site-1', 30)
+  })
+})

--- a/frontend/src/widgets/site-list/ui/SiteListItem.tsx
+++ b/frontend/src/widgets/site-list/ui/SiteListItem.tsx
@@ -10,7 +10,7 @@
  * Feature: 007-adding-a-site (T036, US1, US2, US3)
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@/shared/ui/ui/button';
 import { Badge } from '@/shared/ui/ui/badge';
 import {
@@ -33,6 +33,8 @@ interface SiteListItemProps {
   onActivate?: (siteId: string) => void;
   onDeactivate?: (siteId: string) => void;
   onDelete?: (siteId: string) => void;
+  onUpdateRetention?: (siteId: string, retentionDays: number) => void;
+  showRetentionControls?: boolean;
   isLoading?: boolean;
 }
 
@@ -41,10 +43,17 @@ export function SiteListItem({
   onActivate,
   onDeactivate,
   onDelete,
+  onUpdateRetention,
+  showRetentionControls = false,
   isLoading = false,
 }: SiteListItemProps) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showDeactivateDialog, setShowDeactivateDialog] = useState(false);
+  const [retentionInput, setRetentionInput] = useState(String(site.retentionDays));
+
+  useEffect(() => {
+    setRetentionInput(String(site.retentionDays));
+  }, [site.retentionDays]);
 
   const handleStatusToggle = () => {
     if (site.isActive) {
@@ -62,6 +71,13 @@ export function SiteListItem({
   const handleDelete = () => {
     onDelete?.(site.id);
     setShowDeleteDialog(false);
+  };
+
+  const handleRetentionSave = () => {
+    if (!onUpdateRetention) return;
+    const parsedRetention = Number(retentionInput);
+    if (!Number.isFinite(parsedRetention) || parsedRetention <= 0) return;
+    onUpdateRetention(site.id, parsedRetention);
   };
 
   return (
@@ -91,6 +107,33 @@ export function SiteListItem({
               <p className="text-xs text-muted-foreground mt-1">
                 Created {format(new Date(site.createdAt), 'PPP')}
               </p>
+              {showRetentionControls && (
+                <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                  <span>Retention (days):</span>
+                  <input
+                    type="number"
+                    min={1}
+                    max={3650}
+                    className="h-7 w-20 rounded border border-gray-200 px-2 text-xs text-gray-900"
+                    value={retentionInput}
+                    onChange={(event) => setRetentionInput(event.target.value)}
+                    disabled={isLoading}
+                  />
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleRetentionSave}
+                    disabled={
+                      isLoading ||
+                      !Number.isFinite(Number(retentionInput)) ||
+                      Number(retentionInput) <= 0 ||
+                      Number(retentionInput) === site.retentionDays
+                    }
+                  >
+                    Save
+                  </Button>
+                </div>
+              )}
             </div>
 
             {/* Actions */}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,9 @@ export default defineConfig({
   },
   server: {
     port: 3000,
+    // In devcontainers (and some host environments) Vite may bind only to IPv6 (::1),
+    // which breaks port forwarding to localhost. Bind to all interfaces by default.
+    host: true,
     proxy: {
       '/api': {
         target: 'http://localhost:8080',

--- a/src/main/java/com/bitbi/dfm/account/domain/AdminActionLog.java
+++ b/src/main/java/com/bitbi/dfm/account/domain/AdminActionLog.java
@@ -111,8 +111,8 @@ public class AdminActionLog {
     public static AdminActionLog successForSite(AdminActionType actionType, UUID targetAccountId,
                                                  UUID targetSiteId, UUID adminAccountId,
                                                  String ipAddress, String userAgent) {
-        return new AdminActionLog(actionType, targetAccountId, adminAccountId,
-                targetSiteId, ActionStatus.SUCCESS, null, ipAddress, userAgent);
+        return new AdminActionLog(actionType, targetAccountId, targetSiteId,
+                adminAccountId, ActionStatus.SUCCESS, null, ipAddress, userAgent);
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/account/domain/AdminActionType.java
+++ b/src/main/java/com/bitbi/dfm/account/domain/AdminActionType.java
@@ -17,7 +17,8 @@ public enum AdminActionType {
     CREATE_SITE("Create Site"),
     DEACTIVATE_SITE("Deactivate Site"),
     ACTIVATE_SITE("Activate Site"),
-    DELETE_SITE("Delete Site");
+    DELETE_SITE("Delete Site"),
+    UPDATE_SITE_RETENTION("Update Site Retention Policy");
 
     private final String displayName;
 

--- a/src/main/java/com/bitbi/dfm/account/domain/AdminActionType.java
+++ b/src/main/java/com/bitbi/dfm/account/domain/AdminActionType.java
@@ -18,7 +18,8 @@ public enum AdminActionType {
     DEACTIVATE_SITE("Deactivate Site"),
     ACTIVATE_SITE("Activate Site"),
     DELETE_SITE("Delete Site"),
-    UPDATE_SITE_RETENTION("Update Site Retention Policy");
+    UPDATE_SITE_RETENTION("Update Site Retention Policy"),
+    BATCH_CLEANUP("Batch Cleanup");
 
     private final String displayName;
 

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduler.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduler.java
@@ -1,0 +1,51 @@
+package com.bitbi.dfm.batch.application;
+
+import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupRequest;
+import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Scheduled task to cleanup expired batches based on retention policies.
+ */
+@Component
+public class BatchRetentionScheduler {
+
+    private static final Logger logger = LoggerFactory.getLogger(BatchRetentionScheduler.class);
+
+    private final BatchRetentionService batchRetentionService;
+    private final int cleanupLimit;
+
+    public BatchRetentionScheduler(
+            BatchRetentionService batchRetentionService,
+            @Value("${batch.retention.cleanup-limit:1000}") int cleanupLimit) {
+        this.batchRetentionService = batchRetentionService;
+        this.cleanupLimit = cleanupLimit;
+    }
+
+    /**
+     * Run retention cleanup.
+     * <p>
+     * Default schedule: daily at 02:00.
+     * Override with batch.retention.cron.
+     * </p>
+     */
+    @Scheduled(cron = "${batch.retention.cron:0 0 2 * * *}")
+    public void runRetentionCleanup() {
+        logger.info("Starting retention cleanup job (limit={})", cleanupLimit);
+
+        try {
+            BatchCleanupSummary summary = batchRetentionService.runCleanup(
+                    new BatchCleanupRequest(null, null, null, null, cleanupLimit, false)
+            );
+
+            logger.info("Retention cleanup completed: candidates={}, deletedBatches={}, deletedFiles={}, deletedBytes={}, errors={}",
+                    summary.candidates(), summary.deletedBatches(), summary.deletedFiles(), summary.deletedBytes(), summary.errors().size());
+        } catch (Exception e) {
+            logger.error("Retention cleanup job failed: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionService.java
@@ -80,6 +80,9 @@ public class BatchRetentionService {
         dbResult.summary.deletedFiles += dedupedKeys.size();
 
         if (!dryRun) {
+            // We delete from the DB first, then best-effort delete from S3.
+            // Tradeoff: if S3 deletion fails, it can leave orphaned objects (no DB references),
+            // but avoids the more harmful "DB references missing objects" state.
             DeleteObjectsResult deleteResult = s3FileStorageService.deleteObjects(dedupedKeys);
             if (!deleteResult.errors().isEmpty()) {
                 dbResult.summary.errors.add("S3 delete errors: " + deleteResult.errors());
@@ -100,32 +103,36 @@ public class BatchRetentionService {
         for (Batch batch : candidates) {
             UUID batchId = batch.getId();
             try {
+                // Collect keys/sizes first, but only add them to the global delete list after DB deletion succeeds.
+                // This avoids a "DB still has records but files are gone" state if the DB stage fails.
                 List<UploadedFileRepository.FileKeySize> uploadedKeys = uploadedFileRepository.findS3KeysByBatchId(batchId);
                 List<PluginSqlGenerationRepository.S3KeySize> sqlKeys = sqlGenerationRepository.findS3KeysByBatchId(batchId);
 
-                long totalBytes = 0L;
+                List<String> batchS3Keys = new ArrayList<>();
+                long batchBytes = 0L;
 
                 for (UploadedFileRepository.FileKeySize fileKey : uploadedKeys) {
                     if (fileKey.getS3Key() != null) {
-                        s3Keys.add(fileKey.getS3Key());
+                        batchS3Keys.add(fileKey.getS3Key());
                     }
                     if (fileKey.getFileSize() != null) {
-                        totalBytes += fileKey.getFileSize();
+                        batchBytes += fileKey.getFileSize();
                     }
                 }
 
                 for (PluginSqlGenerationRepository.S3KeySize sqlKey : sqlKeys) {
                     if (sqlKey.getS3Key() != null) {
-                        s3Keys.add(sqlKey.getS3Key());
+                        batchS3Keys.add(sqlKey.getS3Key());
                     }
                     if (sqlKey.getFileSizeBytes() != null) {
-                        totalBytes += sqlKey.getFileSizeBytes();
+                        batchBytes += sqlKey.getFileSizeBytes();
                     }
                 }
 
-                summary.deletedBytes += totalBytes;
-
                 if (dryRun) {
+                    // Dry run reports what would be removed, but doesn't perform any deletions.
+                    summary.deletedBytes += batchBytes;
+                    s3Keys.addAll(batchS3Keys);
                     continue;
                 }
 
@@ -135,6 +142,8 @@ public class BatchRetentionService {
 
                 batchRepository.deleteById(batchId);
                 summary.deletedBatches++;
+                summary.deletedBytes += batchBytes;
+                s3Keys.addAll(batchS3Keys);
             } catch (Exception e) {
                 logger.error("Failed to cleanup batch in DB: batchId={}, error={}", batchId, e.getMessage(), e);
                 summary.errors.add("Batch " + batchId + " cleanup failed: " + e.getMessage());

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionService.java
@@ -1,0 +1,212 @@
+package com.bitbi.dfm.batch.application;
+
+import com.bitbi.dfm.batch.domain.Batch;
+import com.bitbi.dfm.batch.infrastructure.JpaBatchRepository;
+import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
+import com.bitbi.dfm.plugin.infrastructure.persistence.JpaPluginSqlGenerationRepository;
+import com.bitbi.dfm.site.domain.Site;
+import com.bitbi.dfm.site.infrastructure.JpaSiteRepository;
+import com.bitbi.dfm.upload.domain.UploadedFileRepository;
+import com.bitbi.dfm.upload.infrastructure.JpaUploadedFileRepository;
+import com.bitbi.dfm.upload.infrastructure.S3FileStorageService;
+import com.bitbi.dfm.upload.infrastructure.S3FileStorageService.DeleteObjectsResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class BatchRetentionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(BatchRetentionService.class);
+    private static final int DEFAULT_LIMIT = 1000;
+
+    private final JpaBatchRepository batchRepository;
+    private final JpaSiteRepository siteRepository;
+    private final JpaUploadedFileRepository uploadedFileRepository;
+    private final JpaPluginSqlGenerationRepository sqlGenerationRepository;
+    private final S3FileStorageService s3FileStorageService;
+
+    public BatchRetentionService(
+            JpaBatchRepository batchRepository,
+            JpaSiteRepository siteRepository,
+            JpaUploadedFileRepository uploadedFileRepository,
+            JpaPluginSqlGenerationRepository sqlGenerationRepository,
+            S3FileStorageService s3FileStorageService) {
+        this.batchRepository = batchRepository;
+        this.siteRepository = siteRepository;
+        this.uploadedFileRepository = uploadedFileRepository;
+        this.sqlGenerationRepository = sqlGenerationRepository;
+        this.s3FileStorageService = s3FileStorageService;
+    }
+
+    public BatchCleanupSummary runCleanup(BatchCleanupRequest request) {
+        Objects.requireNonNull(request, "request cannot be null");
+        int limit = request.limit() != null && request.limit() > 0 ? request.limit() : DEFAULT_LIMIT;
+        boolean dryRun = request.dryRun() != null && request.dryRun();
+
+        List<Site> sites = resolveSites(request.siteId(), request.accountId());
+        if (sites.isEmpty()) {
+            return BatchCleanupSummary.empty();
+        }
+
+        BatchCleanupSummary summary = new BatchCleanupSummary();
+        int remaining = limit;
+
+        for (Site site : sites) {
+            if (remaining <= 0) {
+                break;
+            }
+            int retentionDays = request.retentionDays() != null ? request.retentionDays() : site.getRetentionDays();
+            LocalDateTime cutoff = request.olderThan() != null
+                    ? request.olderThan()
+                    : LocalDateTime.now().minusDays(retentionDays);
+
+            BatchCleanupSummary siteSummary = cleanupSite(site.getId(), cutoff, remaining, dryRun);
+            summary.merge(siteSummary);
+            remaining -= siteSummary.candidates;
+        }
+
+        return summary;
+    }
+
+    @Transactional
+    protected BatchCleanupSummary cleanupSite(UUID siteId, LocalDateTime cutoff, int limit, boolean dryRun) {
+        List<Batch> candidates = batchRepository.findCleanupCandidatesForSite(siteId, cutoff, limit);
+        BatchCleanupSummary summary = new BatchCleanupSummary();
+        summary.candidates = candidates.size();
+
+        for (Batch batch : candidates) {
+            UUID batchId = batch.getId();
+            try {
+                List<UploadedFileRepository.FileKeySize> uploadedKeys = uploadedFileRepository.findS3KeysByBatchId(batchId);
+                List<PluginSqlGenerationRepository.S3KeySize> sqlKeys = sqlGenerationRepository.findS3KeysByBatchId(batchId);
+
+                List<String> s3Keys = new ArrayList<>();
+                long totalBytes = 0L;
+
+                for (UploadedFileRepository.FileKeySize fileKey : uploadedKeys) {
+                    if (fileKey.getS3Key() != null) {
+                        s3Keys.add(fileKey.getS3Key());
+                    }
+                    if (fileKey.getFileSize() != null) {
+                        totalBytes += fileKey.getFileSize();
+                    }
+                }
+
+                for (PluginSqlGenerationRepository.S3KeySize sqlKey : sqlKeys) {
+                    if (sqlKey.getS3Key() != null) {
+                        s3Keys.add(sqlKey.getS3Key());
+                    }
+                    if (sqlKey.getFileSizeBytes() != null) {
+                        totalBytes += sqlKey.getFileSizeBytes();
+                    }
+                }
+
+                List<String> dedupedKeys = deduplicate(s3Keys);
+
+                if (dryRun) {
+                    summary.deletedFiles += dedupedKeys.size();
+                    summary.deletedBytes += totalBytes;
+                    continue;
+                }
+
+                DeleteObjectsResult deleteResult = s3FileStorageService.deleteObjects(dedupedKeys);
+                if (!deleteResult.errors().isEmpty()) {
+                    summary.errors.add("Batch " + batchId + " S3 delete errors: " + deleteResult.errors());
+                    continue;
+                }
+
+                sqlGenerationRepository.deleteByComparisonBatchId(batchId);
+                ((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository).deleteById(batchId);
+
+                summary.deletedBatches++;
+                summary.deletedFiles += dedupedKeys.size();
+                summary.deletedBytes += totalBytes;
+            } catch (Exception e) {
+                logger.error("Failed to cleanup batch: batchId={}, error={}", batchId, e.getMessage(), e);
+                summary.errors.add("Batch " + batchId + " cleanup failed: " + e.getMessage());
+            }
+        }
+
+        return summary;
+    }
+
+    private List<Site> resolveSites(UUID siteId, UUID accountId) {
+        if (siteId != null) {
+            return ((com.bitbi.dfm.site.domain.SiteRepository) siteRepository)
+                    .findById(siteId)
+                    .map(List::of)
+                    .orElse(List.of());
+        }
+        if (accountId != null) {
+            return siteRepository.findByAccountId(accountId);
+        }
+        return siteRepository.findAll();
+    }
+
+    private List<String> deduplicate(List<String> keys) {
+        if (keys == null || keys.isEmpty()) {
+            return List.of();
+        }
+        Set<String> deduped = new HashSet<>(keys);
+        return new ArrayList<>(deduped);
+    }
+
+    public record BatchCleanupRequest(
+            UUID siteId,
+            UUID accountId,
+            Integer retentionDays,
+            LocalDateTime olderThan,
+            Integer limit,
+            Boolean dryRun
+    ) {}
+
+    public static class BatchCleanupSummary {
+        private int candidates;
+        private int deletedBatches;
+        private int deletedFiles;
+        private long deletedBytes;
+        private final List<String> errors = new ArrayList<>();
+
+        public static BatchCleanupSummary empty() {
+            return new BatchCleanupSummary();
+        }
+
+        public void merge(BatchCleanupSummary other) {
+            this.candidates += other.candidates;
+            this.deletedBatches += other.deletedBatches;
+            this.deletedFiles += other.deletedFiles;
+            this.deletedBytes += other.deletedBytes;
+            this.errors.addAll(other.errors);
+        }
+
+        public int candidates() {
+            return candidates;
+        }
+
+        public int deletedBatches() {
+            return deletedBatches;
+        }
+
+        public int deletedFiles() {
+            return deletedFiles;
+        }
+
+        public long deletedBytes() {
+            return deletedBytes;
+        }
+
+        public List<String> errors() {
+            return errors;
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionService.java
@@ -1,13 +1,10 @@
 package com.bitbi.dfm.batch.application;
 
 import com.bitbi.dfm.batch.domain.Batch;
-import com.bitbi.dfm.batch.infrastructure.JpaBatchRepository;
+import com.bitbi.dfm.batch.domain.BatchRepository;
 import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
-import com.bitbi.dfm.plugin.infrastructure.persistence.JpaPluginSqlGenerationRepository;
 import com.bitbi.dfm.site.domain.Site;
-import com.bitbi.dfm.site.infrastructure.JpaSiteRepository;
 import com.bitbi.dfm.upload.domain.UploadedFileRepository;
-import com.bitbi.dfm.upload.infrastructure.JpaUploadedFileRepository;
 import com.bitbi.dfm.upload.infrastructure.S3FileStorageService;
 import com.bitbi.dfm.upload.infrastructure.S3FileStorageService.DeleteObjectsResult;
 import org.slf4j.Logger;
@@ -17,10 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -29,17 +24,17 @@ public class BatchRetentionService {
     private static final Logger logger = LoggerFactory.getLogger(BatchRetentionService.class);
     private static final int DEFAULT_LIMIT = 1000;
 
-    private final JpaBatchRepository batchRepository;
-    private final JpaSiteRepository siteRepository;
-    private final JpaUploadedFileRepository uploadedFileRepository;
-    private final JpaPluginSqlGenerationRepository sqlGenerationRepository;
+    private final BatchRepository batchRepository;
+    private final com.bitbi.dfm.site.domain.SiteRepository siteRepository;
+    private final UploadedFileRepository uploadedFileRepository;
+    private final PluginSqlGenerationRepository sqlGenerationRepository;
     private final S3FileStorageService s3FileStorageService;
 
     public BatchRetentionService(
-            JpaBatchRepository batchRepository,
-            JpaSiteRepository siteRepository,
-            JpaUploadedFileRepository uploadedFileRepository,
-            JpaPluginSqlGenerationRepository sqlGenerationRepository,
+            BatchRepository batchRepository,
+            com.bitbi.dfm.site.domain.SiteRepository siteRepository,
+            UploadedFileRepository uploadedFileRepository,
+            PluginSqlGenerationRepository sqlGenerationRepository,
             S3FileStorageService s3FileStorageService) {
         this.batchRepository = batchRepository;
         this.siteRepository = siteRepository;
@@ -78,11 +73,29 @@ public class BatchRetentionService {
         return summary;
     }
 
-    @Transactional
     protected BatchCleanupSummary cleanupSite(UUID siteId, LocalDateTime cutoff, int limit, boolean dryRun) {
+        CleanupDbResult dbResult = cleanupSiteInDb(siteId, cutoff, limit, dryRun);
+
+        List<String> dedupedKeys = deduplicate(dbResult.s3Keys);
+        dbResult.summary.deletedFiles += dedupedKeys.size();
+
+        if (!dryRun) {
+            DeleteObjectsResult deleteResult = s3FileStorageService.deleteObjects(dedupedKeys);
+            if (!deleteResult.errors().isEmpty()) {
+                dbResult.summary.errors.add("S3 delete errors: " + deleteResult.errors());
+            }
+        }
+
+        return dbResult.summary;
+    }
+
+    @Transactional
+    protected CleanupDbResult cleanupSiteInDb(UUID siteId, LocalDateTime cutoff, int limit, boolean dryRun) {
         List<Batch> candidates = batchRepository.findCleanupCandidatesForSite(siteId, cutoff, limit);
         BatchCleanupSummary summary = new BatchCleanupSummary();
         summary.candidates = candidates.size();
+
+        List<String> s3Keys = new ArrayList<>();
 
         for (Batch batch : candidates) {
             UUID batchId = batch.getId();
@@ -90,7 +103,6 @@ public class BatchRetentionService {
                 List<UploadedFileRepository.FileKeySize> uploadedKeys = uploadedFileRepository.findS3KeysByBatchId(batchId);
                 List<PluginSqlGenerationRepository.S3KeySize> sqlKeys = sqlGenerationRepository.findS3KeysByBatchId(batchId);
 
-                List<String> s3Keys = new ArrayList<>();
                 long totalBytes = 0L;
 
                 for (UploadedFileRepository.FileKeySize fileKey : uploadedKeys) {
@@ -111,39 +123,30 @@ public class BatchRetentionService {
                     }
                 }
 
-                List<String> dedupedKeys = deduplicate(s3Keys);
+                summary.deletedBytes += totalBytes;
 
                 if (dryRun) {
-                    summary.deletedFiles += dedupedKeys.size();
-                    summary.deletedBytes += totalBytes;
                     continue;
                 }
 
-                DeleteObjectsResult deleteResult = s3FileStorageService.deleteObjects(dedupedKeys);
-                if (!deleteResult.errors().isEmpty()) {
-                    summary.errors.add("Batch " + batchId + " S3 delete errors: " + deleteResult.errors());
-                    continue;
-                }
-
+                // Prevent leaving plugin SQL generations referencing a deleted comparison batch.
                 sqlGenerationRepository.deleteByComparisonBatchId(batchId);
-                ((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository).deleteById(batchId);
+                sqlGenerationRepository.deleteBySourceBatchId(batchId);
 
+                batchRepository.deleteById(batchId);
                 summary.deletedBatches++;
-                summary.deletedFiles += dedupedKeys.size();
-                summary.deletedBytes += totalBytes;
             } catch (Exception e) {
-                logger.error("Failed to cleanup batch: batchId={}, error={}", batchId, e.getMessage(), e);
+                logger.error("Failed to cleanup batch in DB: batchId={}, error={}", batchId, e.getMessage(), e);
                 summary.errors.add("Batch " + batchId + " cleanup failed: " + e.getMessage());
             }
         }
 
-        return summary;
+        return new CleanupDbResult(summary, s3Keys);
     }
 
     private List<Site> resolveSites(UUID siteId, UUID accountId) {
         if (siteId != null) {
-            return ((com.bitbi.dfm.site.domain.SiteRepository) siteRepository)
-                    .findById(siteId)
+            return siteRepository.findById(siteId)
                     .map(List::of)
                     .orElse(List.of());
         }
@@ -157,9 +160,10 @@ public class BatchRetentionService {
         if (keys == null || keys.isEmpty()) {
             return List.of();
         }
-        Set<String> deduped = new HashSet<>(keys);
-        return new ArrayList<>(deduped);
+        return keys.stream().distinct().toList();
     }
+
+    protected record CleanupDbResult(BatchCleanupSummary summary, List<String> s3Keys) {}
 
     public record BatchCleanupRequest(
             UUID siteId,

--- a/src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/domain/BatchRepository.java
@@ -22,6 +22,8 @@ public interface BatchRepository {
 
     List<Batch> findExpiredBatches(LocalDateTime cutoffTime);
 
+    List<Batch> findCleanupCandidatesForSite(UUID siteId, LocalDateTime cutoffTime, int limit);
+
     Page<Batch> findBySiteIdAndStatus(UUID siteId, BatchStatus status, Pageable pageable);
 
     Batch save(Batch batch);

--- a/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
@@ -51,6 +51,29 @@ public interface JpaBatchRepository extends JpaRepository<Batch, UUID>, BatchRep
     List<Batch> findExpiredBatches(LocalDateTime cutoffTime);
 
     /**
+     * Find cleanup candidates for a site based on retention cutoff.
+     * <p>
+     * Excludes IN_PROGRESS batches and selects oldest first.
+     * Uses SKIP LOCKED to avoid concurrent cleanup collisions.
+     * </p>
+     *
+     * @param siteId site identifier
+     * @param cutoffTime batches started before this time are eligible
+     * @param limit max number of batches to return
+     * @return list of cleanup candidates
+     */
+    @Query(value = """
+        SELECT * FROM batches
+        WHERE site_id = :siteId
+          AND status <> 'IN_PROGRESS'
+          AND started_at < :cutoffTime
+        ORDER BY started_at ASC
+        LIMIT :limit
+        FOR UPDATE SKIP LOCKED
+        """, nativeQuery = true)
+    List<Batch> findCleanupCandidatesForSite(UUID siteId, LocalDateTime cutoffTime, int limit);
+
+    /**
      * Find batches by site and status with pagination.
      *
      * @param siteId site identifier

--- a/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
+++ b/src/main/java/com/bitbi/dfm/batch/infrastructure/JpaBatchRepository.java
@@ -67,6 +67,11 @@ public interface JpaBatchRepository extends JpaRepository<Batch, UUID>, BatchRep
         WHERE site_id = :siteId
           AND status <> 'IN_PROGRESS'
           AND started_at < :cutoffTime
+          AND NOT EXISTS (
+              SELECT 1
+              FROM account_plugins ap
+              WHERE ap.baseline_batch_id = batches.id
+          )
         ORDER BY started_at ASC
         LIMIT :limit
         FOR UPDATE SKIP LOCKED

--- a/src/main/java/com/bitbi/dfm/batch/presentation/BatchCleanupAdminController.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/BatchCleanupAdminController.java
@@ -1,0 +1,86 @@
+package com.bitbi.dfm.batch.presentation;
+
+import com.bitbi.dfm.batch.application.BatchRetentionService;
+import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupRequest;
+import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupSummary;
+import com.bitbi.dfm.batch.presentation.dto.BatchCleanupRequestDto;
+import com.bitbi.dfm.batch.presentation.dto.BatchCleanupResultDto;
+import com.bitbi.dfm.shared.api.ApiRoutes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin controller for batch retention cleanup.
+ */
+@RestController
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "UI/Admin API - Batch Cleanup", description = "Manual batch cleanup operations for admins")
+@SecurityRequirement(name = "oauth2")
+public class BatchCleanupAdminController {
+
+    private static final Logger logger = LoggerFactory.getLogger(BatchCleanupAdminController.class);
+
+    private final BatchRetentionService batchRetentionService;
+
+    public BatchCleanupAdminController(BatchRetentionService batchRetentionService) {
+        this.batchRetentionService = batchRetentionService;
+    }
+
+    /**
+     * Manually run batch retention cleanup with filters.
+     *
+     * POST /api/v1/batches/cleanup
+     */
+    @Operation(
+            summary = "Run batch retention cleanup",
+            description = "Runs batch cleanup using retention policy or overrides. Supports dry run."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cleanup completed",
+                    content = @Content(schema = @Schema(implementation = BatchCleanupResultDto.class)))
+    })
+    @PostMapping(ApiRoutes.BATCHES_CLEANUP)
+    public ResponseEntity<BatchCleanupResultDto> cleanupBatches(
+            @Valid @RequestBody(required = false) BatchCleanupRequestDto request) {
+
+        BatchCleanupRequestDto safeRequest = request != null
+                ? request
+                : new BatchCleanupRequestDto(null, null, null, null, null, null);
+
+        logger.info("Running manual batch cleanup: siteId={}, accountId={}, retentionDays={}, olderThan={}, limit={}, dryRun={}",
+                safeRequest.siteId(), safeRequest.accountId(), safeRequest.retentionDays(),
+                safeRequest.olderThan(), safeRequest.limit(), safeRequest.dryRun());
+
+        BatchCleanupSummary summary = batchRetentionService.runCleanup(new BatchCleanupRequest(
+                safeRequest.siteId(),
+                safeRequest.accountId(),
+                safeRequest.retentionDays(),
+                safeRequest.olderThan(),
+                safeRequest.limit(),
+                safeRequest.dryRun()
+        ));
+
+        BatchCleanupResultDto response = new BatchCleanupResultDto(
+                summary.candidates(),
+                summary.deletedBatches(),
+                summary.deletedFiles(),
+                summary.deletedBytes(),
+                summary.errors()
+        );
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/bitbi/dfm/batch/presentation/BatchCleanupAdminController.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/BatchCleanupAdminController.java
@@ -1,5 +1,9 @@
 package com.bitbi.dfm.batch.presentation;
 
+import com.bitbi.dfm.account.domain.ActionStatus;
+import com.bitbi.dfm.account.domain.AdminActionLog;
+import com.bitbi.dfm.account.domain.AdminActionType;
+import com.bitbi.dfm.account.infrastructure.AdminActionLogRepository;
 import com.bitbi.dfm.batch.application.BatchRetentionService;
 import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupRequest;
 import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupSummary;
@@ -13,11 +17,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,9 +40,13 @@ public class BatchCleanupAdminController {
     private static final Logger logger = LoggerFactory.getLogger(BatchCleanupAdminController.class);
 
     private final BatchRetentionService batchRetentionService;
+    private final AdminActionLogRepository adminActionLogRepository;
 
-    public BatchCleanupAdminController(BatchRetentionService batchRetentionService) {
+    public BatchCleanupAdminController(
+            BatchRetentionService batchRetentionService,
+            AdminActionLogRepository adminActionLogRepository) {
         this.batchRetentionService = batchRetentionService;
+        this.adminActionLogRepository = adminActionLogRepository;
     }
 
     /**
@@ -54,7 +64,9 @@ public class BatchCleanupAdminController {
     })
     @PostMapping(ApiRoutes.BATCHES_CLEANUP)
     public ResponseEntity<BatchCleanupResultDto> cleanupBatches(
-            @Valid @RequestBody(required = false) BatchCleanupRequestDto request) {
+            @Valid @RequestBody(required = false) BatchCleanupRequestDto request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
 
         BatchCleanupRequestDto safeRequest = request != null
                 ? request
@@ -64,23 +76,82 @@ public class BatchCleanupAdminController {
                 safeRequest.siteId(), safeRequest.accountId(), safeRequest.retentionDays(),
                 safeRequest.olderThan(), safeRequest.limit(), safeRequest.dryRun());
 
-        BatchCleanupSummary summary = batchRetentionService.runCleanup(new BatchCleanupRequest(
-                safeRequest.siteId(),
-                safeRequest.accountId(),
-                safeRequest.retentionDays(),
-                safeRequest.olderThan(),
-                safeRequest.limit(),
-                safeRequest.dryRun()
-        ));
+        try {
+            BatchCleanupSummary summary = batchRetentionService.runCleanup(new BatchCleanupRequest(
+                    safeRequest.siteId(),
+                    safeRequest.accountId(),
+                    safeRequest.retentionDays(),
+                    safeRequest.olderThan(),
+                    safeRequest.limit(),
+                    safeRequest.dryRun()
+            ));
 
-        BatchCleanupResultDto response = new BatchCleanupResultDto(
-                summary.candidates(),
-                summary.deletedBatches(),
-                summary.deletedFiles(),
-                summary.deletedBytes(),
-                summary.errors()
-        );
+            BatchCleanupResultDto response = new BatchCleanupResultDto(
+                    summary.candidates(),
+                    summary.deletedBatches(),
+                    summary.deletedFiles(),
+                    summary.deletedBytes(),
+                    summary.errors()
+            );
 
-        return ResponseEntity.ok(response);
+            logAdminAction(safeRequest, authentication, httpRequest, null);
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            logAdminAction(safeRequest, authentication, httpRequest, e.getMessage());
+            throw e;
+        }
+    }
+
+    private void logAdminAction(BatchCleanupRequestDto request,
+                                Authentication authentication,
+                                HttpServletRequest httpRequest,
+                                String errorMessage) {
+        try {
+            // Admins do not necessarily have an Account record in Postgres.
+            // We log NULL adminAccountId and rely on Auth0/JWT for identity outside this table.
+            java.util.UUID adminAccountId = null;
+
+            String ipAddress = extractIpAddress(httpRequest);
+            String userAgent = httpRequest.getHeader("User-Agent");
+
+            AdminActionLog log;
+            if (errorMessage == null) {
+                log = AdminActionLog.successForSite(
+                        AdminActionType.BATCH_CLEANUP,
+                        request.accountId(),
+                        request.siteId(),
+                        adminAccountId,
+                        ipAddress,
+                        userAgent
+                );
+            } else {
+                // If accountId/siteId is null, log as account-level failure is not supported by the current schema,
+                // so we still use the site factory with nulls (columns are nullable).
+                log = AdminActionLog.failureForSite(
+                        AdminActionType.BATCH_CLEANUP,
+                        request.accountId(),
+                        request.siteId(),
+                        adminAccountId,
+                        errorMessage,
+                        ipAddress,
+                        userAgent
+                );
+            }
+
+            adminActionLogRepository.save(log);
+            logger.info("Admin action logged: actionType={}, targetAccountId={}, targetSiteId={}, status={}",
+                    AdminActionType.BATCH_CLEANUP, request.accountId(), request.siteId(),
+                    errorMessage == null ? ActionStatus.SUCCESS : ActionStatus.FAILED);
+        } catch (Exception e) {
+            logger.error("Failed to log admin action: actionType={}, error={}", AdminActionType.BATCH_CLEANUP, e.getMessage(), e);
+        }
+    }
+
+    private String extractIpAddress(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchCleanupRequestDto.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchCleanupRequestDto.java
@@ -1,0 +1,34 @@
+package com.bitbi.dfm.batch.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(description = "Batch cleanup request (admin)")
+public record BatchCleanupRequestDto(
+        @Schema(description = "Optional site ID to scope cleanup", example = "123e4567-e89b-12d3-a456-426614174000")
+        UUID siteId,
+
+        @Schema(description = "Optional account ID to scope cleanup", example = "987fcdeb-51a2-43f7-9c3d-123456789abc")
+        UUID accountId,
+
+        @Schema(description = "Retention period override in days", example = "45")
+        @Min(1)
+        @Max(3650)
+        Integer retentionDays,
+
+        @Schema(description = "Override cutoff (delete batches started before this timestamp)", example = "2025-01-15T10:30:00")
+        LocalDateTime olderThan,
+
+        @Schema(description = "Maximum number of batches to process", example = "1000")
+        @Min(1)
+        @Max(10000)
+        Integer limit,
+
+        @Schema(description = "Dry run only (no deletions)", example = "true")
+        Boolean dryRun
+) {
+}

--- a/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchCleanupResultDto.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchCleanupResultDto.java
@@ -1,0 +1,24 @@
+package com.bitbi.dfm.batch.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "Batch cleanup result summary")
+public record BatchCleanupResultDto(
+        @Schema(description = "Number of batches matched by cleanup")
+        int candidates,
+
+        @Schema(description = "Number of batches deleted")
+        int deletedBatches,
+
+        @Schema(description = "Number of files deleted from S3")
+        int deletedFiles,
+
+        @Schema(description = "Total bytes deleted from S3")
+        long deletedBytes,
+
+        @Schema(description = "List of errors encountered")
+        List<String> errors
+) {
+}

--- a/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
@@ -153,6 +153,17 @@ public interface PluginSqlGenerationRepository {
     int deleteByComparisonBatchId(UUID batchId);
 
     /**
+     * Deletes SQL generations where the batch is used as source.
+     * <p>
+     * Note: the database schema has ON DELETE CASCADE for source_batch_id, but this
+     * method is useful for explicit cleanup and symmetry with comparison deletion.
+     *
+     * @param batchId source batch ID
+     * @return number of records deleted
+     */
+    int deleteBySourceBatchId(UUID batchId);
+
+    /**
      * Deletes a SQL generation record.
      *
      * @param generation the generation to delete

--- a/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/domain/PluginSqlGenerationRepository.java
@@ -137,9 +137,33 @@ public interface PluginSqlGenerationRepository {
     java.util.Set<UUID> findGeneratedBatchIdsByAccountPluginId(Long accountPluginId);
 
     /**
+     * Finds S3 keys and sizes for generations referencing a batch.
+     *
+     * @param batchId batch identifier (source or comparison)
+     * @return list of S3 key and size projections
+     */
+    List<S3KeySize> findS3KeysByBatchId(UUID batchId);
+
+    /**
+     * Deletes SQL generations where the batch is used as comparison.
+     *
+     * @param batchId comparison batch ID
+     * @return number of records deleted
+     */
+    int deleteByComparisonBatchId(UUID batchId);
+
+    /**
      * Deletes a SQL generation record.
      *
      * @param generation the generation to delete
      */
     void delete(PluginSqlGeneration generation);
+
+    /**
+     * Projection interface for S3 key and size.
+     */
+    interface S3KeySize {
+        String getS3Key();
+        Long getFileSizeBytes();
+    }
 }

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
@@ -137,4 +137,11 @@ public interface JpaPluginSqlGenerationRepository extends JpaRepository<PluginSq
     @Modifying
     @Query("DELETE FROM PluginSqlGeneration g WHERE g.comparisonBatchId = :batchId")
     int deleteByComparisonBatchId(@Param("batchId") UUID batchId);
+
+    /**
+     * Deletes generations where the batch is used as source.
+     */
+    @Modifying
+    @Query("DELETE FROM PluginSqlGeneration g WHERE g.sourceBatchId = :batchId")
+    int deleteBySourceBatchId(@Param("batchId") UUID batchId);
 }

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/persistence/JpaPluginSqlGenerationRepository.java
@@ -120,4 +120,21 @@ public interface JpaPluginSqlGenerationRepository extends JpaRepository<PluginSq
      */
     @Query("SELECT g.sourceBatchId FROM PluginSqlGeneration g WHERE g.accountPluginId = :accountPluginId")
     java.util.Set<UUID> findGeneratedBatchIdsByAccountPluginId(@Param("accountPluginId") Long accountPluginId);
+
+    /**
+     * Finds S3 keys and sizes for generations referencing a batch.
+     */
+    @Query("""
+        SELECT g.s3Key AS s3Key, g.fileSizeBytes AS fileSizeBytes
+        FROM PluginSqlGeneration g
+        WHERE g.sourceBatchId = :batchId OR g.comparisonBatchId = :batchId
+        """)
+    List<S3KeySize> findS3KeysByBatchId(@Param("batchId") UUID batchId);
+
+    /**
+     * Deletes generations where the batch is used as comparison.
+     */
+    @Modifying
+    @Query("DELETE FROM PluginSqlGeneration g WHERE g.comparisonBatchId = :batchId")
+    int deleteByComparisonBatchId(@Param("batchId") UUID batchId);
 }

--- a/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
+++ b/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
@@ -356,6 +356,16 @@ public final class ApiRoutes {
     public static final String SITES_ID = SITES + "/{id}";
 
     /**
+     * Site retention policy endpoint.
+     * <p>
+     * Methods: GET, PATCH<br>
+     * Path Variable: {id} - Site ID<br>
+     * Authentication: Auth0 OAuth2 (ROLE_ADMIN)
+     * </p>
+     */
+    public static final String SITES_RETENTION = SITES + "/{id}/retention";
+
+    /**
      * Get site statistics endpoint.
      * <p>
      * Method: GET<br>
@@ -438,6 +448,15 @@ public final class ApiRoutes {
      * </p>
      */
     public static final String BATCHES_ADMIN_ID = BATCHES_ADMIN + "/{id}";
+
+    /**
+     * Batch retention cleanup endpoint (admin).
+     * <p>
+     * Method: POST<br>
+     * Authentication: Auth0 OAuth2 (ROLE_ADMIN)
+     * </p>
+     */
+    public static final String BATCHES_CLEANUP = BATCHES_ADMIN + "/cleanup";
 
     // History (User-facing)
     /**

--- a/src/main/java/com/bitbi/dfm/site/application/SiteService.java
+++ b/src/main/java/com/bitbi/dfm/site/application/SiteService.java
@@ -273,6 +273,25 @@ public class SiteService {
     }
 
     /**
+     * Update site retention policy (days).
+     *
+     * @param siteId site identifier
+     * @param retentionDays retention period in days
+     * @return updated site
+     * @throws SiteNotFoundException if site not found
+     */
+    public Site updateRetentionDays(UUID siteId, int retentionDays) {
+        logger.info("Updating site retention policy: id={}, retentionDays={}", siteId, retentionDays);
+
+        Site site = getSite(siteId);
+        site.updateRetentionDays(retentionDays);
+        Site saved = siteRepository.save(site);
+
+        logger.info("Site retention policy updated: siteId={}, retentionDays={}", siteId, retentionDays);
+        return saved;
+    }
+
+    /**
      * Deactivate site (soft delete).
      *
      * @param siteId site identifier

--- a/src/main/java/com/bitbi/dfm/site/domain/Site.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/Site.java
@@ -29,6 +29,7 @@ public class Site {
      */
     private static final int COMPOSITE_DOMAIN_PREFIX_LENGTH = 37;
     private static final int DEFAULT_RETENTION_DAYS = 45;
+    private static final int MAX_RETENTION_DAYS = 3650; // 10 years
 
     @Id
     @Column(name = "id", updatable = false, nullable = false)
@@ -120,8 +121,8 @@ public class Site {
     }
 
     public void updateRetentionDays(int retentionDays) {
-        if (retentionDays <= 0) {
-            throw new IllegalArgumentException("Retention days must be positive");
+        if (retentionDays <= 0 || retentionDays > MAX_RETENTION_DAYS) {
+            throw new IllegalArgumentException("Retention days must be between 1 and " + MAX_RETENTION_DAYS);
         }
         this.retentionDays = retentionDays;
         this.updatedAt = LocalDateTime.now();

--- a/src/main/java/com/bitbi/dfm/site/domain/Site.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/Site.java
@@ -28,6 +28,7 @@ public class Site {
      * UUID is 36 characters + underscore (1 character) = 37 characters total.
      */
     private static final int COMPOSITE_DOMAIN_PREFIX_LENGTH = 37;
+    private static final int DEFAULT_RETENTION_DAYS = 45;
 
     @Id
     @Column(name = "id", updatable = false, nullable = false)
@@ -48,6 +49,9 @@ public class Site {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
 
+    @Column(name = "retention_days", nullable = false)
+    private Integer retentionDays;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -55,13 +59,15 @@ public class Site {
     private LocalDateTime updatedAt;
 
     protected Site(UUID id, UUID accountId, String domain, String clientSecretHash,
-                   String displayName, Boolean isActive, LocalDateTime createdAt, LocalDateTime updatedAt) {
+                   String displayName, Boolean isActive, Integer retentionDays,
+                   LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.accountId = accountId;
         this.domain = domain;
         this.clientSecretHash = clientSecretHash;
         this.displayName = displayName;
         this.isActive = isActive;
+        this.retentionDays = retentionDays;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -86,7 +92,7 @@ public class Site {
         LocalDateTime now = LocalDateTime.now();
 
         return new Site(id, accountId, domain.toLowerCase().trim(), clientSecretHash,
-                displayName.trim(), true, now, now);
+                displayName.trim(), true, DEFAULT_RETENTION_DAYS, now, now);
     }
 
     /**
@@ -110,6 +116,14 @@ public class Site {
             throw new IllegalArgumentException("DisplayName cannot be blank");
         }
         this.displayName = newDisplayName.trim();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateRetentionDays(int retentionDays) {
+        if (retentionDays <= 0) {
+            throw new IllegalArgumentException("Retention days must be positive");
+        }
+        this.retentionDays = retentionDays;
         this.updatedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/bitbi/dfm/site/domain/SiteRepository.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/SiteRepository.java
@@ -25,6 +25,8 @@ public interface SiteRepository {
 
     List<Site> findActiveByAccountId(UUID accountId);
 
+    List<Site> findAll();
+
     List<Site> findByAccountIdAndIsActiveTrueOrderByCreatedAtDesc(UUID accountId);
 
     Optional<Site> findByIdAndAccountId(UUID siteId, UUID accountId);

--- a/src/main/java/com/bitbi/dfm/site/presentation/SiteAdminController.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/SiteAdminController.java
@@ -11,6 +11,7 @@ import com.bitbi.dfm.site.presentation.dto.SiteCreationResponseDto;
 import com.bitbi.dfm.site.presentation.dto.SiteResponseDto;
 import com.bitbi.dfm.site.presentation.dto.SiteStatisticsDto;
 import com.bitbi.dfm.site.presentation.dto.UpdateSiteRequestDto;
+import com.bitbi.dfm.site.presentation.dto.UpdateSiteRetentionRequestDto;
 import com.bitbi.dfm.shared.api.ApiRoutes;
 import com.bitbi.dfm.shared.presentation.dto.ErrorResponseDto;
 import com.bitbi.dfm.shared.presentation.dto.PageResponseDto;
@@ -269,6 +270,75 @@ public class SiteAdminController {
         Site site = siteService.updateSite(siteId, request.displayName());
 
         SiteResponseDto response = SiteResponseDto.fromEntity(site);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Get site retention policy.
+     * <p>
+     * GET /api/v1/sites/{id}/retention
+     * </p>
+     *
+     * @param siteId site identifier
+     * @return site response with retention policy
+     */
+    @Operation(
+            summary = "Get site retention policy",
+            description = "Retrieves the retention policy (in days) for the specified site."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Retention policy retrieved successfully",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = SiteResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "Site not found",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @GetMapping(ApiRoutes.SITES_RETENTION)
+    public ResponseEntity<SiteResponseDto> getSiteRetentionPolicy(@PathVariable("id") UUID siteId) {
+        Site site = siteService.getSite(siteId);
+        SiteResponseDto response = SiteResponseDto.fromEntity(site);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * Update site retention policy.
+     * <p>
+     * PATCH /api/v1/sites/{id}/retention
+     * </p>
+     *
+     * @param siteId site identifier
+     * @param request retention policy request
+     * @return updated site response
+     */
+    @Operation(
+            summary = "Update site retention policy",
+            description = "Updates the retention policy (in days) for the specified site."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Retention policy updated successfully",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = SiteResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid input (validation error)",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "Site not found",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponseDto.class)))
+    })
+    @PatchMapping(ApiRoutes.SITES_RETENTION)
+    public ResponseEntity<SiteResponseDto> updateSiteRetentionPolicy(
+            @PathVariable("id") UUID siteId,
+            @Valid @RequestBody UpdateSiteRetentionRequestDto request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+        Site site = siteService.updateRetentionDays(siteId, request.retentionDays());
+        SiteResponseDto response = SiteResponseDto.fromEntity(site);
+
+        logAdminAction(
+                AdminActionType.UPDATE_SITE_RETENTION,
+                site.getAccountId(),
+                siteId,
+                authentication,
+                httpRequest,
+                null
+        );
+
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteCreationResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteCreationResponseDto.java
@@ -19,6 +19,7 @@ import java.util.UUID;
  * @param domain         Site domain (display format)
  * @param name           Site display name
  * @param isActive       Whether site is active
+ * @param retentionDays  Retention period in days for batch cleanup
  * @param createdAt      Site creation timestamp
  * @param clientSecret   Plaintext client secret (ONLY shown at creation)
  * @param siteIdentifier Full identifier for Basic Auth (accountId_domain)
@@ -43,6 +44,9 @@ public record SiteCreationResponseDto(
         @Schema(description = "Whether site is active", example = "true")
         boolean isActive,
 
+        @Schema(description = "Retention period in days for batch cleanup", example = "45")
+        int retentionDays,
+
         @Schema(description = "Site creation timestamp (ISO-8601)", example = "2025-01-15T10:30:00Z")
         Instant createdAt,
 
@@ -66,6 +70,7 @@ public record SiteCreationResponseDto(
                 result.site().getDisplayDomain(), // Display domain without accountId prefix
                 result.site().getDisplayName(),
                 result.site().getIsActive(),
+                result.site().getRetentionDays(),
                 result.site().getCreatedAt().toInstant(ZoneOffset.UTC),
                 result.plaintextSecret(),
                 result.site().getDomain() // Full composite domain for auth

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDto.java
@@ -23,6 +23,7 @@ import java.util.UUID;
  * @param domain Site domain name (display format, without accountId prefix)
  * @param name Site display name
  * @param isActive Active status
+ * @param retentionDays Retention period in days for batch cleanup
  * @param createdAt Creation timestamp
  */
 public record SiteResponseDto(
@@ -31,6 +32,7 @@ public record SiteResponseDto(
     String domain,
     String name,
     Boolean isActive,
+    Integer retentionDays,
     Instant createdAt
 ) {
 
@@ -53,6 +55,7 @@ public record SiteResponseDto(
             site.getDisplayDomain(), // Use display domain without accountId prefix
             site.getDisplayName(),
             site.getIsActive(),
+            site.getRetentionDays(),
             site.getCreatedAt().toInstant(ZoneOffset.UTC)
         );
     }

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/UpdateSiteRetentionRequestDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/UpdateSiteRetentionRequestDto.java
@@ -1,0 +1,21 @@
+package com.bitbi.dfm.site.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Request DTO for updating site retention policy.
+ *
+ * @param retentionDays Retention period in days
+ */
+@Schema(description = "Update site retention policy request")
+public record UpdateSiteRetentionRequestDto(
+        @Schema(description = "Retention period in days", example = "45")
+        @NotNull
+        @Min(1)
+        @Max(3650)
+        Integer retentionDays
+) {
+}

--- a/src/main/java/com/bitbi/dfm/upload/domain/UploadedFileRepository.java
+++ b/src/main/java/com/bitbi/dfm/upload/domain/UploadedFileRepository.java
@@ -62,6 +62,14 @@ public interface UploadedFileRepository {
     Optional<LatestFileInfoWithS3Key> findLatestByOriginalFileNameForSiteAndFileName(UUID siteId, String originalFileName);
 
     /**
+     * Finds S3 keys and sizes for files in a batch.
+     *
+     * @param batchId batch identifier
+     * @return list of S3 key and size projections
+     */
+    List<FileKeySize> findS3KeysByBatchId(UUID batchId);
+
+    /**
      * Projection interface for latest file info query.
      */
     interface LatestFileInfo {
@@ -79,5 +87,13 @@ public interface UploadedFileRepository {
         Long getFileSize();
         Instant getUploadedAt();
         String getS3Key();
+    }
+
+    /**
+     * Projection interface for S3 key and size.
+     */
+    interface FileKeySize {
+        String getS3Key();
+        Long getFileSize();
     }
 }

--- a/src/main/java/com/bitbi/dfm/upload/infrastructure/JpaUploadedFileRepository.java
+++ b/src/main/java/com/bitbi/dfm/upload/infrastructure/JpaUploadedFileRepository.java
@@ -72,6 +72,15 @@ public interface JpaUploadedFileRepository extends JpaRepository<UploadedFile, U
     long countBySiteId(UUID siteId);
 
     /**
+     * Find S3 keys and sizes for files in a batch.
+     *
+     * @param batchId batch identifier
+     * @return list of key/size projections
+     */
+    @Query("SELECT f.s3Key AS s3Key, f.fileSize AS fileSize FROM UploadedFile f WHERE f.batchId = :batchId")
+    List<FileKeySize> findS3KeysByBatchId(UUID batchId);
+
+    /**
      * Finds the latest uploaded file for each unique original file name for a given account.
      * Uses a subquery to find the maximum uploaded_at per file name.
      *

--- a/src/main/java/com/bitbi/dfm/upload/infrastructure/S3FileStorageService.java
+++ b/src/main/java/com/bitbi/dfm/upload/infrastructure/S3FileStorageService.java
@@ -8,6 +8,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
+import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -16,6 +21,8 @@ import java.io.InputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * S3-based file storage service with retry logic.
@@ -34,6 +41,7 @@ public class S3FileStorageService {
     private static final int MAX_RETRIES = 3;
     private static final long BASE_DELAY_MS = 100; // Base delay for exponential backoff
     private static final long MAX_DELAY_MS = 5000; // Maximum delay cap
+    private static final int MAX_DELETE_BATCH = 1000;
 
     private final S3Client s3Client;
     private final String bucketName;
@@ -175,6 +183,58 @@ public class S3FileStorageService {
     }
 
     /**
+     * Delete multiple files from S3 in batches (up to 1000 per request).
+     * <p>
+     * Returns a summary with deleted count and errors (if any).
+     * </p>
+     *
+     * @param s3Keys list of S3 object keys
+     * @return delete result summary
+     */
+    public DeleteObjectsResult deleteObjects(List<String> s3Keys) {
+        if (s3Keys == null || s3Keys.isEmpty()) {
+            return new DeleteObjectsResult(0, List.of());
+        }
+
+        int deletedCount = 0;
+        List<String> errors = new ArrayList<>();
+
+        for (int i = 0; i < s3Keys.size(); i += MAX_DELETE_BATCH) {
+            List<String> batch = s3Keys.subList(i, Math.min(i + MAX_DELETE_BATCH, s3Keys.size()));
+            try {
+                Delete delete = Delete.builder()
+                        .objects(batch.stream()
+                                .map(key -> ObjectIdentifier.builder().key(key).build())
+                                .toList())
+                        .build();
+
+                DeleteObjectsRequest request = DeleteObjectsRequest.builder()
+                        .bucket(bucketName)
+                        .delete(delete)
+                        .build();
+
+                DeleteObjectsResponse response = s3Client.deleteObjects(request);
+                deletedCount += response.deleted().size();
+
+                for (S3Error error : response.errors()) {
+                    errors.add(error.key() + ": " + error.code());
+                }
+            } catch (S3Exception e) {
+                logger.error("Failed to delete S3 objects batch: {}", e.getMessage(), e);
+                errors.add("S3Exception: " + e.getMessage());
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            logger.warn("S3 deleteObjects completed with {} errors", errors.size());
+        } else {
+            logger.info("S3 deleteObjects completed: deleted {} objects", deletedCount);
+        }
+
+        return new DeleteObjectsResult(deletedCount, errors);
+    }
+
+    /**
      * Calculate exponential backoff delay with jitter.
      * <p>
      * Formula: min(BASE_DELAY * 2^(attempt-1) + random(0, BASE_DELAY), MAX_DELAY)
@@ -221,4 +281,12 @@ public class S3FileStorageService {
             super(message, cause);
         }
     }
+
+    /**
+     * Result summary for bulk delete operations.
+     *
+     * @param deletedCount number of successfully deleted objects
+     * @param errors list of error descriptions (key + error code/message)
+     */
+    public record DeleteObjectsResult(int deletedCount, List<String> errors) {}
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,7 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/dfm
+    # Use DB_URL to support both host-run (localhost) and container-run (postgres service) setups.
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/dfm}
     username: dfm
     password: dfm_password
 
@@ -37,6 +38,7 @@ auth0:
   database-connection: Username-Password-Authentication
 
 s3:
+  # Use AWS_S3_ENDPOINT to support both host-run (localhost) and container-run (localstack service) setups.
   endpoint: ${AWS_S3_ENDPOINT:http://localhost:4566}
   region: ${AWS_S3_REGION:us-east-1}
   bucket:

--- a/src/main/resources/db/migration/V22__add_site_retention_and_error_logs_cascade.sql
+++ b/src/main/resources/db/migration/V22__add_site_retention_and_error_logs_cascade.sql
@@ -1,0 +1,22 @@
+-- Migration: V22__add_site_retention_and_error_logs_cascade.sql
+-- Description: Add retention policy to sites and cascade deletes for batch error logs
+-- Author: Data Forge Team
+-- Date: 2026-02-05
+
+-- Add retention policy to sites
+ALTER TABLE sites
+    ADD COLUMN retention_days INTEGER NOT NULL DEFAULT 45;
+
+COMMENT ON COLUMN sites.retention_days IS 'Retention period in days for batch cleanup (per site)';
+
+-- Update error_logs foreign key to cascade deletes when batches are removed
+ALTER TABLE error_logs
+    DROP CONSTRAINT IF EXISTS error_logs_batch_id_fkey;
+
+ALTER TABLE error_logs
+    ADD CONSTRAINT error_logs_batch_id_fkey
+    FOREIGN KEY (batch_id) REFERENCES batches(id) ON DELETE CASCADE;
+
+-- Index to accelerate retention cleanup queries
+CREATE INDEX IF NOT EXISTS idx_batches_site_status_started_at
+    ON batches(site_id, status, started_at);

--- a/src/main/resources/db/migration/V23__add_update_site_retention_action_type.sql
+++ b/src/main/resources/db/migration/V23__add_update_site_retention_action_type.sql
@@ -1,0 +1,16 @@
+-- Migration: V23__add_update_site_retention_action_type.sql
+-- Description: Allow UPDATE_SITE_RETENTION in admin_action_logs
+-- Author: Data Forge Team
+-- Date: 2026-02-05
+
+ALTER TABLE admin_action_logs
+    DROP CONSTRAINT IF EXISTS chk_action_type;
+
+ALTER TABLE admin_action_logs
+    ADD CONSTRAINT chk_action_type CHECK (
+        action_type IN (
+            'CREATE_ACCOUNT', 'LOCK_ACCOUNT', 'UNLOCK_ACCOUNT', 'RESET_PASSWORD',
+            'CREATE_SITE', 'DEACTIVATE_SITE', 'ACTIVATE_SITE', 'DELETE_SITE',
+            'UPDATE_SITE_RETENTION'
+        )
+    );

--- a/src/main/resources/db/migration/V24__add_batch_cleanup_action_type.sql
+++ b/src/main/resources/db/migration/V24__add_batch_cleanup_action_type.sql
@@ -1,0 +1,18 @@
+-- Migration: V24__add_batch_cleanup_action_type.sql
+-- Description: Allow BATCH_CLEANUP in admin_action_logs
+-- Author: Data Forge Team
+-- Date: 2026-02-07
+
+ALTER TABLE admin_action_logs
+    DROP CONSTRAINT IF EXISTS chk_action_type;
+
+ALTER TABLE admin_action_logs
+    ADD CONSTRAINT chk_action_type CHECK (
+        action_type IN (
+            'CREATE_ACCOUNT', 'LOCK_ACCOUNT', 'UNLOCK_ACCOUNT', 'RESET_PASSWORD',
+            'CREATE_SITE', 'DEACTIVATE_SITE', 'ACTIVATE_SITE', 'DELETE_SITE',
+            'UPDATE_SITE_RETENTION',
+            'BATCH_CLEANUP'
+        )
+    );
+

--- a/src/main/resources/db/migration/V25__restrict_baseline_batch_deletion.sql
+++ b/src/main/resources/db/migration/V25__restrict_baseline_batch_deletion.sql
@@ -1,0 +1,31 @@
+-- V25__restrict_baseline_batch_deletion.sql
+-- Prevent deleting batches that are referenced as a plugin baseline.
+--
+-- Rationale:
+-- baseline_batch_id is used for CSV initialization. If a baseline batch is deleted,
+-- clients may no longer be able to initialize reliably. Retention cleanup also
+-- excludes baseline batches, but this FK prevents races where a batch becomes a
+-- baseline between candidate selection and deletion.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_account_plugins_baseline_batch'
+    ) THEN
+        ALTER TABLE account_plugins DROP CONSTRAINT fk_account_plugins_baseline_batch;
+    END IF;
+END $$;
+
+ALTER TABLE account_plugins
+    ADD CONSTRAINT fk_account_plugins_baseline_batch
+        FOREIGN KEY (baseline_batch_id)
+        REFERENCES batches(id)
+        ON DELETE RESTRICT;
+
+-- Ensure the partial index exists for efficient baseline lookup.
+CREATE INDEX IF NOT EXISTS idx_account_plugins_baseline_batch
+    ON account_plugins(baseline_batch_id)
+    WHERE baseline_batch_id IS NOT NULL;
+

--- a/src/test/java/com/bitbi/dfm/batch/application/BatchRetentionServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/batch/application/BatchRetentionServiceTest.java
@@ -1,13 +1,10 @@
 package com.bitbi.dfm.batch.application;
 
 import com.bitbi.dfm.batch.domain.Batch;
-import com.bitbi.dfm.batch.infrastructure.JpaBatchRepository;
+import com.bitbi.dfm.batch.domain.BatchRepository;
 import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
-import com.bitbi.dfm.plugin.infrastructure.persistence.JpaPluginSqlGenerationRepository;
 import com.bitbi.dfm.site.domain.Site;
-import com.bitbi.dfm.site.infrastructure.JpaSiteRepository;
 import com.bitbi.dfm.upload.domain.UploadedFileRepository;
-import com.bitbi.dfm.upload.infrastructure.JpaUploadedFileRepository;
 import com.bitbi.dfm.upload.infrastructure.S3FileStorageService;
 import com.bitbi.dfm.upload.infrastructure.S3FileStorageService.DeleteObjectsResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,16 +28,16 @@ import static org.mockito.Mockito.*;
 class BatchRetentionServiceTest {
 
     @Mock
-    private JpaBatchRepository batchRepository;
+    private BatchRepository batchRepository;
 
     @Mock
-    private JpaSiteRepository siteRepository;
+    private com.bitbi.dfm.site.domain.SiteRepository siteRepository;
 
     @Mock
-    private JpaUploadedFileRepository uploadedFileRepository;
+    private UploadedFileRepository uploadedFileRepository;
 
     @Mock
-    private JpaPluginSqlGenerationRepository sqlGenerationRepository;
+    private PluginSqlGenerationRepository sqlGenerationRepository;
 
     @Mock
     private S3FileStorageService s3FileStorageService;
@@ -73,8 +70,7 @@ class BatchRetentionServiceTest {
 
         when(site.getId()).thenReturn(siteId);
         when(site.getRetentionDays()).thenReturn(45);
-        when(((com.bitbi.dfm.site.domain.SiteRepository) siteRepository).findById(siteId))
-                .thenReturn(Optional.of(site));
+        when(siteRepository.findById(siteId)).thenReturn(Optional.of(site));
         when(batchRepository.findCleanupCandidatesForSite(eq(siteId), any(), anyInt()))
                 .thenReturn(List.of(batch));
         when(batch.getId()).thenReturn(batchId);
@@ -98,7 +94,7 @@ class BatchRetentionServiceTest {
         assertThat(summary.deletedFiles()).isEqualTo(2);
         assertThat(summary.deletedBytes()).isEqualTo(300L);
         verify(s3FileStorageService, never()).deleteObjects(any());
-        verify(((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository), never()).deleteById(any());
+        verify(batchRepository, never()).deleteById(any());
     }
 
     @Test
@@ -109,8 +105,7 @@ class BatchRetentionServiceTest {
 
         when(site.getId()).thenReturn(siteId);
         when(site.getRetentionDays()).thenReturn(45);
-        when(((com.bitbi.dfm.site.domain.SiteRepository) siteRepository).findById(siteId))
-                .thenReturn(Optional.of(site));
+        when(siteRepository.findById(siteId)).thenReturn(Optional.of(site));
         when(batchRepository.findCleanupCandidatesForSite(eq(siteId), any(), anyInt()))
                 .thenReturn(List.of(batch));
         when(batch.getId()).thenReturn(batchId);
@@ -130,19 +125,19 @@ class BatchRetentionServiceTest {
         assertThat(summary.deletedBatches()).isEqualTo(1);
         verify(s3FileStorageService).deleteObjects(any());
         verify(sqlGenerationRepository).deleteByComparisonBatchId(batchId);
-        verify(((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository)).deleteById(batchId);
+        verify(sqlGenerationRepository).deleteBySourceBatchId(batchId);
+        verify(batchRepository).deleteById(batchId);
     }
 
     @Test
-    @DisplayName("cleanup should skip delete when S3 deletion returns errors")
-    void cleanup_shouldSkipWhenS3Errors() {
+    @DisplayName("cleanup should still delete DB records even if S3 deletion returns errors (best-effort)")
+    void cleanup_shouldDeleteDbWhenS3Errors() {
         Site site = mock(Site.class);
         Batch batch = mock(Batch.class);
 
         when(site.getId()).thenReturn(siteId);
         when(site.getRetentionDays()).thenReturn(45);
-        when(((com.bitbi.dfm.site.domain.SiteRepository) siteRepository).findById(siteId))
-                .thenReturn(Optional.of(site));
+        when(siteRepository.findById(siteId)).thenReturn(Optional.of(site));
         when(batchRepository.findCleanupCandidatesForSite(eq(siteId), any(), anyInt()))
                 .thenReturn(List.of(batch));
         when(batch.getId()).thenReturn(batchId);
@@ -160,8 +155,8 @@ class BatchRetentionServiceTest {
                 new BatchRetentionService.BatchCleanupRequest(siteId, null, null, null, 10, false)
         );
 
-        assertThat(summary.deletedBatches()).isEqualTo(0);
+        assertThat(summary.deletedBatches()).isEqualTo(1);
         assertThat(summary.errors()).isNotEmpty();
-        verify(((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository), never()).deleteById(any());
+        verify(batchRepository).deleteById(batchId);
     }
 }

--- a/src/test/java/com/bitbi/dfm/batch/application/BatchRetentionServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/batch/application/BatchRetentionServiceTest.java
@@ -1,0 +1,167 @@
+package com.bitbi.dfm.batch.application;
+
+import com.bitbi.dfm.batch.domain.Batch;
+import com.bitbi.dfm.batch.infrastructure.JpaBatchRepository;
+import com.bitbi.dfm.plugin.domain.PluginSqlGenerationRepository;
+import com.bitbi.dfm.plugin.infrastructure.persistence.JpaPluginSqlGenerationRepository;
+import com.bitbi.dfm.site.domain.Site;
+import com.bitbi.dfm.site.infrastructure.JpaSiteRepository;
+import com.bitbi.dfm.upload.domain.UploadedFileRepository;
+import com.bitbi.dfm.upload.infrastructure.JpaUploadedFileRepository;
+import com.bitbi.dfm.upload.infrastructure.S3FileStorageService;
+import com.bitbi.dfm.upload.infrastructure.S3FileStorageService.DeleteObjectsResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BatchRetentionService")
+class BatchRetentionServiceTest {
+
+    @Mock
+    private JpaBatchRepository batchRepository;
+
+    @Mock
+    private JpaSiteRepository siteRepository;
+
+    @Mock
+    private JpaUploadedFileRepository uploadedFileRepository;
+
+    @Mock
+    private JpaPluginSqlGenerationRepository sqlGenerationRepository;
+
+    @Mock
+    private S3FileStorageService s3FileStorageService;
+
+    private BatchRetentionService service;
+
+    private UUID siteId;
+    private UUID accountId;
+    private UUID batchId;
+
+    @BeforeEach
+    void setUp() {
+        service = new BatchRetentionService(
+                batchRepository,
+                siteRepository,
+                uploadedFileRepository,
+                sqlGenerationRepository,
+                s3FileStorageService
+        );
+        siteId = UUID.randomUUID();
+        accountId = UUID.randomUUID();
+        batchId = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("dryRun should not delete batches or S3 objects")
+    void dryRun_shouldNotDelete() {
+        Site site = mock(Site.class);
+        Batch batch = mock(Batch.class);
+
+        when(site.getId()).thenReturn(siteId);
+        when(site.getRetentionDays()).thenReturn(45);
+        when(((com.bitbi.dfm.site.domain.SiteRepository) siteRepository).findById(siteId))
+                .thenReturn(Optional.of(site));
+        when(batchRepository.findCleanupCandidatesForSite(eq(siteId), any(), anyInt()))
+                .thenReturn(List.of(batch));
+        when(batch.getId()).thenReturn(batchId);
+
+        UploadedFileRepository.FileKeySize fileKey = mock(UploadedFileRepository.FileKeySize.class);
+        when(fileKey.getS3Key()).thenReturn("batch/file.csv");
+        when(fileKey.getFileSize()).thenReturn(100L);
+        when(uploadedFileRepository.findS3KeysByBatchId(batchId)).thenReturn(List.of(fileKey));
+
+        PluginSqlGenerationRepository.S3KeySize sqlKey = mock(PluginSqlGenerationRepository.S3KeySize.class);
+        when(sqlKey.getS3Key()).thenReturn("plugins/sql.sql");
+        when(sqlKey.getFileSizeBytes()).thenReturn(200L);
+        when(sqlGenerationRepository.findS3KeysByBatchId(batchId)).thenReturn(List.of(sqlKey));
+
+        BatchRetentionService.BatchCleanupSummary summary = service.runCleanup(
+                new BatchRetentionService.BatchCleanupRequest(siteId, null, null, null, 10, true)
+        );
+
+        assertThat(summary.candidates()).isEqualTo(1);
+        assertThat(summary.deletedBatches()).isEqualTo(0);
+        assertThat(summary.deletedFiles()).isEqualTo(2);
+        assertThat(summary.deletedBytes()).isEqualTo(300L);
+        verify(s3FileStorageService, never()).deleteObjects(any());
+        verify(((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository), never()).deleteById(any());
+    }
+
+    @Test
+    @DisplayName("cleanup should delete batches when S3 deletion succeeds")
+    void cleanup_shouldDeleteOnSuccess() {
+        Site site = mock(Site.class);
+        Batch batch = mock(Batch.class);
+
+        when(site.getId()).thenReturn(siteId);
+        when(site.getRetentionDays()).thenReturn(45);
+        when(((com.bitbi.dfm.site.domain.SiteRepository) siteRepository).findById(siteId))
+                .thenReturn(Optional.of(site));
+        when(batchRepository.findCleanupCandidatesForSite(eq(siteId), any(), anyInt()))
+                .thenReturn(List.of(batch));
+        when(batch.getId()).thenReturn(batchId);
+
+        UploadedFileRepository.FileKeySize fileKey = mock(UploadedFileRepository.FileKeySize.class);
+        when(fileKey.getS3Key()).thenReturn("batch/file.csv");
+        when(fileKey.getFileSize()).thenReturn(100L);
+        when(uploadedFileRepository.findS3KeysByBatchId(batchId)).thenReturn(List.of(fileKey));
+        when(sqlGenerationRepository.findS3KeysByBatchId(batchId)).thenReturn(List.of());
+
+        when(s3FileStorageService.deleteObjects(any())).thenReturn(new DeleteObjectsResult(1, List.of()));
+
+        BatchRetentionService.BatchCleanupSummary summary = service.runCleanup(
+                new BatchRetentionService.BatchCleanupRequest(siteId, null, null, LocalDateTime.now().minusDays(1), 10, false)
+        );
+
+        assertThat(summary.deletedBatches()).isEqualTo(1);
+        verify(s3FileStorageService).deleteObjects(any());
+        verify(sqlGenerationRepository).deleteByComparisonBatchId(batchId);
+        verify(((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository)).deleteById(batchId);
+    }
+
+    @Test
+    @DisplayName("cleanup should skip delete when S3 deletion returns errors")
+    void cleanup_shouldSkipWhenS3Errors() {
+        Site site = mock(Site.class);
+        Batch batch = mock(Batch.class);
+
+        when(site.getId()).thenReturn(siteId);
+        when(site.getRetentionDays()).thenReturn(45);
+        when(((com.bitbi.dfm.site.domain.SiteRepository) siteRepository).findById(siteId))
+                .thenReturn(Optional.of(site));
+        when(batchRepository.findCleanupCandidatesForSite(eq(siteId), any(), anyInt()))
+                .thenReturn(List.of(batch));
+        when(batch.getId()).thenReturn(batchId);
+
+        UploadedFileRepository.FileKeySize fileKey = mock(UploadedFileRepository.FileKeySize.class);
+        when(fileKey.getS3Key()).thenReturn("batch/file.csv");
+        when(fileKey.getFileSize()).thenReturn(100L);
+        when(uploadedFileRepository.findS3KeysByBatchId(batchId)).thenReturn(List.of(fileKey));
+        when(sqlGenerationRepository.findS3KeysByBatchId(batchId)).thenReturn(List.of());
+
+        when(s3FileStorageService.deleteObjects(any()))
+                .thenReturn(new DeleteObjectsResult(0, List.of("error")));
+
+        BatchRetentionService.BatchCleanupSummary summary = service.runCleanup(
+                new BatchRetentionService.BatchCleanupRequest(siteId, null, null, null, 10, false)
+        );
+
+        assertThat(summary.deletedBatches()).isEqualTo(0);
+        assertThat(summary.errors()).isNotEmpty();
+        verify(((com.bitbi.dfm.batch.domain.BatchRepository) batchRepository), never()).deleteById(any());
+    }
+}

--- a/src/test/java/com/bitbi/dfm/integration/BatchRetentionIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/BatchRetentionIntegrationTest.java
@@ -151,4 +151,89 @@ class BatchRetentionIntegrationTest extends AbstractIntegrationTest {
         assertThat(uploadedFileRepository.countByBatchId(eligibleBatchId)).isZero();
         assertThat(errorLogRepository.countByBatchId(eligibleBatchId)).isZero();
     }
+
+    @Test
+    @Transactional
+    @DisplayName("Should NOT delete batches referenced as plugin baseline_batch_id")
+    void shouldNotDeleteBaselineBatch() {
+        UUID accountId = UUID.randomUUID();
+        UUID siteId = UUID.randomUUID();
+        UUID baselineBatchId = UUID.randomUUID();
+        UUID eligibleBatchId = UUID.randomUUID();
+
+        String compositeDomain = accountId + "_example.com";
+        String secretHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoOhiN4Y7sJpX6dC";
+
+        jdbcTemplate.update(
+                "INSERT INTO accounts (id, email, name, is_active, created_at, updated_at) VALUES (?,?,?,?,NOW(),NOW())",
+                accountId,
+                "baseline-test@example.com",
+                "Baseline Test",
+                true
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, retention_days, created_at, updated_at) VALUES (?,?,?,?,?,?,?,NOW(),NOW())",
+                siteId,
+                accountId,
+                compositeDomain,
+                secretHash,
+                "Baseline Site",
+                true,
+                45
+        );
+
+        LocalDateTime oldStartedAt = LocalDateTime.now().minusDays(60);
+
+        // Baseline batch (old but must not be deleted)
+        jdbcTemplate.update(
+                "INSERT INTO batches (id, site_id, account_id, status, s3_path, uploaded_files_count, total_size, has_errors, started_at, completed_at, created_at, version) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),0)",
+                baselineBatchId,
+                siteId,
+                accountId,
+                "COMPLETED",
+                "path/baseline/",
+                0,
+                0,
+                false,
+                oldStartedAt,
+                oldStartedAt.plusMinutes(5)
+        );
+
+        // Another eligible old batch (should be deleted)
+        jdbcTemplate.update(
+                "INSERT INTO batches (id, site_id, account_id, status, s3_path, uploaded_files_count, total_size, has_errors, started_at, completed_at, created_at, version) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),0)",
+                eligibleBatchId,
+                siteId,
+                accountId,
+                "COMPLETED",
+                "path/eligible2/",
+                0,
+                0,
+                false,
+                oldStartedAt,
+                oldStartedAt.plusMinutes(5)
+        );
+
+        // account_plugins row referencing baseline batch
+        jdbcTemplate.update(
+                "INSERT INTO account_plugins (account_id, plugin_id, plugin_data, is_active, activated_at, created_at, updated_at, baseline_batch_id) VALUES (?,?,?::jsonb,?,?,NOW(),NOW(),?)",
+                accountId,
+                "bit-bi",
+                "{}",
+                true,
+                LocalDateTime.now(),
+                baselineBatchId
+        );
+
+        BatchRetentionService.BatchCleanupSummary summary = batchRetentionService.runCleanup(
+                new BatchCleanupRequest(siteId, null, null, null, 100, false)
+        );
+
+        assertThat(summary.candidates()).isEqualTo(1);
+        assertThat(summary.deletedBatches()).isEqualTo(1);
+
+        assertThat(batchRepository.existsById(baselineBatchId)).isTrue();
+        assertThat(batchRepository.existsById(eligibleBatchId)).isFalse();
+    }
 }

--- a/src/test/java/com/bitbi/dfm/integration/BatchRetentionIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/BatchRetentionIntegrationTest.java
@@ -1,0 +1,154 @@
+package com.bitbi.dfm.integration;
+
+import com.bitbi.dfm.batch.application.BatchRetentionService;
+import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupRequest;
+import com.bitbi.dfm.batch.domain.BatchRepository;
+import com.bitbi.dfm.error.domain.ErrorLogRepository;
+import com.bitbi.dfm.upload.domain.UploadedFileRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Batch Retention Integration Tests (Testcontainers)")
+class BatchRetentionIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private BatchRetentionService batchRetentionService;
+
+    @Autowired
+    private BatchRepository batchRepository;
+
+    @Autowired
+    private ErrorLogRepository errorLogRepository;
+
+    @Autowired
+    private UploadedFileRepository uploadedFileRepository;
+
+    @Test
+    @Transactional
+    @DisplayName("Should cleanup eligible batches and cascade error logs")
+    void shouldCleanupEligibleBatches() {
+        UUID accountId = UUID.randomUUID();
+        UUID siteId = UUID.randomUUID();
+        UUID eligibleBatchId = UUID.randomUUID();
+        UUID inProgressBatchId = UUID.randomUUID();
+        UUID recentBatchId = UUID.randomUUID();
+        UUID errorId = UUID.randomUUID();
+        UUID fileId = UUID.randomUUID();
+
+        String compositeDomain = accountId + "_example.com";
+        String secretHash = "$2a$10$7EqJtq98hPqEX7fNZaFWoOhiN4Y7sJpX6dC";
+
+        jdbcTemplate.update(
+                "INSERT INTO accounts (id, email, name, is_active, created_at, updated_at) VALUES (?,?,?,?,NOW(),NOW())",
+                accountId,
+                "retention-test@example.com",
+                "Retention Test",
+                true
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, retention_days, created_at, updated_at) VALUES (?,?,?,?,?,?,?,NOW(),NOW())",
+                siteId,
+                accountId,
+                compositeDomain,
+                secretHash,
+                "Retention Site",
+                true,
+                45
+        );
+
+        LocalDateTime oldStartedAt = LocalDateTime.now().minusDays(60);
+        LocalDateTime recentStartedAt = LocalDateTime.now().minusDays(10);
+
+        jdbcTemplate.update(
+                "INSERT INTO batches (id, site_id, account_id, status, s3_path, uploaded_files_count, total_size, has_errors, started_at, completed_at, created_at, version) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),0)",
+                eligibleBatchId,
+                siteId,
+                accountId,
+                "COMPLETED",
+                "path/eligible/",
+                1,
+                100,
+                false,
+                oldStartedAt,
+                oldStartedAt.plusMinutes(5)
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO batches (id, site_id, account_id, status, s3_path, uploaded_files_count, total_size, has_errors, started_at, completed_at, created_at, version) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),0)",
+                inProgressBatchId,
+                siteId,
+                accountId,
+                "IN_PROGRESS",
+                "path/in-progress/",
+                0,
+                0,
+                false,
+                oldStartedAt,
+                null
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO batches (id, site_id, account_id, status, s3_path, uploaded_files_count, total_size, has_errors, started_at, completed_at, created_at, version) VALUES (?,?,?,?,?,?,?,?,?,?,NOW(),0)",
+                recentBatchId,
+                siteId,
+                accountId,
+                "COMPLETED",
+                "path/recent/",
+                0,
+                0,
+                false,
+                recentStartedAt,
+                recentStartedAt.plusMinutes(5)
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO uploaded_files (id, batch_id, original_file_name, s3_key, file_size, content_type, checksum, uploaded_at) VALUES (?,?,?,?,?,?,?,NOW())",
+                fileId,
+                eligibleBatchId,
+                "data.csv",
+                "path/eligible/data.csv",
+                100,
+                "text/csv",
+                "checksum"
+        );
+
+        jdbcTemplate.update(
+                "INSERT INTO error_logs (id, site_id, batch_id, type, title, message, stack_trace, client_version, metadata, occurred_at, created_at) VALUES (?,?,?,?,?,?,?,?,?::jsonb,NOW(),NOW())",
+                errorId,
+                siteId,
+                eligibleBatchId,
+                "UPLOAD_ERROR",
+                "Test Error",
+                "Test error message",
+                null,
+                null,
+                "{}"
+        );
+
+        BatchRetentionService.BatchCleanupSummary summary = batchRetentionService.runCleanup(
+                new BatchCleanupRequest(siteId, null, null, null, 100, false)
+        );
+
+        assertThat(summary.candidates()).isEqualTo(1);
+        assertThat(summary.deletedBatches()).isEqualTo(1);
+
+        assertThat(batchRepository.existsById(eligibleBatchId)).isFalse();
+        assertThat(batchRepository.existsById(inProgressBatchId)).isTrue();
+        assertThat(batchRepository.existsById(recentBatchId)).isTrue();
+
+        assertThat(uploadedFileRepository.countByBatchId(eligibleBatchId)).isZero();
+        assertThat(errorLogRepository.countByBatchId(eligibleBatchId)).isZero();
+    }
+}

--- a/src/test/java/com/bitbi/dfm/site/application/SiteServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/site/application/SiteServiceTest.java
@@ -210,6 +210,24 @@ class SiteServiceTest {
     }
 
     @Test
+    @DisplayName("updateRetentionDays - Should update site retention policy")
+    void updateRetentionDays_ShouldUpdateRetentionPolicy() {
+        // Given
+        Site mockSite = mock(Site.class);
+        when(siteRepository.findById(siteId)).thenReturn(Optional.of(mockSite));
+        when(siteRepository.save(mockSite)).thenReturn(mockSite);
+
+        // When
+        Site result = siteService.updateRetentionDays(siteId, 45);
+
+        // Then
+        assertThat(result).isEqualTo(mockSite);
+        verify(siteRepository).findById(siteId);
+        verify(mockSite).updateRetentionDays(45);
+        verify(siteRepository).save(mockSite);
+    }
+
+    @Test
     @DisplayName("deleteSite - Should hard delete site with cascade deletion of all related data")
     void deleteSite_ShouldHardDeleteWithCascade() {
         // Given

--- a/src/test/java/com/bitbi/dfm/site/domain/SiteTest.java
+++ b/src/test/java/com/bitbi/dfm/site/domain/SiteTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit tests for Site entity.
@@ -120,6 +121,36 @@ class SiteTest {
 
             // Then
             assertThat(displayDomain).isEqualTo("roshel");
+        }
+    }
+
+    @Nested
+    @DisplayName("updateRetentionDays() - Validation")
+    class UpdateRetentionDays {
+
+        @Test
+        @DisplayName("Should accept retention days in range 1..3650")
+        void shouldAcceptValidRetentionDays() {
+            Site site = Site.createForTesting(UUID.randomUUID(), "example.com", "Example");
+            site.updateRetentionDays(1);
+            assertThat(site.getRetentionDays()).isEqualTo(1);
+
+            site.updateRetentionDays(3650);
+            assertThat(site.getRetentionDays()).isEqualTo(3650);
+        }
+
+        @Test
+        @DisplayName("Should reject retention days outside 1..3650")
+        void shouldRejectInvalidRetentionDays() {
+            Site site = Site.createForTesting(UUID.randomUUID(), "example.com", "Example");
+
+            assertThatThrownBy(() -> site.updateRetentionDays(0))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("between 1 and");
+
+            assertThatThrownBy(() -> site.updateRetentionDays(3651))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("between 1 and");
         }
     }
 

--- a/src/test/java/com/bitbi/dfm/site/domain/SiteTest.java
+++ b/src/test/java/com/bitbi/dfm/site/domain/SiteTest.java
@@ -136,12 +136,12 @@ class SiteTest {
         try {
             java.lang.reflect.Constructor<Site> constructor = Site.class.getDeclaredConstructor(
                     UUID.class, UUID.class, String.class, String.class,
-                    String.class, Boolean.class, LocalDateTime.class, LocalDateTime.class
+                    String.class, Boolean.class, Integer.class, LocalDateTime.class, LocalDateTime.class
             );
             constructor.setAccessible(true);
             return constructor.newInstance(
                     id, accountId, domain, "$2a$10$dummyHash",
-                    "Test Site", true, now, now
+                    "Test Site", true, 45, now, now
             );
         } catch (Exception e) {
             throw new RuntimeException("Failed to create Site for testing", e);

--- a/src/test/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDtoTest.java
+++ b/src/test/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDtoTest.java
@@ -32,6 +32,7 @@ class SiteResponseDtoTest {
         when(site.getDisplayDomain()).thenReturn("example.com"); // Use getDisplayDomain() per FR-019
         when(site.getDisplayName()).thenReturn("Example Site");
         when(site.getIsActive()).thenReturn(true);
+        when(site.getRetentionDays()).thenReturn(45);
         when(site.getCreatedAt()).thenReturn(createdAt);
 
         // When
@@ -44,6 +45,7 @@ class SiteResponseDtoTest {
         assertEquals("example.com", dto.domain()); // domain field shows display format only
         assertEquals("Example Site", dto.name());
         assertEquals(true, dto.isActive());
+        assertEquals(45, dto.retentionDays());
         assertEquals(createdAt.toInstant(ZoneOffset.UTC), dto.createdAt());
     }
 
@@ -57,6 +59,7 @@ class SiteResponseDtoTest {
         when(site.getDisplayDomain()).thenReturn("secure.example.com"); // Use getDisplayDomain() per FR-019
         when(site.getDisplayName()).thenReturn("Secure Site");
         when(site.getIsActive()).thenReturn(true);
+        when(site.getRetentionDays()).thenReturn(30);
         when(site.getCreatedAt()).thenReturn(LocalDateTime.now());
         // Note: Site entity has clientSecretHash field which should NOT be exposed
 
@@ -66,7 +69,7 @@ class SiteResponseDtoTest {
         // Then
         assertNotNull(dto);
         // Verify DTO only contains safe fields (6 fields total)
-        assertEquals(6, dto.getClass().getRecordComponents().length);
+        assertEquals(7, dto.getClass().getRecordComponents().length);
         // Verify no clientSecret-like field exists in DTO
         assertDoesNotThrow(() -> {
             dto.id();
@@ -74,6 +77,7 @@ class SiteResponseDtoTest {
             dto.domain();
             dto.name();
             dto.isActive();
+            dto.retentionDays();
             dto.createdAt();
         });
     }

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -18,11 +18,12 @@ DELETE FROM file_comparisons WHERE account_id IN (SELECT id FROM accounts WHERE 
 DELETE FROM admin_action_logs WHERE target_account_id IN (SELECT id FROM accounts WHERE email LIKE '%@example.com') OR admin_account_id IN (SELECT id FROM accounts WHERE email LIKE '%@example.com');
 DELETE FROM error_logs WHERE site_id IN (SELECT id FROM sites WHERE domain LIKE '%.example.com');
 DELETE FROM uploaded_files WHERE batch_id IN (SELECT id FROM batches WHERE site_id IN (SELECT id FROM sites WHERE domain LIKE '%.example.com'));
+-- account_plugins may reference batches via baseline_batch_id (FK RESTRICT), so must be deleted before batches
+DELETE FROM account_plugins WHERE account_id IN (SELECT id FROM accounts WHERE email LIKE '%@example.com');
 DELETE FROM batches WHERE site_id IN (SELECT id FROM sites WHERE domain LIKE '%.example.com');
 DELETE FROM sites WHERE domain LIKE '%.example.com';
 -- Clean up plugin-related data (FK to accounts or referencing account)
 -- Note: plugin_audit_logs cleanup skipped - table is partitioned and should be empty in tests
-DELETE FROM account_plugins WHERE account_id IN (SELECT id FROM accounts WHERE email LIKE '%@example.com');
 DELETE FROM accounts WHERE email LIKE '%@example.com';
 
 -- Test accounts


### PR DESCRIPTION
## Summary
- Implement/advance batch retention cleanup feature work (branch scope).
- DevContainer: build devcontainer image with Node 20 + npm so frontend can run in-container.
- Frontend: make `npm run test` non-watch (use `vitest run`), add `test:watch`.
- Frontend: add dev stub for `/env-config.js` to prevent blank page when file is missing.
- Frontend: bind Vite dev server to all interfaces to make VS Code port forwarding reliable.
- Dev compose: remove Keycloak from local infra (Auth0-only local flow).

## How To Test
- Backend: `./gradlew test`
- Frontend: `cd frontend && npm run test`
- DevContainer: `Dev Containers: Rebuild and Reopen in Container`, then `cd frontend && npm ci && npm run dev`

## Notes
- Auth0 SPA Client ID must be valid for tenant `dev-dfm.us.auth0.com` (otherwise Auth0 shows 'Unknown client').
