### PR TITLE
Admin: UI + API to configure retention cleanup schedule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ docker-compose up postgres localstack     # Start dependencies
 - One active batch per site (query check)
 - Max 5 concurrent batches per account
 - 60-minute batch timeout (scheduled task)
+- Retention cleanup schedule is configurable by admins (cron via `/api/v1/admin/settings/batch-retention-schedule`)
 - 500MB file size limit
 
 ## Code Style

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -17,6 +17,7 @@ const ComparisonListPage = lazy(() => import('@/pages/comparison/ComparisonListP
 const ComparisonDetailPage = lazy(() => import('@/pages/comparison/ComparisonDetailPage'))
 const PluginsAdminPage = lazy(() => import('@/pages/admin/plugins/PluginsAdminPage'))
 const PluginHistoryPage = lazy(() => import('@/pages/admin/plugins/PluginHistoryPage'))
+const AdminSettingsPage = lazy(() => import('@/pages/admin/settings/AdminSettingsPage'))
 const MyPluginsPage = lazy(() => import('@/pages/account/plugins').then(m => ({ default: m.MyPluginsPage })))
 const DeviceVerifyPage = lazy(() => import('@/pages/device-verify/DeviceVerifyPage'))
 
@@ -92,6 +93,12 @@ const pluginHistoryRoute = createRoute({
   component: () => <AuthenticationGuard component={PluginHistoryPage} />,
 })
 
+const adminSettingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/admin/settings',
+  component: () => <AuthenticationGuard component={AdminSettingsPage} />,
+})
+
 // User routes - protected with UserOnlyGuard (redirects admins to /admin/users)
 const siteManagementRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -152,6 +159,7 @@ const routeTree = rootRoute.addChildren([
   userSitesRoute,
   pluginsAdminRoute,
   pluginHistoryRoute,
+  adminSettingsRoute,
   siteManagementRoute,
   uploadHistoryRoute,
   batchDetailRoute,

--- a/frontend/src/entities/settings/api/settingsApi.ts
+++ b/frontend/src/entities/settings/api/settingsApi.ts
@@ -1,0 +1,14 @@
+import { apiClient } from '@/shared/api/client';
+import { SETTINGS_BATCH_RETENTION_SCHEDULE } from '@/shared/api/apiRoutes';
+import type { BatchRetentionSchedule } from '../model/types';
+
+export async function getBatchRetentionSchedule(): Promise<BatchRetentionSchedule> {
+  const response = await apiClient.get<BatchRetentionSchedule>(SETTINGS_BATCH_RETENTION_SCHEDULE);
+  return response.data;
+}
+
+export async function updateBatchRetentionSchedule(cron: string): Promise<BatchRetentionSchedule> {
+  const response = await apiClient.put<BatchRetentionSchedule>(SETTINGS_BATCH_RETENTION_SCHEDULE, { cron });
+  return response.data;
+}
+

--- a/frontend/src/entities/settings/index.ts
+++ b/frontend/src/entities/settings/index.ts
@@ -1,0 +1,3 @@
+export type { BatchRetentionSchedule, BatchRetentionScheduleSource } from './model/types';
+export { getBatchRetentionSchedule, updateBatchRetentionSchedule } from './api/settingsApi';
+

--- a/frontend/src/entities/settings/model/types.ts
+++ b/frontend/src/entities/settings/model/types.ts
@@ -1,0 +1,8 @@
+export type BatchRetentionScheduleSource = 'DB' | 'CONFIG';
+
+export interface BatchRetentionSchedule {
+  cron: string;
+  source: BatchRetentionScheduleSource;
+  updatedAt: string | null;
+}
+

--- a/frontend/src/pages/admin/settings/AdminSettingsPage.tsx
+++ b/frontend/src/pages/admin/settings/AdminSettingsPage.tsx
@@ -1,0 +1,135 @@
+/**
+ * AdminSettingsPage - Admin view for runtime-configurable system settings.
+ *
+ * Route: /admin/settings
+ * Requires: ROLE_ADMIN (backend enforced)
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Header } from '@/widgets/header/Header';
+import { Button } from '@/shared/ui/ui/button';
+import { Card, CardContent } from '@/shared/ui/ui/card';
+import { Label } from '@/shared/ui/ui/label';
+import { Input } from '@/shared/ui/ui/input';
+import { toast } from 'sonner';
+import { getBatchRetentionSchedule, updateBatchRetentionSchedule } from '@/entities/settings';
+
+const settingsKeys = {
+  all: ['settings'] as const,
+  retentionSchedule: () => [...settingsKeys.all, 'batchRetentionSchedule'] as const,
+};
+
+export default function AdminSettingsPage() {
+  const queryClient = useQueryClient();
+
+  const scheduleQuery = useQuery({
+    queryKey: settingsKeys.retentionSchedule(),
+    queryFn: getBatchRetentionSchedule,
+    staleTime: 0,
+    gcTime: 300000,
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (cron: string) => updateBatchRetentionSchedule(cron),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: settingsKeys.retentionSchedule() });
+      toast.success('Schedule updated');
+    },
+    onError: (error: any) => {
+      toast.error(error?.response?.data?.message || 'Failed to update schedule');
+    },
+  });
+
+  const [cron, setCron] = useState<string>('');
+
+  useEffect(() => {
+    if (scheduleQuery.data?.cron) setCron(scheduleQuery.data.cron);
+  }, [scheduleQuery.data?.cron]);
+
+  const metaText = useMemo(() => {
+    if (!scheduleQuery.data) return '';
+    const updatedAt = scheduleQuery.data.updatedAt ? new Date(scheduleQuery.data.updatedAt).toLocaleString() : null;
+    return scheduleQuery.data.source === 'DB'
+      ? `Source: DB${updatedAt ? ` (updated ${updatedAt})` : ''}`
+      : 'Source: CONFIG (env/default)';
+  }, [scheduleQuery.data]);
+
+  const save = async () => {
+    const trimmed = cron.trim();
+    if (!trimmed) {
+      toast.error('Cron cannot be empty');
+      return;
+    }
+    await updateMutation.mutateAsync(trimmed);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6 lg:px-8 space-y-6">
+        <div>
+          <h2 className="text-2xl font-semibold text-gray-900">Admin Settings</h2>
+          <p className="text-sm text-gray-600 mt-1">
+            Runtime-configurable system settings (admin only).
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="p-6 space-y-4">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900">Retention Cleanup Schedule</h3>
+              <p className="text-sm text-muted-foreground">
+                Controls when old batches/uploads are deleted automatically. Cron format: sec min hour day month day-of-week.
+              </p>
+              {metaText && (
+                <p className="mt-2 text-xs text-gray-500">{metaText}</p>
+              )}
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2 md:col-span-2">
+                <Label htmlFor="retention-cron">Cron</Label>
+                <Input
+                  id="retention-cron"
+                  placeholder="0 0 2 * * *"
+                  value={cron}
+                  onChange={(e) => setCron(e.target.value)}
+                  disabled={scheduleQuery.isLoading || updateMutation.isPending}
+                />
+                <div className="text-xs text-gray-500">
+                  Examples: daily 02:00 = <code className="font-mono">0 0 2 * * *</code>, every 6 hours =
+                  <code className="ml-1 font-mono">0 0 */6 * * *</code>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => scheduleQuery.refetch()}
+                disabled={updateMutation.isPending}
+              >
+                Refresh
+              </Button>
+              <Button
+                onClick={save}
+                disabled={scheduleQuery.isLoading || updateMutation.isPending}
+              >
+                Save
+              </Button>
+            </div>
+
+            {scheduleQuery.isError && (
+              <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+                Failed to load schedule.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}
+

--- a/frontend/src/pages/admin/settings/AdminSettingsPage.tsx
+++ b/frontend/src/pages/admin/settings/AdminSettingsPage.tsx
@@ -26,7 +26,7 @@ export default function AdminSettingsPage() {
   const scheduleQuery = useQuery({
     queryKey: settingsKeys.retentionSchedule(),
     queryFn: getBatchRetentionSchedule,
-    staleTime: 0,
+    staleTime: 60000, // settings change infrequently
     gcTime: 300000,
   });
 
@@ -117,7 +117,7 @@ export default function AdminSettingsPage() {
                 onClick={save}
                 disabled={scheduleQuery.isLoading || updateMutation.isPending}
               >
-                Save
+                {updateMutation.isPending ? 'Saving...' : 'Save'}
               </Button>
             </div>
 
@@ -132,4 +132,3 @@ export default function AdminSettingsPage() {
     </div>
   );
 }
-

--- a/frontend/src/shared/api/apiRoutes.ts
+++ b/frontend/src/shared/api/apiRoutes.ts
@@ -113,6 +113,10 @@ export const ADMIN_PLUGINS = `${ADMIN_API_BASE}/admin/plugins`;
 export const ADMIN_PLUGINS_AUDIT = `${ADMIN_PLUGINS}/audit`;
 export const ADMIN_PLUGINS_AUDIT_BY_PLUGIN = (pluginId: string) => `${ADMIN_PLUGINS}/${pluginId}/audit`;
 
+// Admin Settings
+export const ADMIN_SETTINGS = `${ADMIN_API_BASE}/admin/settings`;
+export const SETTINGS_BATCH_RETENTION_SCHEDULE = `${ADMIN_SETTINGS}/batch-retention-schedule`;
+
 // Account Plugins (User-facing)
 export const ACCOUNT_PLUGINS = `${ADMIN_API_BASE}/account/plugins`;
 export const ACCOUNT_PLUGIN_LOGS = (pluginId: string) => `${ACCOUNT_PLUGINS}/${pluginId}/logs`;

--- a/frontend/src/widgets/header/Header.tsx
+++ b/frontend/src/widgets/header/Header.tsx
@@ -113,6 +113,19 @@ export function Header() {
               </Link>
             )}
 
+            {/* Settings - only visible for ADMIN role */}
+            {isAdmin && (
+              <Link
+                to="/admin/settings"
+                className="text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors"
+                activeProps={{
+                  className: 'text-sm font-medium text-primary hover:text-primary',
+                }}
+              >
+                Settings
+              </Link>
+            )}
+
             {/* Current User Info */}
             <div className="flex items-center gap-2 ml-4 border-l border-gray-300 pl-4 text-sm text-gray-600">
               <User className="h-4 w-4" />

--- a/frontend/tests/unit/pages/admin/settings/AdminSettingsPage.test.tsx
+++ b/frontend/tests/unit/pages/admin/settings/AdminSettingsPage.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AdminSettingsPage from '@/pages/admin/settings/AdminSettingsPage';
+import { toast } from 'sonner';
+import * as settings from '@/entities/settings';
+
+vi.mock('@/widgets/header/Header', () => ({
+  Header: () => <header data-testid="header">Header</header>,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/entities/settings', () => ({
+  getBatchRetentionSchedule: vi.fn(),
+  updateBatchRetentionSchedule: vi.fn(),
+}));
+
+const renderWithQueryClient = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {ui}
+    </QueryClientProvider>
+  );
+};
+
+describe('AdminSettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('loads and displays current cron value', async () => {
+    vi.mocked(settings.getBatchRetentionSchedule).mockResolvedValue({
+      cron: '0 0 2 * * *',
+      source: 'CONFIG',
+      updatedAt: null,
+    } as any);
+
+    renderWithQueryClient(<AdminSettingsPage />);
+
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+
+    const input = await screen.findByLabelText('Cron');
+    await waitFor(() => {
+      expect(input).toHaveValue('0 0 2 * * *');
+    });
+  });
+
+  it('submits updated cron and shows success toast', async () => {
+    vi.mocked(settings.getBatchRetentionSchedule).mockResolvedValue({
+      cron: '0 0 2 * * *',
+      source: 'CONFIG',
+      updatedAt: null,
+    } as any);
+
+    vi.mocked(settings.updateBatchRetentionSchedule).mockResolvedValue({
+      cron: '0 0 3 * * *',
+      source: 'DB',
+      updatedAt: '2026-02-08T00:00:00Z',
+    } as any);
+
+    renderWithQueryClient(<AdminSettingsPage />);
+
+    const input = await screen.findByLabelText('Cron');
+    await waitFor(() => {
+      expect(input).not.toBeDisabled();
+      expect(input).toHaveValue('0 0 2 * * *');
+    });
+    await userEvent.clear(input);
+    await userEvent.type(input, '0 0 3 * * *');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(settings.updateBatchRetentionSchedule).toHaveBeenCalledWith('0 0 3 * * *');
+      expect(toast.success).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleChangedEvent.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleChangedEvent.java
@@ -1,0 +1,8 @@
+package com.bitbi.dfm.batch.application;
+
+/**
+ * Published when the batch retention cleanup cron schedule is updated.
+ */
+public record BatchRetentionScheduleChangedEvent(String cron) {
+}
+

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleService.java
@@ -1,0 +1,84 @@
+package com.bitbi.dfm.batch.application;
+
+import com.bitbi.dfm.settings.domain.AppSetting;
+import com.bitbi.dfm.settings.domain.AppSettingRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.support.CronExpression;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * Resolves and persists runtime-configurable scheduling settings for batch retention cleanup.
+ */
+@Service
+public class BatchRetentionScheduleService {
+
+    private static final Logger logger = LoggerFactory.getLogger(BatchRetentionScheduleService.class);
+
+    public static final String CRON_SETTING_KEY = "batch.retention.cron";
+
+    private final AppSettingRepository appSettingRepository;
+    private final String fallbackCron;
+
+    public BatchRetentionScheduleService(
+            AppSettingRepository appSettingRepository,
+            @Value("${batch.retention.cron:0 0 2 * * *}") String fallbackCron) {
+        this.appSettingRepository = appSettingRepository;
+        this.fallbackCron = fallbackCron;
+    }
+
+    public BatchRetentionSchedule getSchedule() {
+        Optional<AppSetting> stored = appSettingRepository.findById(CRON_SETTING_KEY);
+        if (stored.isPresent()) {
+            String value = stored.get().getValue();
+            if (isValidCron(value)) {
+                return new BatchRetentionSchedule(value, BatchRetentionScheduleSource.DB, stored.get().getUpdatedAt());
+            }
+            logger.warn("Invalid cron expression stored for {}: '{}'. Falling back to configured default.", CRON_SETTING_KEY, value);
+        }
+        return new BatchRetentionSchedule(fallbackCron, BatchRetentionScheduleSource.CONFIG, null);
+    }
+
+    public String getEffectiveCron() {
+        return getSchedule().cron();
+    }
+
+    @Transactional
+    public BatchRetentionSchedule updateCron(String cron) {
+        if (cron == null || cron.isBlank()) {
+            throw new IllegalArgumentException("cron cannot be blank");
+        }
+        if (!isValidCron(cron)) {
+            throw new IllegalArgumentException("Invalid cron expression: " + cron);
+        }
+
+        AppSetting setting = appSettingRepository.findById(CRON_SETTING_KEY)
+                .orElseGet(() -> new AppSetting(CRON_SETTING_KEY, cron));
+        setting.setValue(cron);
+        AppSetting saved = appSettingRepository.save(setting);
+
+        return new BatchRetentionSchedule(saved.getValue(), BatchRetentionScheduleSource.DB, saved.getUpdatedAt());
+    }
+
+    private boolean isValidCron(String cron) {
+        try {
+            CronExpression.parse(cron);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public enum BatchRetentionScheduleSource {
+        DB,
+        CONFIG
+    }
+
+    public record BatchRetentionSchedule(String cron, BatchRetentionScheduleSource source, Instant updatedAt) {}
+}
+

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleService.java
@@ -5,6 +5,7 @@ import com.bitbi.dfm.settings.domain.AppSettingRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,12 +24,15 @@ public class BatchRetentionScheduleService {
     public static final String CRON_SETTING_KEY = "batch.retention.cron";
 
     private final AppSettingRepository appSettingRepository;
+    private final ApplicationEventPublisher eventPublisher;
     private final String fallbackCron;
 
     public BatchRetentionScheduleService(
             AppSettingRepository appSettingRepository,
+            ApplicationEventPublisher eventPublisher,
             @Value("${batch.retention.cron:0 0 2 * * *}") String fallbackCron) {
         this.appSettingRepository = appSettingRepository;
+        this.eventPublisher = eventPublisher;
         this.fallbackCron = fallbackCron;
     }
 
@@ -53,14 +57,15 @@ public class BatchRetentionScheduleService {
         if (cron == null || cron.isBlank()) {
             throw new IllegalArgumentException("cron cannot be blank");
         }
-        if (!isValidCron(cron)) {
-            throw new IllegalArgumentException("Invalid cron expression: " + cron);
-        }
+        validateCronOrThrow(cron);
 
         AppSetting setting = appSettingRepository.findById(CRON_SETTING_KEY)
                 .orElseGet(() -> new AppSetting(CRON_SETTING_KEY, cron));
         setting.setValue(cron);
         AppSetting saved = appSettingRepository.save(setting);
+
+        // Notify scheduler to reschedule without requiring restart.
+        eventPublisher.publishEvent(new BatchRetentionScheduleChangedEvent(saved.getValue()));
 
         return new BatchRetentionSchedule(saved.getValue(), BatchRetentionScheduleSource.DB, saved.getUpdatedAt());
     }
@@ -74,6 +79,18 @@ public class BatchRetentionScheduleService {
         }
     }
 
+    private void validateCronOrThrow(String cron) {
+        try {
+            CronExpression.parse(cron);
+        } catch (Exception e) {
+            String message = e.getMessage() != null ? e.getMessage() : "invalid format";
+            throw new IllegalArgumentException(
+                    "Invalid cron expression: " + message +
+                            ". Expected format: sec min hour day month day-of-week (e.g., '0 0 2 * * *')."
+            );
+        }
+    }
+
     public enum BatchRetentionScheduleSource {
         DB,
         CONFIG
@@ -81,4 +98,3 @@ public class BatchRetentionScheduleService {
 
     public record BatchRetentionSchedule(String cron, BatchRetentionScheduleSource source, Instant updatedAt) {}
 }
-

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduler.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduler.java
@@ -5,35 +5,52 @@ import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupSummary
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
 /**
  * Scheduled task to cleanup expired batches based on retention policies.
  */
 @Component
-public class BatchRetentionScheduler {
+public class BatchRetentionScheduler implements SchedulingConfigurer {
 
     private static final Logger logger = LoggerFactory.getLogger(BatchRetentionScheduler.class);
+    private static final String DEFAULT_FALLBACK_CRON = "0 0 2 * * *";
 
     private final BatchRetentionService batchRetentionService;
+    private final BatchRetentionScheduleService scheduleService;
     private final int cleanupLimit;
 
     public BatchRetentionScheduler(
             BatchRetentionService batchRetentionService,
+            BatchRetentionScheduleService scheduleService,
             @Value("${batch.retention.cleanup-limit:1000}") int cleanupLimit) {
         this.batchRetentionService = batchRetentionService;
+        this.scheduleService = scheduleService;
         this.cleanupLimit = cleanupLimit;
     }
 
-    /**
-     * Run retention cleanup.
-     * <p>
-     * Default schedule: daily at 02:00.
-     * Override with batch.retention.cron.
-     * </p>
-     */
-    @Scheduled(cron = "${batch.retention.cron:0 0 2 * * *}")
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.addTriggerTask(this::runRetentionCleanup, cronTrigger());
+    }
+
+    private Trigger cronTrigger() {
+        return triggerContext -> {
+            String cron = scheduleService.getEffectiveCron();
+            try {
+                return new CronTrigger(cron).nextExecution(triggerContext);
+            } catch (Exception e) {
+                logger.error("Failed to compute next execution time for retention cleanup cron='{}'. Falling back to default cron='{}'.",
+                        cron, DEFAULT_FALLBACK_CRON, e);
+                return new CronTrigger(DEFAULT_FALLBACK_CRON).nextExecution(triggerContext);
+            }
+        };
+    }
+
     public void runRetentionCleanup() {
         logger.info("Starting retention cleanup job (limit={})", cleanupLimit);
 

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduler.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchRetentionScheduler.java
@@ -2,57 +2,99 @@ package com.bitbi.dfm.batch.application;
 
 import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupRequest;
 import com.bitbi.dfm.batch.application.BatchRetentionService.BatchCleanupSummary;
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.Trigger;
-import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * Scheduled task to cleanup expired batches based on retention policies.
+ *
+ * <p>
+ * Uses a dynamic cron schedule that can be updated at runtime via admin settings.
+ * When the cron is updated, the scheduler is rescheduled without restarting the app.
+ * </p>
  */
 @Component
-public class BatchRetentionScheduler implements SchedulingConfigurer {
+public class BatchRetentionScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger(BatchRetentionScheduler.class);
     private static final String DEFAULT_FALLBACK_CRON = "0 0 2 * * *";
 
+    private final TaskScheduler taskScheduler;
     private final BatchRetentionService batchRetentionService;
     private final BatchRetentionScheduleService scheduleService;
     private final int cleanupLimit;
 
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    private final Object scheduleLock = new Object();
+    private volatile ScheduledFuture<?> scheduledFuture;
+    private volatile String scheduledCron;
+
     public BatchRetentionScheduler(
+            TaskScheduler taskScheduler,
             BatchRetentionService batchRetentionService,
             BatchRetentionScheduleService scheduleService,
             @Value("${batch.retention.cleanup-limit:1000}") int cleanupLimit) {
+        this.taskScheduler = taskScheduler;
         this.batchRetentionService = batchRetentionService;
         this.scheduleService = scheduleService;
         this.cleanupLimit = cleanupLimit;
     }
 
-    @Override
-    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-        taskRegistrar.addTriggerTask(this::runRetentionCleanup, cronTrigger());
+    @PostConstruct
+    public void initialize() {
+        reschedule(scheduleService.getEffectiveCron());
     }
 
-    private Trigger cronTrigger() {
-        return triggerContext -> {
-            String cron = scheduleService.getEffectiveCron();
-            try {
-                return new CronTrigger(cron).nextExecution(triggerContext);
-            } catch (Exception e) {
-                logger.error("Failed to compute next execution time for retention cleanup cron='{}'. Falling back to default cron='{}'.",
-                        cron, DEFAULT_FALLBACK_CRON, e);
-                return new CronTrigger(DEFAULT_FALLBACK_CRON).nextExecution(triggerContext);
+    @EventListener
+    public void onScheduleChanged(BatchRetentionScheduleChangedEvent event) {
+        if (event == null || event.cron() == null || event.cron().isBlank()) {
+            return;
+        }
+        reschedule(event.cron());
+    }
+
+    private void reschedule(String cron) {
+        String desiredCron = cron != null && !cron.isBlank() ? cron : DEFAULT_FALLBACK_CRON;
+
+        synchronized (scheduleLock) {
+            if (desiredCron.equals(scheduledCron) && scheduledFuture != null && !scheduledFuture.isCancelled()) {
+                return;
             }
-        };
+
+            if (scheduledFuture != null) {
+                scheduledFuture.cancel(false);
+            }
+
+            try {
+                scheduledFuture = taskScheduler.schedule(this::runRetentionCleanup, new CronTrigger(desiredCron));
+                scheduledCron = desiredCron;
+                logger.info("Retention cleanup scheduler configured: cron='{}', limit={}", scheduledCron, cleanupLimit);
+            } catch (Exception e) {
+                logger.error("Failed to schedule retention cleanup with cron='{}'. Falling back to cron='{}'.",
+                        desiredCron, DEFAULT_FALLBACK_CRON, e);
+                scheduledFuture = taskScheduler.schedule(this::runRetentionCleanup, new CronTrigger(DEFAULT_FALLBACK_CRON));
+                scheduledCron = DEFAULT_FALLBACK_CRON;
+            }
+        }
     }
 
     public void runRetentionCleanup() {
-        logger.info("Starting retention cleanup job (limit={})", cleanupLimit);
+        if (!running.compareAndSet(false, true)) {
+            logger.warn("Retention cleanup job is already running; skipping this trigger (cron='{}').", scheduledCron);
+            return;
+        }
+
+        logger.info("Starting retention cleanup job (limit={}, cron='{}')", cleanupLimit, scheduledCron);
 
         try {
             BatchCleanupSummary summary = batchRetentionService.runCleanup(
@@ -63,6 +105,9 @@ public class BatchRetentionScheduler implements SchedulingConfigurer {
                     summary.candidates(), summary.deletedBatches(), summary.deletedFiles(), summary.deletedBytes(), summary.errors().size());
         } catch (Exception e) {
             logger.error("Retention cleanup job failed: {}", e.getMessage(), e);
+        } finally {
+            running.set(false);
         }
     }
 }
+

--- a/src/main/java/com/bitbi/dfm/batch/presentation/BatchRetentionScheduleAdminController.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/BatchRetentionScheduleAdminController.java
@@ -1,0 +1,69 @@
+package com.bitbi.dfm.batch.presentation;
+
+import com.bitbi.dfm.batch.application.BatchRetentionScheduleService;
+import com.bitbi.dfm.batch.application.BatchRetentionScheduleService.BatchRetentionSchedule;
+import com.bitbi.dfm.batch.presentation.dto.BatchRetentionScheduleResponseDto;
+import com.bitbi.dfm.batch.presentation.dto.UpdateBatchRetentionScheduleRequestDto;
+import com.bitbi.dfm.shared.api.ApiRoutes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Admin controller for runtime scheduler settings (batch retention cleanup cron).
+ */
+@RestController
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "UI/Admin API - Settings", description = "Runtime-configurable settings for admins")
+@SecurityRequirement(name = "oauth2")
+public class BatchRetentionScheduleAdminController {
+
+    private final BatchRetentionScheduleService scheduleService;
+
+    public BatchRetentionScheduleAdminController(BatchRetentionScheduleService scheduleService) {
+        this.scheduleService = scheduleService;
+    }
+
+    @Operation(summary = "Get batch retention cleanup scheduler schedule")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Schedule returned",
+                    content = @Content(schema = @Schema(implementation = BatchRetentionScheduleResponseDto.class)))
+    })
+    @GetMapping(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+    public ResponseEntity<BatchRetentionScheduleResponseDto> getSchedule() {
+        BatchRetentionSchedule schedule = scheduleService.getSchedule();
+        return ResponseEntity.ok(new BatchRetentionScheduleResponseDto(
+                schedule.cron(),
+                schedule.source().name(),
+                schedule.updatedAt()
+        ));
+    }
+
+    @Operation(summary = "Update batch retention cleanup scheduler cron")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Schedule updated",
+                    content = @Content(schema = @Schema(implementation = BatchRetentionScheduleResponseDto.class)))
+    })
+    @PutMapping(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+    public ResponseEntity<BatchRetentionScheduleResponseDto> updateSchedule(
+            @Valid @RequestBody UpdateBatchRetentionScheduleRequestDto request) {
+        BatchRetentionSchedule schedule = scheduleService.updateCron(request.cron());
+        return ResponseEntity.ok(new BatchRetentionScheduleResponseDto(
+                schedule.cron(),
+                schedule.source().name(),
+                schedule.updatedAt()
+        ));
+    }
+}
+

--- a/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchRetentionScheduleResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchRetentionScheduleResponseDto.java
@@ -1,0 +1,17 @@
+package com.bitbi.dfm.batch.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+@Schema(description = "Batch retention cleanup scheduler settings")
+public record BatchRetentionScheduleResponseDto(
+        @Schema(description = "Cron expression (Spring format: sec min hour day month day-of-week)", example = "0 0 2 * * *")
+        String cron,
+        @Schema(description = "Where the effective value comes from", example = "DB")
+        String source,
+        @Schema(description = "When it was last updated (only for DB-sourced values)")
+        Instant updatedAt
+) {
+}
+

--- a/src/main/java/com/bitbi/dfm/batch/presentation/dto/UpdateBatchRetentionScheduleRequestDto.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/dto/UpdateBatchRetentionScheduleRequestDto.java
@@ -1,0 +1,13 @@
+package com.bitbi.dfm.batch.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "Update batch retention cleanup scheduler settings")
+public record UpdateBatchRetentionScheduleRequestDto(
+        @NotBlank
+        @Schema(description = "New cron expression (Spring format: sec min hour day month day-of-week)", example = "0 30 3 * * *")
+        String cron
+) {
+}
+

--- a/src/main/java/com/bitbi/dfm/settings/domain/AppSetting.java
+++ b/src/main/java/com/bitbi/dfm/settings/domain/AppSetting.java
@@ -40,6 +40,9 @@ public class AppSetting {
     public AppSetting(String key, String value) {
         this.key = Objects.requireNonNull(key, "key cannot be null");
         this.value = Objects.requireNonNull(value, "value cannot be null");
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
     }
 
     @PrePersist
@@ -64,6 +67,7 @@ public class AppSetting {
 
     public void setValue(String value) {
         this.value = Objects.requireNonNull(value, "value cannot be null");
+        this.updatedAt = Instant.now();
     }
 
     public Instant getCreatedAt() {
@@ -74,4 +78,3 @@ public class AppSetting {
         return updatedAt;
     }
 }
-

--- a/src/main/java/com/bitbi/dfm/settings/domain/AppSetting.java
+++ b/src/main/java/com/bitbi/dfm/settings/domain/AppSetting.java
@@ -1,0 +1,77 @@
+package com.bitbi.dfm.settings.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Simple key/value application setting stored in the database.
+ * <p>
+ * Used for runtime-configurable admin settings (e.g., scheduler cron).
+ * </p>
+ */
+@Entity
+@Table(name = "app_settings")
+public class AppSetting {
+
+    @Id
+    @Column(name = "setting_key", nullable = false)
+    private String key;
+
+    @Column(name = "setting_value", nullable = false)
+    private String value;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected AppSetting() {
+        // for JPA
+    }
+
+    public AppSetting(String key, String value) {
+        this.key = Objects.requireNonNull(key, "key cannot be null");
+        this.value = Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        if (createdAt == null) createdAt = now;
+        if (updatedAt == null) updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = Objects.requireNonNull(value, "value cannot be null");
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}
+

--- a/src/main/java/com/bitbi/dfm/settings/domain/AppSettingRepository.java
+++ b/src/main/java/com/bitbi/dfm/settings/domain/AppSettingRepository.java
@@ -1,0 +1,14 @@
+package com.bitbi.dfm.settings.domain;
+
+import java.util.Optional;
+
+/**
+ * Repository interface for application settings.
+ */
+public interface AppSettingRepository {
+
+    Optional<AppSetting> findById(String key);
+
+    AppSetting save(AppSetting setting);
+}
+

--- a/src/main/java/com/bitbi/dfm/settings/infrastructure/JpaAppSettingRepository.java
+++ b/src/main/java/com/bitbi/dfm/settings/infrastructure/JpaAppSettingRepository.java
@@ -1,0 +1,14 @@
+package com.bitbi.dfm.settings.infrastructure;
+
+import com.bitbi.dfm.settings.domain.AppSetting;
+import com.bitbi.dfm.settings.domain.AppSettingRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * JPA implementation of AppSettingRepository.
+ */
+@Repository
+public interface JpaAppSettingRepository extends JpaRepository<AppSetting, String>, AppSettingRepository {
+}
+

--- a/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
+++ b/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
@@ -458,6 +458,24 @@ public final class ApiRoutes {
      */
     public static final String BATCHES_CLEANUP = BATCHES_ADMIN + "/cleanup";
 
+    // Settings (Admin)
+    /**
+     * Base path for admin-managed runtime settings.
+     * <p>
+     * Requires: ROLE_ADMIN (Auth0)
+     * </p>
+     */
+    public static final String ADMIN_SETTINGS = ADMIN_API_BASE + "/admin/settings";
+
+    /**
+     * Batch retention cleanup scheduler settings.
+     * <p>
+     * Methods: GET, PUT<br>
+     * Authentication: Auth0 OAuth2 (ROLE_ADMIN)
+     * </p>
+     */
+    public static final String SETTINGS_BATCH_RETENTION_SCHEDULE = ADMIN_SETTINGS + "/batch-retention-schedule";
+
     // History (User-facing)
     /**
      * Base path for upload history endpoints.

--- a/src/main/resources/db/migration/V26__create_app_settings_table.sql
+++ b/src/main/resources/db/migration/V26__create_app_settings_table.sql
@@ -1,0 +1,10 @@
+-- Migration: V26__create_app_settings_table.sql
+-- Description: Create simple key/value settings table for runtime-configurable admin settings
+
+CREATE TABLE IF NOT EXISTS app_settings (
+    setting_key TEXT PRIMARY KEY,
+    setting_value TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+

--- a/src/test/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/batch/application/BatchRetentionScheduleServiceTest.java
@@ -1,0 +1,115 @@
+package com.bitbi.dfm.batch.application;
+
+import com.bitbi.dfm.settings.domain.AppSetting;
+import com.bitbi.dfm.settings.domain.AppSettingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("BatchRetentionScheduleService")
+class BatchRetentionScheduleServiceTest {
+
+    @Test
+    @DisplayName("getSchedule should fallback to config when DB has no value")
+    void getSchedule_shouldFallbackToConfig() {
+        InMemoryAppSettingRepository repo = new InMemoryAppSettingRepository();
+        CapturingEventPublisher publisher = new CapturingEventPublisher();
+        BatchRetentionScheduleService service = new BatchRetentionScheduleService(repo, publisher, "0 0 2 * * *");
+
+        var schedule = service.getSchedule();
+
+        assertThat(schedule.cron()).isEqualTo("0 0 2 * * *");
+        assertThat(schedule.source()).isEqualTo(BatchRetentionScheduleService.BatchRetentionScheduleSource.CONFIG);
+        assertThat(schedule.updatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateCron should persist value and publish schedule changed event")
+    void updateCron_shouldPersistAndPublish() {
+        InMemoryAppSettingRepository repo = new InMemoryAppSettingRepository();
+        CapturingEventPublisher publisher = new CapturingEventPublisher();
+        BatchRetentionScheduleService service = new BatchRetentionScheduleService(repo, publisher, "0 0 2 * * *");
+
+        var updated = service.updateCron("0 0 3 * * *");
+
+        assertThat(updated.cron()).isEqualTo("0 0 3 * * *");
+        assertThat(updated.source()).isEqualTo(BatchRetentionScheduleService.BatchRetentionScheduleSource.DB);
+        assertThat(updated.updatedAt()).isNotNull();
+
+        assertThat(repo.findById(BatchRetentionScheduleService.CRON_SETTING_KEY))
+                .isPresent()
+                .get()
+                .extracting(AppSetting::getValue)
+                .isEqualTo("0 0 3 * * *");
+
+        assertThat(publisher.events.stream()
+                .filter(e -> e instanceof BatchRetentionScheduleChangedEvent)
+                .map(e -> ((BatchRetentionScheduleChangedEvent) e).cron())
+                .toList()).contains("0 0 3 * * *");
+    }
+
+    @Test
+    @DisplayName("updateCron should reject invalid cron expressions with helpful message")
+    void updateCron_shouldRejectInvalidCron() {
+        InMemoryAppSettingRepository repo = new InMemoryAppSettingRepository();
+        CapturingEventPublisher publisher = new CapturingEventPublisher();
+        BatchRetentionScheduleService service = new BatchRetentionScheduleService(repo, publisher, "0 0 2 * * *");
+
+        assertThatThrownBy(() -> service.updateCron("not-a-cron"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Expected format");
+    }
+
+    @Test
+    @DisplayName("getSchedule should fallback to config when DB contains invalid value")
+    void getSchedule_shouldFallbackWhenDbInvalid() {
+        InMemoryAppSettingRepository repo = new InMemoryAppSettingRepository();
+        CapturingEventPublisher publisher = new CapturingEventPublisher();
+        BatchRetentionScheduleService service = new BatchRetentionScheduleService(repo, publisher, "0 0 2 * * *");
+
+        repo.save(new AppSetting(BatchRetentionScheduleService.CRON_SETTING_KEY, "bad bad bad"));
+
+        var schedule = service.getSchedule();
+        assertThat(schedule.source()).isEqualTo(BatchRetentionScheduleService.BatchRetentionScheduleSource.CONFIG);
+        assertThat(schedule.cron()).isEqualTo("0 0 2 * * *");
+    }
+
+    private static class InMemoryAppSettingRepository implements AppSettingRepository {
+        private final Map<String, AppSetting> data = new ConcurrentHashMap<>();
+
+        @Override
+        public Optional<AppSetting> findById(String key) {
+            return Optional.ofNullable(data.get(key));
+        }
+
+        @Override
+        public AppSetting save(AppSetting setting) {
+            data.put(setting.getKey(), setting);
+            return setting;
+        }
+    }
+
+    private static class CapturingEventPublisher implements ApplicationEventPublisher {
+        private final List<Object> events = new ArrayList<>();
+
+        @Override
+        public void publishEvent(Object event) {
+            events.add(event);
+        }
+
+        @Override
+        public void publishEvent(ApplicationEvent event) {
+            events.add(event);
+        }
+    }
+}

--- a/src/test/java/com/bitbi/dfm/integration/BatchRetentionScheduleAdminControllerIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/BatchRetentionScheduleAdminControllerIntegrationTest.java
@@ -1,0 +1,83 @@
+package com.bitbi.dfm.integration;
+
+import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Batch Retention Schedule Admin API Integration Tests")
+class BatchRetentionScheduleAdminControllerIntegrationTest extends BaseIntegrationTest {
+
+    @Test
+    @DisplayName("GET schedule with Auth0 admin token should return effective schedule")
+    void getSchedule_withAuth0_shouldReturn200() throws Exception {
+        String auth0Token = "Bearer mock.admin.jwt.token";
+
+        mockMvc.perform(get(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+                        .header("Authorization", auth0Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cron").value("0 0 2 * * *"))
+                .andExpect(jsonPath("$.source").value("CONFIG"))
+                .andExpect(jsonPath("$.updatedAt").isEmpty());
+    }
+
+    @Test
+    @DisplayName("PUT schedule with Auth0 admin token should persist schedule and return DB-sourced value")
+    void updateSchedule_withAuth0_shouldPersistAndReturnDbValue() throws Exception {
+        String auth0Token = "Bearer mock.admin.jwt.token";
+
+        String requestBody = """
+                { "cron": "0 0 3 * * *" }
+                """;
+
+        mockMvc.perform(put(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+                        .header("Authorization", auth0Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cron").value("0 0 3 * * *"))
+                .andExpect(jsonPath("$.source").value("DB"))
+                .andExpect(jsonPath("$.updatedAt").exists());
+
+        // Verify subsequent GET returns DB-sourced value.
+        mockMvc.perform(get(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+                        .header("Authorization", auth0Token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cron").value("0 0 3 * * *"))
+                .andExpect(jsonPath("$.source").value("DB"))
+                .andExpect(jsonPath("$.updatedAt").exists());
+    }
+
+    @Test
+    @DisplayName("PUT schedule with invalid cron should return 400")
+    void updateSchedule_invalidCron_shouldReturn400() throws Exception {
+        String auth0Token = "Bearer mock.admin.jwt.token";
+
+        String requestBody = """
+                { "cron": "not-a-cron" }
+                """;
+
+        mockMvc.perform(put(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+                        .header("Authorization", auth0Token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value(org.hamcrest.Matchers.containsString("Invalid cron expression")));
+    }
+
+    @Test
+    @DisplayName("GET schedule with JWT token should be rejected (unauthorized)")
+    void getSchedule_withJwt_shouldReturn401() throws Exception {
+        String jwtToken = generateTestToken();
+
+        mockMvc.perform(get(ApiRoutes.SETTINGS_BATCH_RETENTION_SCHEDULE)
+                        .header("Authorization", jwtToken))
+                .andExpect(status().isUnauthorized());
+    }
+}
+

--- a/src/test/java/com/bitbi/dfm/settings/domain/AppSettingTest.java
+++ b/src/test/java/com/bitbi/dfm/settings/domain/AppSettingTest.java
@@ -1,0 +1,34 @@
+package com.bitbi.dfm.settings.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AppSetting")
+class AppSettingTest {
+
+    @Test
+    @DisplayName("constructor should set createdAt and updatedAt")
+    void constructor_shouldSetTimestamps() {
+        AppSetting setting = new AppSetting("k", "v");
+
+        assertThat(setting.getCreatedAt()).isNotNull();
+        assertThat(setting.getUpdatedAt()).isNotNull();
+        assertThat(setting.getUpdatedAt()).isEqualTo(setting.getCreatedAt());
+    }
+
+    @Test
+    @DisplayName("setValue should update updatedAt")
+    void setValue_shouldUpdateTimestamp() {
+        AppSetting setting = new AppSetting("k", "v1");
+        var before = setting.getUpdatedAt();
+
+        setting.setValue("v2");
+
+        assertThat(setting.getValue()).isEqualTo("v2");
+        assertThat(setting.getUpdatedAt()).isNotNull();
+        assertThat(setting.getUpdatedAt()).isAfterOrEqualTo(before);
+    }
+}
+


### PR DESCRIPTION
Adds admin-configurable cron schedule for automatic retention cleanup.

Backend:
- Stores cron in DB (new app_settings table)
- Admin endpoints:
  - GET /api/v1/admin/settings/batch-retention-schedule
  - PUT /api/v1/admin/settings/batch-retention-schedule { cron }
- Scheduler now reads cron from DB and picks up changes without restart (fallback to config)

Frontend:
- New admin page /admin/settings with cron editor
- Header link for admins

Tests:
- ./gradlew test
- (frontend) npm test
