### PR TITLE
feat(auth): Auth V2 — refresh tokens, remove composite domain and Basic Auth

### DIFF
--- a/docs/auth-v2-migration-guide.md
+++ b/docs/auth-v2-migration-guide.md
@@ -1,0 +1,464 @@
+# Auth V2 Migration Guide
+
+## Overview
+
+Auth V2 replaces Basic Auth credential-based authentication with a token-based system using JWT access tokens and refresh tokens. This is a **breaking change** that affects all clients using the Data Forge Middleware API.
+
+**Key changes:**
+- Basic Auth endpoints (`POST /api/v1/auth/token`, `POST /api/v1/device/auth/token`) are **removed**
+- Device Flow now returns JWT + refresh token directly (instead of `clientSecret` + `compositeDomain`)
+- Composite domain (`accountId_domain`) is **removed** from all API responses
+- Site names now support unicode characters
+- New `POST /api/v1/device/auth/refresh` endpoint for token renewal
+
+---
+
+## Migration Timeline
+
+| Phase | Action |
+|-------|--------|
+| **Now** | Auth V2 endpoints available alongside deprecated V1 |
+| **+30 days** | Basic Auth endpoints return 410 Gone |
+| **+60 days** | Basic Auth endpoints removed |
+
+---
+
+## What's Removed
+
+| Component | Status |
+|-----------|--------|
+| `POST /api/v1/auth/token` (Basic Auth) | **Removed** |
+| `POST /api/v1/device/auth/token` (Basic Auth) | **Removed** |
+| `clientSecret` in API responses | **Removed** |
+| `siteIdentifier` (composite domain) in API responses | **Removed** |
+| `domain` field in site responses | **Renamed to `siteName`** |
+
+## What's New
+
+| Component | Description |
+|-----------|-------------|
+| `POST /api/v1/device/auth/refresh` | Token refresh endpoint |
+| `siteName` field | Replaces `domain` in all site responses |
+| Refresh tokens | 90-day rotating tokens for session continuity |
+| JWT access tokens (1h) | Short-lived tokens (previously 24h) |
+| Unicode site names | No more alphanumeric-only restriction |
+
+---
+
+## New Authentication Flow
+
+### Phase 1: Device Authorization (unchanged)
+
+```
+Device                              Server                              User
+  |                                   |                                   |
+  |-- POST /api/v1/device/authorize ->|                                   |
+  |   {siteName, siteDescription}     |                                   |
+  |                                   |                                   |
+  |<- {deviceCode, userCode,       ---|                                   |
+  |    verificationUri, expiresIn}    |                                   |
+  |                                   |                                   |
+  |   Display: "Go to {uri}"         |                                   |
+  |   Display: "Enter code: XXXX-XXXX"|                                   |
+  |                                   |                                   |
+  |                                   |<-- User opens browser, logs in ---|
+  |                                   |<-- User enters code, approves  ---|
+```
+
+### Phase 2: Token Retrieval (CHANGED)
+
+```
+Device                              Server
+  |                                   |
+  |-- POST /api/v1/device/token ----->|
+  |   {deviceCode}  (polling 5s)      |
+  |                                   |
+  |<- {                            ---|
+  |     siteId,                       |   (UUID)
+  |     siteName,                     |   (display name)
+  |     accessToken,                  |   (JWT, 1 hour TTL)
+  |     refreshToken,                 |   (opaque, 90 days TTL)
+  |     accessTokenExpiresAt,         |   (ISO 8601)
+  |     refreshTokenExpiresAt,        |   (ISO 8601)
+  |     apiBaseUrl                    |   (base URL for API calls)
+  |   }                               |
+```
+
+**Old response (removed):**
+```json
+{
+  "siteId": "...",
+  "domain": "accountId_siteName",
+  "clientSecret": "...",
+  "apiBaseUrl": "..."
+}
+```
+
+**New response:**
+```json
+{
+  "siteId": "550e8400-e29b-41d4-a716-446655440000",
+  "siteName": "warehouse-01",
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+  "refreshToken": "dGhpcyBpcyBhIHJlZnJlc2g...",
+  "accessTokenExpiresAt": "2025-02-10T15:30:00Z",
+  "refreshTokenExpiresAt": "2025-05-11T14:30:00Z",
+  "apiBaseUrl": "https://dev.dfm.bitbi.io"
+}
+```
+
+### Phase 3: API Calls with Bearer JWT (unchanged)
+
+```
+Device                              Server
+  |                                   |
+  |-- POST /api/v1/device/batches/start -->|
+  |   Authorization: Bearer {accessToken}  |
+  |                                        |
+  |<- {batchId, status}               ----|
+```
+
+### Phase 4: Token Refresh (NEW)
+
+```
+Device                              Server
+  |                                   |
+  |-- POST /api/v1/device/auth/refresh -->|
+  |   {refreshToken}                      |
+  |                                       |
+  |<- {                               ---|
+  |     accessToken,                      |   (new JWT, 1 hour)
+  |     refreshToken,                     |   (rotated, new 90 days)
+  |     accessTokenExpiresAt,             |
+  |     refreshTokenExpiresAt             |
+  |   }                                   |
+```
+
+---
+
+## Endpoint Changes
+
+| Old Endpoint | New Endpoint | Notes |
+|-------------|-------------|-------|
+| `POST /api/v1/auth/token` | **Removed** | Use Device Flow instead |
+| `POST /api/v1/device/auth/token` | **Removed** | Use Device Flow instead |
+| `POST /api/v1/device/token` | `POST /api/v1/device/token` | Response format changed (see above) |
+| — | `POST /api/v1/device/auth/refresh` | **New**: Token refresh |
+
+---
+
+## Credential Persistence
+
+### Old Model (remove)
+
+```json
+{
+  "domain": "550e8400-..._warehouse-01",
+  "clientSecret": "secret_abc123",
+  "siteId": "550e8400-e29b-41d4-a716-446655440000",
+  "apiBaseUrl": "https://dev.dfm.bitbi.io"
+}
+```
+
+### New Model (store this)
+
+```json
+{
+  "siteId": "550e8400-e29b-41d4-a716-446655440000",
+  "siteName": "warehouse-01",
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+  "refreshToken": "dGhpcyBpcyBhIHJlZnJlc2g...",
+  "accessTokenExpiresAt": "2025-02-10T15:30:00Z",
+  "refreshTokenExpiresAt": "2025-05-11T14:30:00Z",
+  "apiBaseUrl": "https://dev.dfm.bitbi.io"
+}
+```
+
+**Important:** Store both `accessToken` and `refreshToken` securely. The refresh token is a long-lived secret.
+
+---
+
+## Token Refresh Implementation
+
+### Algorithm
+
+```
+Before each API call:
+  1. Check if accessToken is expired (or will expire within 60 seconds)
+  2. If expired:
+     a. Call POST /api/v1/device/auth/refresh with refreshToken
+     b. Store new accessToken and refreshToken
+     c. Use new accessToken for the API call
+  3. If refreshToken is expired:
+     a. Re-run Device Authorization Flow from Step 1
+```
+
+### cURL
+
+```bash
+# Refresh tokens
+curl -X POST https://dev.dfm.bitbi.io/api/v1/device/auth/refresh \
+  -H "Content-Type: application/json" \
+  -d '{"refreshToken": "dGhpcyBpcyBhIHJlZnJlc2g..."}'
+```
+
+**Response:**
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+  "refreshToken": "bmV3IHJlZnJlc2ggdG9rZW4...",
+  "accessTokenExpiresAt": "2025-02-10T16:30:00Z",
+  "refreshTokenExpiresAt": "2025-05-11T15:30:00Z"
+}
+```
+
+### Python
+
+```python
+import requests
+from datetime import datetime, timezone
+
+class DataForgeClient:
+    def __init__(self, config_path: str):
+        self.config = self._load_config(config_path)
+        self.base_url = self.config["apiBaseUrl"]
+
+    def _is_token_expired(self) -> bool:
+        expires_at = datetime.fromisoformat(
+            self.config["accessTokenExpiresAt"].replace("Z", "+00:00")
+        )
+        # Refresh 60 seconds before expiry
+        return datetime.now(timezone.utc) >= expires_at.replace(
+            second=expires_at.second - 60
+        )
+
+    def _refresh_tokens(self):
+        response = requests.post(
+            f"{self.base_url}/api/v1/device/auth/refresh",
+            json={"refreshToken": self.config["refreshToken"]}
+        )
+
+        if response.status_code == 401:
+            error = response.json().get("error", "")
+            if error in ("refresh_token_expired", "refresh_token_revoked"):
+                raise Exception(f"Refresh token invalid: {error}. "
+                              "Re-run Device Authorization Flow.")
+
+        response.raise_for_status()
+        data = response.json()
+
+        self.config["accessToken"] = data["accessToken"]
+        self.config["refreshToken"] = data["refreshToken"]
+        self.config["accessTokenExpiresAt"] = data["accessTokenExpiresAt"]
+        self.config["refreshTokenExpiresAt"] = data["refreshTokenExpiresAt"]
+        self._save_config()
+
+    def _get_headers(self) -> dict:
+        if self._is_token_expired():
+            self._refresh_tokens()
+        return {"Authorization": f"Bearer {self.config['accessToken']}"}
+
+    def start_batch(self):
+        response = requests.post(
+            f"{self.base_url}/api/v1/device/batches/start",
+            headers=self._get_headers()
+        )
+        response.raise_for_status()
+        return response.json()
+```
+
+### Node.js
+
+```javascript
+const axios = require('axios');
+
+class DataForgeClient {
+  constructor(config) {
+    this.config = config;
+    this.baseUrl = config.apiBaseUrl;
+  }
+
+  isTokenExpired() {
+    const expiresAt = new Date(this.config.accessTokenExpiresAt);
+    const now = new Date();
+    // Refresh 60 seconds before expiry
+    return now >= new Date(expiresAt.getTime() - 60000);
+  }
+
+  async refreshTokens() {
+    try {
+      const { data } = await axios.post(
+        `${this.baseUrl}/api/v1/device/auth/refresh`,
+        { refreshToken: this.config.refreshToken }
+      );
+
+      this.config.accessToken = data.accessToken;
+      this.config.refreshToken = data.refreshToken;
+      this.config.accessTokenExpiresAt = data.accessTokenExpiresAt;
+      this.config.refreshTokenExpiresAt = data.refreshTokenExpiresAt;
+      // Save config to persistent storage
+    } catch (error) {
+      if (error.response?.status === 401) {
+        const err = error.response.data?.error;
+        if (err === 'refresh_token_expired' || err === 'refresh_token_revoked') {
+          throw new Error(`Refresh token invalid: ${err}. Re-run Device Authorization Flow.`);
+        }
+      }
+      throw error;
+    }
+  }
+
+  async getHeaders() {
+    if (this.isTokenExpired()) {
+      await this.refreshTokens();
+    }
+    return { Authorization: `Bearer ${this.config.accessToken}` };
+  }
+
+  async startBatch() {
+    const headers = await this.getHeaders();
+    const { data } = await axios.post(
+      `${this.baseUrl}/api/v1/device/batches/start`,
+      null,
+      { headers }
+    );
+    return data;
+  }
+}
+```
+
+### Java
+
+```java
+import java.net.http.*;
+import java.time.Instant;
+
+public class DataForgeClient {
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private Config config;
+
+    private boolean isTokenExpired() {
+        Instant expiresAt = Instant.parse(config.accessTokenExpiresAt);
+        return Instant.now().isAfter(expiresAt.minusSeconds(60));
+    }
+
+    private void refreshTokens() throws Exception {
+        String body = "{\"refreshToken\":\"" + config.refreshToken + "\"}";
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(config.apiBaseUrl + "/api/v1/device/auth/refresh"))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+
+        HttpResponse<String> response = httpClient.send(request,
+            HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() == 401) {
+            throw new RuntimeException(
+                "Refresh token invalid. Re-run Device Authorization Flow.");
+        }
+
+        // Parse response and update config
+        // config.accessToken = ...
+        // config.refreshToken = ...
+        // Save config to persistent storage
+    }
+
+    private String getAuthHeader() throws Exception {
+        if (isTokenExpired()) {
+            refreshTokens();
+        }
+        return "Bearer " + config.accessToken;
+    }
+}
+```
+
+---
+
+## Error Handling
+
+### Refresh Endpoint Errors
+
+| HTTP Status | Error | Description | Action |
+|-------------|-------|-------------|--------|
+| 200 | — | Success | Store new tokens |
+| 400 | `invalid_request` | Missing refreshToken | Check request body |
+| 401 | `refresh_token_expired` | Refresh token TTL exceeded (90 days) | Re-run Device Authorization Flow |
+| 401 | `refresh_token_revoked` | Token was revoked (e.g., site re-authorized) | Re-run Device Authorization Flow |
+| 401 | `invalid_refresh_token` | Token not found or invalid | Re-run Device Authorization Flow |
+| 500 | `internal_error` | Server error | Retry with exponential backoff |
+
+### API Call Errors (Bearer JWT)
+
+| HTTP Status | Meaning | Action |
+|-------------|---------|--------|
+| 401 | JWT expired or invalid | Refresh token, retry |
+| 403 | Site doesn't own this resource | Check siteId |
+
+---
+
+## Migration Checklist
+
+### For existing clients using Basic Auth:
+
+- [ ] **Remove** stored `clientSecret` and `domain` (composite) from config
+- [ ] **Remove** Basic Auth token generation code (`POST /api/v1/device/auth/token` or `POST /api/v1/auth/token`)
+- [ ] **Run** Device Authorization Flow to get new JWT + refresh token
+- [ ] **Store** `siteId`, `siteName`, `accessToken`, `refreshToken`, and expiry timestamps
+- [ ] **Implement** automatic token refresh before API calls
+- [ ] **Handle** refresh token expiry (re-run Device Authorization Flow)
+- [ ] **Update** any references to `domain` field to use `siteName`
+- [ ] **Test** full flow: authorize -> upload batch -> token refresh -> upload again
+
+### For new clients:
+
+- [ ] **Implement** Device Authorization Flow (Steps 1-2 from `device-flow-client-guide.md`)
+- [ ] **Parse** new token response format from `POST /api/v1/device/token`
+- [ ] **Store** tokens securely with expiry timestamps
+- [ ] **Implement** automatic token refresh
+- [ ] **Handle** error cases (expired refresh token, revoked token)
+
+---
+
+## FAQ
+
+**Q: Can I still use Basic Auth?**
+A: No. Basic Auth endpoints are removed in Auth V2. Use Device Flow with JWT + refresh tokens.
+
+**Q: How long does the access token last?**
+A: 1 hour. Use the refresh token to get a new access token without user interaction.
+
+**Q: How long does the refresh token last?**
+A: 90 days. After that, the user must re-authorize via Device Flow.
+
+**Q: What happens when I refresh a token?**
+A: The old refresh token is immediately revoked and a new one is issued (token rotation). Always store the new refresh token from the response.
+
+**Q: What if the refresh token is lost?**
+A: Re-run the Device Authorization Flow. The user will need to approve again.
+
+**Q: Can a site have multiple active refresh tokens?**
+A: No. When a new Device Authorization is approved for the same site, all previous refresh tokens are revoked.
+
+**Q: Why was the composite domain removed?**
+A: The `accountId_siteName` format was an internal implementation detail that leaked into the API. Site names now support unicode and are identified by the `(accountId, siteName)` pair internally.
+
+**Q: Can site names contain special characters now?**
+A: Yes. Site names support unicode characters (letters, numbers, dots, hyphens, spaces, etc.). The only restriction is 1-255 characters and non-blank.
+
+---
+
+## Breaking Changes Summary
+
+| Change | Old | New |
+|--------|-----|-----|
+| Authentication | Basic Auth (`domain:clientSecret`) | Bearer JWT (1h) + refresh token (90d) |
+| Token endpoint | `POST /api/v1/device/auth/token` | **Removed** (use Device Flow) |
+| Token refresh | Not available (re-auth required) | `POST /api/v1/device/auth/refresh` |
+| Device Flow response | `{siteId, domain, clientSecret, apiBaseUrl}` | `{siteId, siteName, accessToken, refreshToken, ...}` |
+| Site identifier | `domain` (composite: `accountId_siteName`) | `siteName` (clean name) |
+| Site name validation | `^[a-zA-Z0-9.-]+$` | Unicode allowed, 1-255 chars |
+| JWT TTL | 24 hours | 1 hour |
+| JWT claims | `siteId`, `accountId`, `domain` | `siteId`, `accountId` (no `domain`) |
+| S3 paths (new batches) | `{accountId}/{compositeDomain}/{date}/{time}/` | `{accountId}/{siteId}/{date}/{time}/` |

--- a/frontend/src/entities/site/model/types.ts
+++ b/frontend/src/entities/site/model/types.ts
@@ -11,7 +11,7 @@
  *
  * @property id - Unique site identifier
  * @property accountId - Account this site belongs to
- * @property domain - Site domain name for display (e.g., "example.com", without accountId prefix)
+ * @property siteName - Site name (unique within account, unicode allowed)
  * @property name - Display name for the site
  * @property isActive - Activation status (true = active, false = inactive/deleted)
  * @property retentionDays - Retention period in days for batch cleanup
@@ -20,7 +20,7 @@
 export interface Site {
   id: string;
   accountId: string;
-  domain: string; // Display domain only (FR-019)
+  siteName: string;
   name: string;
   isActive: boolean;
   retentionDays: number;
@@ -30,27 +30,25 @@ export interface Site {
 /**
  * Request payload for creating a new site.
  *
- * @property domain - Site domain (3-255 chars, alphanumeric + dots/hyphens)
+ * @property siteName - Site name (1-255 chars, unicode allowed)
  * @property displayName - Human-readable site name (2-100 chars)
- * @property password - Site password (8+ chars, alphanumeric, optional - will be auto-generated if not provided)
+ * @property password - Site password (8+ chars, optional - will be auto-generated if not provided)
  */
 export interface CreateSiteRequest {
-  domain: string;
+  siteName: string;
   displayName: string;
   password?: string;
 }
 
 /**
- * Response from site creation endpoint.
+ * Response from site creation endpoint (Auth V2).
  *
- * @property site - Created site entity (domain is display format)
+ * @property site - Created site entity
  * @property password - Plaintext password (only returned once at creation)
- * @property siteIdentifier - Full site identifier for Basic Auth (accountId_domain format, FR-019)
  */
 export interface CreateSiteResponse {
   site: Site;
   password: string;
-  siteIdentifier: string; // accountId_domain for Basic Auth
 }
 
 /**

--- a/frontend/src/features/batch-cleanup/ui/BatchCleanupPanel.tsx
+++ b/frontend/src/features/batch-cleanup/ui/BatchCleanupPanel.tsx
@@ -23,7 +23,7 @@ export function BatchCleanupPanel({ accountId }: BatchCleanupPanelProps) {
 
   const siteOptions = useMemo(() => {
     if (!sites) return [];
-    return sites.map((site) => ({ id: site.id, label: site.domain }));
+    return sites.map((site) => ({ id: site.id, label: site.siteName }));
   }, [sites]);
 
   const runCleanup = async (executeDryRun: boolean) => {

--- a/frontend/src/features/my-plugins/ui/PluginTabFilters.tsx
+++ b/frontend/src/features/my-plugins/ui/PluginTabFilters.tsx
@@ -184,7 +184,7 @@ export function PluginTabFilters({
                   <SelectItem value="all">All Sites</SelectItem>
                   {sites.map((site: Site) => (
                     <SelectItem key={site.id} value={site.id}>
-                      {site.domain}
+                      {site.siteName}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/frontend/src/features/site-crud/model/queries.test.ts
+++ b/frontend/src/features/site-crud/model/queries.test.ts
@@ -25,17 +25,19 @@ describe('useUpdateSiteStatus', () => {
     {
       id: 'site-1',
       accountId: 'account-1',
-      domain: 'example.com',
-      displayName: 'Example Site',
+      siteName: 'example.com',
+      name: 'Example Site',
       isActive: true,
+      retentionDays: 45,
       createdAt: '2024-01-01T00:00:00Z',
     },
     {
       id: 'site-2',
       accountId: 'account-1',
-      domain: 'test.com',
-      displayName: 'Test Site',
+      siteName: 'test.com',
+      name: 'Test Site',
       isActive: false,
+      retentionDays: 45,
       createdAt: '2024-01-02T00:00:00Z',
     },
   ];

--- a/frontend/src/features/site-crud/model/schemas.ts
+++ b/frontend/src/features/site-crud/model/schemas.ts
@@ -12,21 +12,16 @@ import { z } from 'zod';
  * Schema for creating a new site.
  *
  * Validation rules match backend CreateSiteRequestDto:
- * - domain: 3-255 chars, alphanumeric + dots/hyphens (case-insensitive, stored as lowercase)
+ * - siteName: 1-255 chars, unicode allowed (case-insensitive, stored as lowercase)
  * - displayName: 2-100 chars, human-readable site name
  * - password: 8+ chars, alphanumeric, optional (auto-generated if not provided)
  */
 export const CreateSiteFormSchema = z.object({
-  domain: z
+  siteName: z
     .string()
     .trim()
-    .min(1, 'Domain is required')
-    .min(3, 'Domain must be at least 3 characters')
-    .max(255, 'Domain must be at most 255 characters')
-    .regex(
-      /^[a-zA-Z0-9.-]+$/,
-      'Domain can only contain letters, numbers, dots, and hyphens'
-    ),
+    .min(1, 'Site name is required')
+    .max(255, 'Site name must be at most 255 characters'),
   displayName: z
     .string()
     .trim()
@@ -53,16 +48,12 @@ export const CreateSiteFormSchema = z.object({
 export type CreateSiteFormData = z.infer<typeof CreateSiteFormSchema>;
 
 /**
- * Schema for site domain validation (standalone).
+ * Schema for site name validation (standalone).
  */
-export const DomainSchema = z
+export const SiteNameSchema = z
   .string()
-  .min(3, 'Domain must be at least 3 characters')
-  .max(255, 'Domain must be at most 255 characters')
-  .regex(
-    /^[a-zA-Z0-9.-]+$/,
-    'Domain can only contain letters, numbers, dots, and hyphens'
-  )
+  .min(1, 'Site name is required')
+  .max(255, 'Site name must be at most 255 characters')
   .trim();
 
 /**

--- a/frontend/src/features/site-crud/ui/CreateSiteForm.test.tsx
+++ b/frontend/src/features/site-crud/ui/CreateSiteForm.test.tsx
@@ -93,7 +93,7 @@ describe('CreateSiteForm', () => {
     it('should render all form fields', () => {
       renderForm();
 
-      expect(screen.getByLabelText(/domain/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/site name/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /create site/i })).toBeInTheDocument();
@@ -117,7 +117,7 @@ describe('CreateSiteForm', () => {
   });
 
   describe('Form Validation', () => {
-    it('should show error when domain is empty', async () => {
+    it('should show error when site name is empty', async () => {
       const user = userEvent.setup();
       renderForm();
 
@@ -125,37 +125,7 @@ describe('CreateSiteForm', () => {
       await user.click(submitButton);
 
       await waitFor(() => {
-        expect(screen.getByText(/domain is required/i)).toBeInTheDocument();
-      });
-    });
-
-    it('should show error when domain is too short', async () => {
-      const user = userEvent.setup();
-      renderForm();
-
-      const domainInput = screen.getByLabelText(/domain/i);
-      await user.type(domainInput, 'ab');
-
-      const submitButton = screen.getByRole('button', { name: /create site/i });
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/at least 3 characters/i)).toBeInTheDocument();
-      });
-    });
-
-    it('should show error when domain contains invalid characters', async () => {
-      const user = userEvent.setup();
-      renderForm();
-
-      const domainInput = screen.getByLabelText(/domain/i);
-      await user.type(domainInput, 'invalid_domain');
-
-      const submitButton = screen.getByRole('button', { name: /create site/i });
-      await user.click(submitButton);
-
-      await waitFor(() => {
-        expect(screen.getByText(/can only contain letters/i)).toBeInTheDocument();
+        expect(screen.getByText(/site name is required/i)).toBeInTheDocument();
       });
     });
 
@@ -190,7 +160,7 @@ describe('CreateSiteForm', () => {
       const user = userEvent.setup();
       renderForm();
 
-      await user.type(screen.getByLabelText(/domain/i), 'valid-domain');
+      await user.type(screen.getByLabelText(/site name/i), 'valid-site');
       await user.type(screen.getByLabelText(/display name/i), 'Valid Site');
       await user.type(screen.getByLabelText(/password/i), 'validPass123');
 
@@ -293,19 +263,18 @@ describe('CreateSiteForm', () => {
         site: {
           id: '123',
           accountId: 'acc-123',
-          domain: 'test-site',
+          siteName: 'test-site',
           name: 'Test Site',
           isActive: true,
           createdAt: '2025-01-01T00:00:00Z',
         },
         password: 'testPassword123',
-        siteIdentifier: 'acc-123_test-site',
       };
 
       mockMutateAsync.mockResolvedValue(mockResult);
       renderForm();
 
-      await user.type(screen.getByLabelText(/domain/i), 'test-site');
+      await user.type(screen.getByLabelText(/site name/i), 'test-site');
       await user.type(screen.getByLabelText(/display name/i), 'Test Site');
       await user.type(screen.getByLabelText(/password/i), 'testPassword123');
 
@@ -313,7 +282,7 @@ describe('CreateSiteForm', () => {
 
       await waitFor(() => {
         expect(mockMutateAsync).toHaveBeenCalledWith({
-          domain: 'test-site',
+          siteName: 'test-site',
           displayName: 'Test Site',
           password: 'testPassword123',
         });
@@ -326,25 +295,24 @@ describe('CreateSiteForm', () => {
         site: {
           id: '123',
           accountId: 'acc-123',
-          domain: 'test-site',
+          siteName: 'test-site',
           name: 'Test Site',
           isActive: true,
           createdAt: '2025-01-01T00:00:00Z',
         },
         password: 'GeneratedPassword',
-        siteIdentifier: 'acc-123_test-site',
       });
 
       renderForm();
 
-      await user.type(screen.getByLabelText(/domain/i), 'test-site');
+      await user.type(screen.getByLabelText(/site name/i), 'test-site');
       await user.type(screen.getByLabelText(/display name/i), 'Test Site');
 
       await user.click(screen.getByRole('button', { name: /create site/i }));
 
       await waitFor(() => {
         expect(mockMutateAsync).toHaveBeenCalledWith({
-          domain: 'test-site',
+          siteName: 'test-site',
           displayName: 'Test Site',
           password: undefined,
         });
@@ -358,19 +326,18 @@ describe('CreateSiteForm', () => {
         site: {
           id: '123',
           accountId: 'acc-123',
-          domain: 'test-site',
+          siteName: 'test-site',
           name: 'Test Site',
           isActive: true,
           createdAt: '2025-01-01T00:00:00Z',
         },
         password: 'testPassword123',
-        siteIdentifier: 'acc-123_test-site',
       };
 
       mockMutateAsync.mockResolvedValue(mockResult);
       renderForm({ onSuccess: mockOnSuccess });
 
-      await user.type(screen.getByLabelText(/domain/i), 'test-site');
+      await user.type(screen.getByLabelText(/site name/i), 'test-site');
       await user.type(screen.getByLabelText(/display name/i), 'Test Site');
       await user.type(screen.getByLabelText(/password/i), 'testPassword123');
 
@@ -387,29 +354,28 @@ describe('CreateSiteForm', () => {
         site: {
           id: '123',
           accountId: 'acc-123',
-          domain: 'test-site',
+          siteName: 'test-site',
           name: 'Test Site',
           isActive: true,
           createdAt: '2025-01-01T00:00:00Z',
         },
         password: 'testPassword123',
-        siteIdentifier: 'acc-123_test-site',
       });
 
       renderForm();
 
-      const domainInput = screen.getByLabelText(/domain/i) as HTMLInputElement;
+      const siteNameInput = screen.getByLabelText(/site name/i) as HTMLInputElement;
       const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement;
       const passwordInput = screen.getByLabelText(/password/i) as HTMLInputElement;
 
-      await user.type(domainInput, 'test-site');
+      await user.type(siteNameInput, 'test-site');
       await user.type(displayNameInput, 'Test Site');
       await user.type(passwordInput, 'testPassword123');
 
       await user.click(screen.getByRole('button', { name: /create site/i }));
 
       await waitFor(() => {
-        expect(domainInput.value).toBe('');
+        expect(siteNameInput.value).toBe('');
         expect(displayNameInput.value).toBe('');
         expect(passwordInput.value).toBe('');
       });
@@ -420,7 +386,7 @@ describe('CreateSiteForm', () => {
       const mockError = {
         response: {
           data: {
-            message: 'Domain already exists',
+            message: 'Site with name already exists',
           },
         },
       };
@@ -428,7 +394,7 @@ describe('CreateSiteForm', () => {
       mockMutateAsync.mockRejectedValue(mockError);
       renderForm();
 
-      await user.type(screen.getByLabelText(/domain/i), 'test-site');
+      await user.type(screen.getByLabelText(/site name/i), 'test-site');
       await user.type(screen.getByLabelText(/display name/i), 'Test Site');
       await user.type(screen.getByLabelText(/password/i), 'testPassword123');
 
@@ -436,8 +402,8 @@ describe('CreateSiteForm', () => {
 
       // Form should not be reset on error
       await waitFor(() => {
-        const domainInput = screen.getByLabelText(/domain/i) as HTMLInputElement;
-        expect(domainInput.value).toBe('test-site');
+        const siteNameInput = screen.getByLabelText(/site name/i) as HTMLInputElement;
+        expect(siteNameInput.value).toBe('test-site');
       });
     });
   });
@@ -447,17 +413,17 @@ describe('CreateSiteForm', () => {
       const user = userEvent.setup();
       renderForm();
 
-      const domainInput = screen.getByLabelText(/domain/i) as HTMLInputElement;
+      const siteNameInput = screen.getByLabelText(/site name/i) as HTMLInputElement;
       const displayNameInput = screen.getByLabelText(/display name/i) as HTMLInputElement;
       const passwordInput = screen.getByLabelText(/password/i) as HTMLInputElement;
 
-      await user.type(domainInput, 'test-site');
+      await user.type(siteNameInput, 'test-site');
       await user.type(displayNameInput, 'Test Site');
       await user.type(passwordInput, 'testPassword123');
 
       await user.click(screen.getByRole('button', { name: /clear/i }));
 
-      expect(domainInput.value).toBe('');
+      expect(siteNameInput.value).toBe('');
       expect(displayNameInput.value).toBe('');
       expect(passwordInput.value).toBe('');
     });
@@ -498,10 +464,10 @@ describe('CreateSiteForm', () => {
 
       renderForm();
 
-      const domainInput = screen.getByLabelText(/domain/i);
+      const siteNameInput = screen.getByLabelText(/site name/i);
       const submitButton = screen.getByRole('button', { name: /create site/i });
 
-      expect(domainInput).toBeDisabled();
+      expect(siteNameInput).toBeDisabled();
       expect(submitButton).toBeDisabled();
     });
   });

--- a/frontend/src/features/site-crud/ui/CreateSiteForm.tsx
+++ b/frontend/src/features/site-crud/ui/CreateSiteForm.tsx
@@ -2,7 +2,7 @@
  * CreateSiteForm - Form for creating a new site with password generation.
  *
  * Features:
- * - Domain and password input fields
+ * - Site name and password input fields
  * - Password generation button
  * - Form validation with Zod + React Hook Form
  * - Automatic site creation via TanStack Query mutation
@@ -41,9 +41,9 @@ interface CreateSiteFormProps {
 
   /**
    * Callback when site is successfully created.
-   * Receives the created site data, plaintext password, and site identifier.
+   * Receives the created site data and plaintext password.
    */
-  onSuccess?: (data: { site: any; password: string; siteIdentifier: string }) => void;
+  onSuccess?: (data: { site: any; password: string }) => void;
 
   /**
    * Whether to show the form in a card layout.
@@ -58,7 +58,6 @@ export function CreateSiteForm({ accountId, onSuccess, showCard = true }: Create
   const [createdSiteData, setCreatedSiteData] = useState<{
     site: any;
     password: string;
-    siteIdentifier: string;
   } | null>(null);
   const [showSuccessDialog, setShowSuccessDialog] = useState(false);
 
@@ -72,7 +71,7 @@ export function CreateSiteForm({ accountId, onSuccess, showCard = true }: Create
   } = useForm<CreateSiteFormData>({
     resolver: zodResolver(CreateSiteFormSchema),
     defaultValues: {
-      domain: '',
+      siteName: '',
       displayName: '',
       password: '',
     },
@@ -109,12 +108,12 @@ export function CreateSiteForm({ accountId, onSuccess, showCard = true }: Create
   const onSubmit = async (data: CreateSiteFormData) => {
     try {
       const result = await createSiteMutation.mutateAsync({
-        domain: data.domain,
+        siteName: data.siteName,
         displayName: data.displayName,
         password: data.password || undefined,
       });
 
-      toast.success(`Site "${data.domain}" created successfully!`);
+      toast.success(`Site "${data.siteName}" created successfully!`);
 
       // Store created site data and show success dialog
       setCreatedSiteData(result);
@@ -135,26 +134,26 @@ export function CreateSiteForm({ accountId, onSuccess, showCard = true }: Create
 
   const formContent = (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      {/* Domain field */}
+      {/* Site Name field */}
       <div className="space-y-2">
-        <Label htmlFor="domain">
-          Domain <span className="text-destructive">*</span>
+        <Label htmlFor="siteName">
+          Site Name <span className="text-destructive">*</span>
         </Label>
         <Input
-          id="domain"
+          id="siteName"
           placeholder="site-1"
-          {...register('domain')}
+          {...register('siteName')}
           disabled={createSiteMutation.isPending}
-          aria-invalid={errors.domain ? 'true' : 'false'}
-          aria-describedby={errors.domain ? 'domain-error' : undefined}
+          aria-invalid={errors.siteName ? 'true' : 'false'}
+          aria-describedby={errors.siteName ? 'siteName-error' : undefined}
         />
-        {errors.domain && (
-          <p id="domain-error" className="text-sm text-destructive">
-            {errors.domain.message}
+        {errors.siteName && (
+          <p id="siteName-error" className="text-sm text-destructive">
+            {errors.siteName.message}
           </p>
         )}
         <p className="text-sm text-muted-foreground">
-          Enter the domain name (lowercase, 3-255 characters)
+          Enter the site name (1-255 characters, unicode allowed)
         </p>
       </div>
 
@@ -293,7 +292,6 @@ export function CreateSiteForm({ accountId, onSuccess, showCard = true }: Create
           onOpenChange={setShowSuccessDialog}
           site={createdSiteData.site}
           password={createdSiteData.password}
-          siteIdentifier={createdSiteData.siteIdentifier}
           accountId={accountId || createdSiteData.site.accountId}
         />
       )}

--- a/frontend/src/features/site-crud/ui/SiteCreatedDialog.tsx
+++ b/frontend/src/features/site-crud/ui/SiteCreatedDialog.tsx
@@ -28,11 +28,10 @@ interface SiteCreatedDialogProps {
   onOpenChange: (open: boolean) => void;
   site: {
     id: string;
-    domain: string;
+    siteName: string;
     name: string;
   };
   password: string;
-  siteIdentifier: string;
   accountId: string;
 }
 
@@ -41,7 +40,6 @@ export function SiteCreatedDialog({
   onOpenChange,
   site,
   password,
-  siteIdentifier,
   accountId,
 }: SiteCreatedDialogProps) {
   const [passwordCopied, setPasswordCopied] = useState(false);
@@ -53,7 +51,7 @@ export function SiteCreatedDialog({
   // Build CLI install command
   const cliCommand = `data_exporter.exe install \`
   --account "${accountId}" \`
-  --username "${site.domain}" \`
+  --site-id "${site.id}" \`
   --password "${password}" \`
   --source-dir "c:\\data" \`
   --crontab "0 */5 * * * *" \`
@@ -88,7 +86,7 @@ export function SiteCreatedDialog({
         <AlertDialogHeader>
           <AlertDialogTitle className="text-2xl">Site Created Successfully!</AlertDialogTitle>
           <AlertDialogDescription>
-            Your site <strong>{site.domain}</strong> has been created. Save these credentials now - you won't see them again!
+            Your site <strong>{site.siteName}</strong> has been created. Save these credentials now - you won't see them again!
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -104,8 +102,8 @@ export function SiteCreatedDialog({
           {/* Site Details */}
           <div className="space-y-3">
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Site Domain</p>
-              <p className="font-mono text-sm bg-muted p-2 rounded">{site.domain}</p>
+              <p className="text-sm font-medium text-muted-foreground">Site Name</p>
+              <p className="font-mono text-sm bg-muted p-2 rounded">{site.siteName}</p>
             </div>
 
             <div>
@@ -114,8 +112,8 @@ export function SiteCreatedDialog({
             </div>
 
             <div>
-              <p className="text-sm font-medium text-muted-foreground">Site Identifier</p>
-              <p className="font-mono text-sm bg-muted p-2 rounded">{siteIdentifier}</p>
+              <p className="text-sm font-medium text-muted-foreground">Site ID</p>
+              <p className="font-mono text-sm bg-muted p-2 rounded">{site.id}</p>
             </div>
 
             <div>

--- a/frontend/src/pages/site-management/SiteManagementPage.test.tsx
+++ b/frontend/src/pages/site-management/SiteManagementPage.test.tsx
@@ -33,17 +33,19 @@ describe('SiteManagementPage', () => {
     {
       id: '1',
       accountId: 'account-1',
-      domain: 'example.com',
+      siteName: 'example.com',
       name: 'Example Site',
       isActive: true,
+      retentionDays: 45,
       createdAt: '2024-01-01T00:00:00Z',
     },
     {
       id: '2',
       accountId: 'account-1',
-      domain: 'test.com',
+      siteName: 'test.com',
       name: 'Test Site',
       isActive: false,
+      retentionDays: 45,
       createdAt: '2024-01-02T00:00:00Z',
     },
   ];
@@ -168,11 +170,11 @@ describe('SiteManagementPage', () => {
       vi.mocked(siteApi.listUserSites).mockResolvedValue([mockSites[0]]);
 
       // Fill in the form
-      const domainInput = screen.getByLabelText(/domain/i);
+      const siteNameInput = screen.getByLabelText(/site name/i);
       const displayNameInput = screen.getByLabelText(/display name/i);
       const submitButton = screen.getByRole('button', { name: /create site/i });
 
-      await user.type(domainInput, 'example.com');
+      await user.type(siteNameInput, 'example.com');
       await user.type(displayNameInput, 'Example Site');
       await user.click(submitButton);
 
@@ -181,8 +183,8 @@ describe('SiteManagementPage', () => {
       await waitFor(() => {
         const siteElements = screen.getAllByText('Example Site');
         expect(siteElements.length).toBeGreaterThan(0);
-        const domainElements = screen.getAllByText('example.com');
-        expect(domainElements.length).toBeGreaterThan(0);
+        const siteNameElements = screen.getAllByText('example.com');
+        expect(siteNameElements.length).toBeGreaterThan(0);
       });
     });
 
@@ -198,11 +200,11 @@ describe('SiteManagementPage', () => {
       renderPage();
 
       // Fill in the form without password
-      const domainInput = screen.getByLabelText(/domain/i);
+      const siteNameInput = screen.getByLabelText(/site name/i);
       const displayNameInput = screen.getByLabelText(/display name/i);
       const submitButton = screen.getByRole('button', { name: /create site/i });
 
-      await user.type(domainInput, 'example.com');
+      await user.type(siteNameInput, 'example.com');
       await user.type(displayNameInput, 'Example Site');
       await user.click(submitButton);
 

--- a/frontend/src/widgets/site-list/ui/SiteListItem.tsx
+++ b/frontend/src/widgets/site-list/ui/SiteListItem.tsx
@@ -88,7 +88,7 @@ export function SiteListItem({
             {/* Site info */}
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-1">
-                <h3 className="font-semibold text-lg truncate">{site.domain}</h3>
+                <h3 className="font-semibold text-lg truncate">{site.siteName}</h3>
                 <Badge variant={site.isActive ? 'default' : 'secondary'}>
                   {site.isActive ? (
                     <>
@@ -181,7 +181,7 @@ export function SiteListItem({
           <AlertDialogHeader>
             <AlertDialogTitle>Deactivate Site</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to deactivate <strong>{site.domain}</strong>?
+              Are you sure you want to deactivate <strong>{site.siteName}</strong>?
               <br />
               <br />
               The site will be temporarily disabled. All historical data, batches, errors, and uploads will be preserved. You can reactivate the site at any time.
@@ -206,7 +206,7 @@ export function SiteListItem({
                 ⚠️ WARNING: This action cannot be undone!
               </p>
               <p>
-                Are you sure you want to permanently delete <strong>{site.domain}</strong>?
+                Are you sure you want to permanently delete <strong>{site.siteName}</strong>?
               </p>
               <p>
                 This will permanently delete:

--- a/src/main/java/com/bitbi/dfm/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/bitbi/dfm/auth/application/RefreshTokenService.java
@@ -1,0 +1,234 @@
+package com.bitbi.dfm.auth.application;
+
+import com.bitbi.dfm.account.domain.Account;
+import com.bitbi.dfm.account.domain.AccountRepository;
+import com.bitbi.dfm.auth.domain.JwtToken;
+import com.bitbi.dfm.auth.domain.RefreshToken;
+import com.bitbi.dfm.auth.domain.RefreshTokenRepository;
+import com.bitbi.dfm.auth.infrastructure.JwtTokenProvider;
+import com.bitbi.dfm.site.domain.Site;
+import com.bitbi.dfm.site.domain.SiteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.UUID;
+
+/**
+ * Service for refresh token management.
+ * <p>
+ * Handles generation, validation, rotation, and revocation of refresh tokens.
+ * Refresh tokens are opaque strings stored as SHA-256 hashes in the database.
+ * Token rotation is enforced: on each use, the old token is revoked and a new one issued.
+ * </p>
+ *
+ * @author Data Forge Team
+ * @version 1.0.0
+ */
+@Service
+@Transactional
+public class RefreshTokenService {
+
+    private static final Logger logger = LoggerFactory.getLogger(RefreshTokenService.class);
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int TOKEN_BYTE_LENGTH = 32; // 256-bit token
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final SiteRepository siteRepository;
+    private final AccountRepository accountRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public RefreshTokenService(
+            RefreshTokenRepository refreshTokenRepository,
+            SiteRepository siteRepository,
+            AccountRepository accountRepository,
+            JwtTokenProvider jwtTokenProvider) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.siteRepository = siteRepository;
+        this.accountRepository = accountRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    /**
+     * Generate a new refresh token for a site.
+     *
+     * @param siteId site identifier
+     * @return the opaque refresh token string (to be returned to client once)
+     */
+    public String generateRefreshToken(UUID siteId) {
+        String opaqueToken = generateOpaqueToken();
+        String tokenHash = sha256(opaqueToken);
+
+        RefreshToken refreshToken = RefreshToken.create(siteId, tokenHash);
+        refreshTokenRepository.save(refreshToken);
+
+        logger.info("Generated refresh token for site: siteId={}", siteId);
+        return opaqueToken;
+    }
+
+    /**
+     * Refresh an access token using a refresh token.
+     * <p>
+     * Validates the refresh token, generates a new JWT access token,
+     * and rotates the refresh token (old revoked, new issued).
+     * </p>
+     *
+     * @param refreshTokenString the opaque refresh token
+     * @return refresh result containing new access token and rotated refresh token
+     * @throws RefreshTokenExpiredException if token is expired
+     * @throws RefreshTokenRevokedException if token was already revoked
+     * @throws InvalidRefreshTokenException if token is not found
+     */
+    public RefreshResult refreshAccessToken(String refreshTokenString) {
+        String tokenHash = sha256(refreshTokenString);
+
+        RefreshToken refreshToken = refreshTokenRepository.findByTokenHash(tokenHash)
+                .orElseThrow(() -> new InvalidRefreshTokenException("Invalid refresh token"));
+
+        if (refreshToken.isRevoked()) {
+            logger.warn("Attempted to use revoked refresh token: siteId={}", refreshToken.getSiteId());
+            throw new RefreshTokenRevokedException("Refresh token has been revoked");
+        }
+
+        if (refreshToken.isExpired()) {
+            logger.warn("Attempted to use expired refresh token: siteId={}", refreshToken.getSiteId());
+            throw new RefreshTokenExpiredException("Refresh token has expired");
+        }
+
+        UUID siteId = refreshToken.getSiteId();
+
+        // Validate site still exists and is active
+        Site site = siteRepository.findById(siteId)
+                .orElseThrow(() -> new InvalidRefreshTokenException("Site not found"));
+
+        if (!site.getIsActive()) {
+            throw new InvalidRefreshTokenException("Site is not active");
+        }
+
+        // Validate parent account is active
+        Account account = accountRepository.findById(site.getAccountId())
+                .orElseThrow(() -> new InvalidRefreshTokenException("Account not found"));
+
+        if (!account.getIsActive()) {
+            throw new InvalidRefreshTokenException("Account is not active");
+        }
+
+        // Revoke old refresh token (rotation)
+        refreshToken.revoke();
+        refreshTokenRepository.save(refreshToken);
+
+        // Generate new JWT access token
+        JwtToken accessToken = jwtTokenProvider.generateToken(siteId, site.getAccountId());
+
+        // Generate new refresh token (rotation)
+        String newRefreshTokenString = generateRefreshToken(siteId);
+
+        logger.info("Access token refreshed successfully: siteId={}", siteId);
+
+        return new RefreshResult(
+                accessToken,
+                newRefreshTokenString,
+                Instant.now().plus(90, ChronoUnit.DAYS)
+        );
+    }
+
+    /**
+     * Revoke a specific refresh token.
+     *
+     * @param refreshTokenString the opaque refresh token to revoke
+     */
+    public void revokeRefreshToken(String refreshTokenString) {
+        String tokenHash = sha256(refreshTokenString);
+
+        refreshTokenRepository.findByTokenHash(tokenHash).ifPresent(token -> {
+            token.revoke();
+            refreshTokenRepository.save(token);
+            logger.info("Refresh token revoked: siteId={}", token.getSiteId());
+        });
+    }
+
+    /**
+     * Revoke all refresh tokens for a site.
+     *
+     * @param siteId site identifier
+     */
+    public void revokeAllForSite(UUID siteId) {
+        int revoked = refreshTokenRepository.revokeAllBySiteId(siteId);
+        logger.info("Revoked {} refresh tokens for site: siteId={}", revoked, siteId);
+    }
+
+    /**
+     * Cleanup expired and revoked tokens.
+     * Runs daily.
+     */
+    @Scheduled(fixedRate = 86400000) // 24 hours
+    @Transactional
+    public void cleanupExpiredTokens() {
+        logger.debug("Running refresh token cleanup...");
+        Instant cutoff = Instant.now().minus(7, ChronoUnit.DAYS);
+        int deleted = refreshTokenRepository.deleteExpiredBefore(cutoff);
+        if (deleted > 0) {
+            logger.info("Cleaned up {} expired/revoked refresh tokens", deleted);
+        }
+    }
+
+    // --- Private helpers ---
+
+    private String generateOpaqueToken() {
+        byte[] bytes = new byte[TOKEN_BYTE_LENGTH];
+        SECURE_RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    static String sha256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+
+    // --- Result types ---
+
+    /**
+     * Result of a successful token refresh.
+     */
+    public record RefreshResult(
+            JwtToken accessToken,
+            String refreshToken,
+            Instant refreshTokenExpiresAt
+    ) {
+    }
+
+    // --- Exceptions ---
+
+    public static class InvalidRefreshTokenException extends RuntimeException {
+        public InvalidRefreshTokenException(String message) {
+            super(message);
+        }
+    }
+
+    public static class RefreshTokenExpiredException extends RuntimeException {
+        public RefreshTokenExpiredException(String message) {
+            super(message);
+        }
+    }
+
+    public static class RefreshTokenRevokedException extends RuntimeException {
+        public RefreshTokenRevokedException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/auth/application/RefreshTokenService.java
+++ b/src/main/java/com/bitbi/dfm/auth/application/RefreshTokenService.java
@@ -171,7 +171,7 @@ public class RefreshTokenService {
      * Cleanup expired and revoked tokens.
      * Runs daily.
      */
-    @Scheduled(fixedRate = 86400000) // 24 hours
+    @Scheduled(fixedDelay = 86400000, initialDelay = 3600000) // 24h between runs, 1h initial delay
     @Transactional
     public void cleanupExpiredTokens() {
         logger.debug("Running refresh token cleanup...");

--- a/src/main/java/com/bitbi/dfm/auth/application/TokenService.java
+++ b/src/main/java/com/bitbi/dfm/auth/application/TokenService.java
@@ -39,31 +39,63 @@ public class TokenService {
     }
 
     /**
-     * Generate JWT token for site.
+     * Generate JWT token for a site (Auth V2 - by siteId, no credentials required).
      * <p>
-     * Authenticates site using domain and clientSecret.
+     * Used internally after successful authentication (e.g., Device Flow approval).
      * </p>
+     *
+     * @param siteId site identifier
+     * @return JWT token with site claims
+     * @throws AuthenticationException if site is invalid or inactive
+     */
+    @Transactional(readOnly = true)
+    public JwtToken generateTokenForSite(UUID siteId) {
+        logger.debug("Generating token for siteId: {}", siteId);
+
+        Site site = siteRepository.findById(siteId)
+                .orElseThrow(() -> new AuthenticationException("Invalid credentials"));
+
+        if (!site.getIsActive()) {
+            logger.warn("Site is not active: siteId={}", siteId);
+            throw new AuthenticationException("Invalid credentials");
+        }
+
+        Account account = accountRepository.findById(site.getAccountId())
+                .orElseThrow(() -> new AuthenticationException("Invalid credentials"));
+
+        if (!account.getIsActive()) {
+            logger.warn("Parent account is not active: accountId={}, siteId={}", account.getId(), siteId);
+            throw new AuthenticationException("Invalid credentials");
+        }
+
+        JwtToken token = jwtTokenProvider.generateToken(site.getId(), site.getAccountId());
+
+        logger.info("Token generated successfully: siteId={}", siteId);
+        return token;
+    }
+
+    /**
+     * Generate JWT token for site using Basic Auth credentials (legacy).
      *
      * @param domain       site domain
      * @param clientSecret site clientSecret
      * @return JWT token with site claims
      * @throws AuthenticationException if credentials are invalid
+     * @deprecated Use Device Flow with refresh tokens instead
      */
+    @Deprecated
     @Transactional(readOnly = true)
     public JwtToken generateToken(String domain, String clientSecret) {
         logger.debug("Generating token for domain: {}", domain);
 
-        // Find site by domain
         Site site = siteRepository.findByDomain(domain)
                 .orElseThrow(() -> new AuthenticationException("Invalid credentials"));
 
-        // Validate site is active
         if (!site.getIsActive()) {
             logger.warn("Site is not active: domain={}", domain);
             throw new AuthenticationException("Invalid credentials");
         }
 
-        // Validate parent account is active
         Account account = accountRepository.findById(site.getAccountId())
                 .orElseThrow(() -> new AuthenticationException("Invalid credentials"));
 
@@ -72,14 +104,12 @@ public class TokenService {
             throw new AuthenticationException("Invalid credentials");
         }
 
-        // Validate clientSecret using bcrypt
         if (!site.verifySecret(clientSecret)) {
             logger.warn("Invalid clientSecret for domain: {}", domain);
             throw new AuthenticationException("Invalid credentials");
         }
 
-        // Generate JWT token
-        JwtToken token = jwtTokenProvider.generateToken(site.getId(), site.getAccountId(), domain);
+        JwtToken token = jwtTokenProvider.generateToken(site.getId(), site.getAccountId());
 
         logger.info("Token generated successfully: domain={}, siteId={}", domain, site.getId());
         return token;
@@ -137,21 +167,6 @@ public class TokenService {
     public UUID extractAccountId(String tokenString) {
         try {
             return jwtTokenProvider.extractAccountId(tokenString);
-        } catch (JwtTokenProvider.InvalidTokenException e) {
-            throw new InvalidTokenException("Invalid token format", e);
-        }
-    }
-
-    /**
-     * Extract domain from token without full validation.
-     *
-     * @param tokenString JWT token string
-     * @return domain
-     * @throws InvalidTokenException if token is malformed
-     */
-    public String extractDomain(String tokenString) {
-        try {
-            return jwtTokenProvider.extractDomain(tokenString);
         } catch (JwtTokenProvider.InvalidTokenException e) {
             throw new InvalidTokenException("Invalid token format", e);
         }

--- a/src/main/java/com/bitbi/dfm/auth/domain/AuthenticationService.java
+++ b/src/main/java/com/bitbi/dfm/auth/domain/AuthenticationService.java
@@ -12,9 +12,12 @@ import java.util.Objects;
  * and determining authentication eligibility.
  * </p>
  *
+ * @deprecated Auth V2: Basic Auth credential validation is no longer used.
+ * Authentication is now handled via Device Flow with JWT + refresh tokens.
  * @author Data Forge Team
  * @version 1.0.0
  */
+@Deprecated
 @Service
 public class AuthenticationService {
 

--- a/src/main/java/com/bitbi/dfm/auth/domain/JwtToken.java
+++ b/src/main/java/com/bitbi/dfm/auth/domain/JwtToken.java
@@ -11,9 +11,12 @@ import java.util.UUID;
  * Encapsulates token string, expiration time, and claims.
  * Immutable and validated at construction time.
  * </p>
+ * <p>
+ * Auth V2: domain field is nullable (new tokens don't include domain).
+ * </p>
  *
  * @author Data Forge Team
- * @version 1.0.0
+ * @version 2.0.0
  */
 public record JwtToken(
         String token,
@@ -28,14 +31,7 @@ public record JwtToken(
 
     /**
      * Constructs JwtToken with validation.
-     *
-     * @param token     JWT token string
-     * @param issuedAt  token issue timestamp
-     * @param expiresAt token expiration timestamp
-     * @param siteId    site identifier
-     * @param accountId account identifier
-     * @param domain    site domain
-     * @throws IllegalArgumentException if any parameter is null or invalid
+     * Domain is nullable for Auth V2 tokens.
      */
     public JwtToken {
         Objects.requireNonNull(token, "Token cannot be null");
@@ -43,7 +39,7 @@ public record JwtToken(
         Objects.requireNonNull(expiresAt, "ExpiresAt cannot be null");
         Objects.requireNonNull(siteId, "SiteId cannot be null");
         Objects.requireNonNull(accountId, "AccountId cannot be null");
-        Objects.requireNonNull(domain, "Domain cannot be null");
+        // domain is nullable for Auth V2
 
         if (token.isBlank()) {
             throw new IllegalArgumentException("Token cannot be blank");
@@ -55,14 +51,38 @@ public record JwtToken(
     }
 
     /**
-     * Create new JWT token with default expiration (24 hours).
+     * Create JWT token without domain (Auth V2).
      *
-     * @param tokenString JWT token string
-     * @param siteId      site identifier
-     * @param accountId   account identifier
-     * @param domain      site domain
-     * @return new JwtToken
+     * @param tokenString       JWT token string
+     * @param siteId            site identifier
+     * @param accountId         account identifier
+     * @param expirationSeconds expiration duration in seconds
+     * @return new JwtToken without domain
      */
+    public static JwtToken create(String tokenString, UUID siteId, UUID accountId, long expirationSeconds) {
+        Instant now = Instant.now();
+        Instant expires = now.plus(expirationSeconds, ChronoUnit.SECONDS);
+        return new JwtToken(tokenString, now, expires, siteId, accountId, null);
+    }
+
+    /**
+     * Create JWT token with domain (legacy).
+     *
+     * @deprecated Use {@link #create(String, UUID, UUID, long)} instead
+     */
+    @Deprecated
+    public static JwtToken createWithDomain(String tokenString, UUID siteId, UUID accountId, String domain, long expirationSeconds) {
+        Instant now = Instant.now();
+        Instant expires = now.plus(expirationSeconds, ChronoUnit.SECONDS);
+        return new JwtToken(tokenString, now, expires, siteId, accountId, domain);
+    }
+
+    /**
+     * Create new JWT token with default expiration (24 hours) and domain (legacy).
+     *
+     * @deprecated Use {@link #create(String, UUID, UUID, long)} instead
+     */
+    @Deprecated
     public static JwtToken create(String tokenString, UUID siteId, UUID accountId, String domain) {
         Instant now = Instant.now();
         Instant expires = now.plus(DEFAULT_EXPIRATION_SECONDS, ChronoUnit.SECONDS);
@@ -70,15 +90,11 @@ public record JwtToken(
     }
 
     /**
-     * Create JWT token with custom expiration duration.
+     * Create JWT token with custom expiration duration and domain (legacy).
      *
-     * @param tokenString      JWT token string
-     * @param siteId           site identifier
-     * @param accountId        account identifier
-     * @param domain           site domain
-     * @param expirationSeconds expiration duration in seconds
-     * @return new JwtToken
+     * @deprecated Use {@link #create(String, UUID, UUID, long)} instead
      */
+    @Deprecated
     public static JwtToken create(String tokenString, UUID siteId, UUID accountId, String domain, long expirationSeconds) {
         Instant now = Instant.now();
         Instant expires = now.plus(expirationSeconds, ChronoUnit.SECONDS);
@@ -87,8 +103,6 @@ public record JwtToken(
 
     /**
      * Check if token is expired.
-     *
-     * @return true if current time is after expiresAt
      */
     public boolean isExpired() {
         return Instant.now().isAfter(expiresAt);
@@ -96,8 +110,6 @@ public record JwtToken(
 
     /**
      * Check if token is still valid.
-     *
-     * @return true if current time is before expiresAt
      */
     public boolean isValid() {
         return !isExpired();
@@ -105,8 +117,6 @@ public record JwtToken(
 
     /**
      * Get remaining validity duration in seconds.
-     *
-     * @return seconds until expiration (0 if already expired)
      */
     public long getExpiresInSeconds() {
         if (isExpired()) {
@@ -117,8 +127,6 @@ public record JwtToken(
 
     /**
      * Get total expiration duration in seconds.
-     *
-     * @return original expiration duration
      */
     public long getExpirationDuration() {
         return ChronoUnit.SECONDS.between(issuedAt, expiresAt);

--- a/src/main/java/com/bitbi/dfm/auth/domain/RefreshToken.java
+++ b/src/main/java/com/bitbi/dfm/auth/domain/RefreshToken.java
@@ -1,0 +1,108 @@
+package com.bitbi.dfm.auth.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Entity representing a refresh token for device authentication.
+ * <p>
+ * Refresh tokens are opaque strings stored as SHA-256 hashes.
+ * They support rotation: on each use, the old token is revoked
+ * and a new one is issued.
+ * </p>
+ *
+ * @author Data Forge Team
+ * @version 1.0.0
+ */
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor
+public class RefreshToken {
+
+    private static final long DEFAULT_TTL_DAYS = 90;
+
+    @Id
+    @Column(name = "id", updatable = false, nullable = false)
+    private UUID id;
+
+    @Column(name = "site_id", nullable = false)
+    private UUID siteId;
+
+    /**
+     * SHA-256 hash of the opaque refresh token string.
+     */
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @Column(name = "expires_at", nullable = false)
+    private Instant expiresAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    /**
+     * When the token was revoked. NULL means the token is active.
+     */
+    @Column(name = "revoked_at")
+    private Instant revokedAt;
+
+    private RefreshToken(UUID id, UUID siteId, String tokenHash, Instant expiresAt, Instant createdAt) {
+        this.id = id;
+        this.siteId = siteId;
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * Create a new refresh token with default 90-day TTL.
+     *
+     * @param siteId    site identifier
+     * @param tokenHash SHA-256 hash of the opaque token
+     * @return new RefreshToken entity
+     */
+    public static RefreshToken create(UUID siteId, String tokenHash) {
+        return new RefreshToken(
+                UUID.randomUUID(),
+                siteId,
+                tokenHash,
+                Instant.now().plusSeconds(DEFAULT_TTL_DAYS * 24 * 60 * 60),
+                Instant.now()
+        );
+    }
+
+    /**
+     * Check if the token is expired.
+     */
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+
+    /**
+     * Check if the token has been revoked.
+     */
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    /**
+     * Check if the token is still valid (not expired and not revoked).
+     */
+    public boolean isValid() {
+        return !isExpired() && !isRevoked();
+    }
+
+    /**
+     * Revoke this refresh token.
+     */
+    public void revoke() {
+        if (this.revokedAt == null) {
+            this.revokedAt = Instant.now();
+        }
+    }
+}

--- a/src/main/java/com/bitbi/dfm/auth/domain/RefreshTokenRepository.java
+++ b/src/main/java/com/bitbi/dfm/auth/domain/RefreshTokenRepository.java
@@ -1,0 +1,46 @@
+package com.bitbi.dfm.auth.domain;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Repository interface for refresh token operations.
+ *
+ * @author Data Forge Team
+ * @version 1.0.0
+ */
+public interface RefreshTokenRepository {
+
+    /**
+     * Save a refresh token.
+     *
+     * @param refreshToken the token to save
+     * @return saved token
+     */
+    RefreshToken save(RefreshToken refreshToken);
+
+    /**
+     * Find a refresh token by its SHA-256 hash.
+     *
+     * @param tokenHash SHA-256 hash of the opaque token
+     * @return token if found
+     */
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    /**
+     * Revoke all active refresh tokens for a site.
+     *
+     * @param siteId site identifier
+     * @return number of revoked tokens
+     */
+    int revokeAllBySiteId(UUID siteId);
+
+    /**
+     * Delete expired and revoked tokens older than cutoff.
+     *
+     * @param cutoffTime tokens with expiresAt before this time will be deleted
+     * @return number of deleted records
+     */
+    int deleteExpiredBefore(Instant cutoffTime);
+}

--- a/src/main/java/com/bitbi/dfm/auth/infrastructure/JpaRefreshTokenRepository.java
+++ b/src/main/java/com/bitbi/dfm/auth/infrastructure/JpaRefreshTokenRepository.java
@@ -2,7 +2,9 @@ package com.bitbi.dfm.auth.infrastructure;
 
 import com.bitbi.dfm.auth.domain.RefreshToken;
 import com.bitbi.dfm.auth.domain.RefreshTokenRepository;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -21,6 +23,8 @@ import java.util.UUID;
 public interface JpaRefreshTokenRepository extends JpaRepository<RefreshToken, UUID>, RefreshTokenRepository {
 
     @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT rt FROM RefreshToken rt WHERE rt.tokenHash = :tokenHash")
     Optional<RefreshToken> findByTokenHash(String tokenHash);
 
     @Override

--- a/src/main/java/com/bitbi/dfm/auth/infrastructure/JpaRefreshTokenRepository.java
+++ b/src/main/java/com/bitbi/dfm/auth/infrastructure/JpaRefreshTokenRepository.java
@@ -34,6 +34,6 @@ public interface JpaRefreshTokenRepository extends JpaRepository<RefreshToken, U
 
     @Override
     @Modifying
-    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :cutoffTime AND (rt.revokedAt IS NOT NULL OR rt.expiresAt < CURRENT_TIMESTAMP)")
+    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :cutoffTime OR (rt.revokedAt IS NOT NULL AND rt.revokedAt < :cutoffTime)")
     int deleteExpiredBefore(Instant cutoffTime);
 }

--- a/src/main/java/com/bitbi/dfm/auth/infrastructure/JpaRefreshTokenRepository.java
+++ b/src/main/java/com/bitbi/dfm/auth/infrastructure/JpaRefreshTokenRepository.java
@@ -1,0 +1,35 @@
+package com.bitbi.dfm.auth.infrastructure;
+
+import com.bitbi.dfm.auth.domain.RefreshToken;
+import com.bitbi.dfm.auth.domain.RefreshTokenRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * JPA implementation of RefreshTokenRepository.
+ *
+ * @author Data Forge Team
+ * @version 1.0.0
+ */
+@Repository
+public interface JpaRefreshTokenRepository extends JpaRepository<RefreshToken, UUID>, RefreshTokenRepository {
+
+    @Override
+    Optional<RefreshToken> findByTokenHash(String tokenHash);
+
+    @Override
+    @Modifying
+    @Query("UPDATE RefreshToken rt SET rt.revokedAt = CURRENT_TIMESTAMP WHERE rt.siteId = :siteId AND rt.revokedAt IS NULL")
+    int revokeAllBySiteId(UUID siteId);
+
+    @Override
+    @Modifying
+    @Query("DELETE FROM RefreshToken rt WHERE rt.expiresAt < :cutoffTime AND (rt.revokedAt IS NOT NULL OR rt.expiresAt < CURRENT_TIMESTAMP)")
+    int deleteExpiredBefore(Instant cutoffTime);
+}

--- a/src/main/java/com/bitbi/dfm/auth/infrastructure/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bitbi/dfm/auth/infrastructure/JwtAuthenticationFilter.java
@@ -82,13 +82,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // Validate token and get site ID
             UUID siteId = tokenService.validateToken(token);
             UUID accountId = tokenService.extractAccountId(token);
-            String domain = tokenService.extractDomain(token);
 
             // Create authentication object with site ID as principal
             JwtAuthenticationToken authentication = new JwtAuthenticationToken(
                     siteId,
                     accountId,
-                    domain,
                     Collections.singletonList(new SimpleGrantedAuthority("ROLE_CLIENT"))
             );
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
@@ -96,7 +94,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // Set authentication in security context
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            logger.debug("JWT authentication successful: siteId={}, accountId={}, domain={}", siteId, accountId, domain);
+            logger.debug("JWT authentication successful: siteId={}, accountId={}", siteId, accountId);
 
         } catch (TokenService.InvalidTokenException e) {
             logger.warn("JWT token validation failed for path {}: {}", path, e.getMessage());
@@ -109,21 +107,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     /**
      * Custom authentication token for JWT-authenticated requests.
      * <p>
-     * Stores siteId, accountId, and domain for authorization checks.
+     * Stores siteId and accountId for authorization checks.
      * Token is pre-authenticated (created with authorities in constructor).
      * </p>
      */
     public static class JwtAuthenticationToken extends UsernamePasswordAuthenticationToken {
         private final UUID siteId;
         private final UUID accountId;
-        private final String domain;
 
-        public JwtAuthenticationToken(UUID siteId, UUID accountId, String domain, java.util.List<SimpleGrantedAuthority> authorities) {
+        public JwtAuthenticationToken(UUID siteId, UUID accountId, java.util.List<SimpleGrantedAuthority> authorities) {
             // Use constructor that accepts authorities - this automatically sets authenticated=true
             super(siteId, null, authorities);
             this.siteId = siteId;
             this.accountId = accountId;
-            this.domain = domain;
             // Do NOT call setAuthenticated(true) - already handled by super constructor
         }
 
@@ -133,10 +129,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         public UUID getAccountId() {
             return accountId;
-        }
-
-        public String getDomain() {
-            return domain;
         }
     }
 }

--- a/src/main/java/com/bitbi/dfm/auth/infrastructure/JwtTokenProvider.java
+++ b/src/main/java/com/bitbi/dfm/auth/infrastructure/JwtTokenProvider.java
@@ -39,14 +39,36 @@ public class JwtTokenProvider {
     }
 
     /**
-     * Generate JWT token for site authentication.
+     * Generate JWT token for site authentication (Auth V2 - no domain claim).
+     *
+     * @param siteId    site identifier
+     * @param accountId account identifier
+     * @return JWT token with claims
+     */
+    public JwtToken generateToken(UUID siteId, UUID accountId) {
+        String tokenString = Jwts.builder()
+                .subject(siteId.toString())
+                .claim("siteId", siteId.toString())
+                .claim("accountId", accountId.toString())
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expirationSeconds * 1000))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+
+        return JwtToken.create(tokenString, siteId, accountId, expirationSeconds);
+    }
+
+    /**
+     * Generate JWT token for site authentication (legacy with domain).
      *
      * @param siteId    site identifier
      * @param accountId account identifier
      * @param domain    site domain name
      * @return JWT token with claims
+     * @deprecated Use {@link #generateToken(UUID, UUID)} instead
      */
-    public JwtToken generateToken(UUID siteId, UUID accountId, String domain) {
+    @Deprecated
+    public JwtToken generateTokenWithDomain(UUID siteId, UUID accountId, String domain) {
         String tokenString = Jwts.builder()
                 .subject(siteId.toString())
                 .claim("siteId", siteId.toString())
@@ -57,7 +79,7 @@ public class JwtTokenProvider {
                 .signWith(secretKey, Jwts.SIG.HS256)
                 .compact();
 
-        return JwtToken.create(tokenString, siteId, accountId, domain, expirationSeconds);
+        return JwtToken.createWithDomain(tokenString, siteId, accountId, domain, expirationSeconds);
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/auth/presentation/AuthController.java
+++ b/src/main/java/com/bitbi/dfm/auth/presentation/AuthController.java
@@ -21,9 +21,13 @@ import java.util.Map;
  * Provides JWT token generation endpoint with Basic Auth.
  * </p>
  *
+ * @deprecated Auth V2: Use Device Flow with JWT + refresh tokens instead.
+ * Basic Auth endpoints will be removed in the next major version.
+ * See DeviceAuthController for the new refresh token endpoint.
  * @author Data Forge Team
  * @version 1.0.0
  */
+@Deprecated
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {

--- a/src/main/java/com/bitbi/dfm/auth/presentation/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/bitbi/dfm/auth/presentation/dto/RefreshTokenRequestDto.java
@@ -1,0 +1,17 @@
+package com.bitbi.dfm.auth.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Request DTO for token refresh.
+ *
+ * @param refreshToken the opaque refresh token
+ */
+@Schema(description = "Request body for refreshing access token")
+public record RefreshTokenRequestDto(
+        @Schema(description = "Opaque refresh token", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "Refresh token is required")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/bitbi/dfm/auth/presentation/dto/RefreshTokenRequestDto.java
+++ b/src/main/java/com/bitbi/dfm/auth/presentation/dto/RefreshTokenRequestDto.java
@@ -2,6 +2,7 @@ package com.bitbi.dfm.auth.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 /**
  * Request DTO for token refresh.
@@ -12,6 +13,7 @@ import jakarta.validation.constraints.NotBlank;
 public record RefreshTokenRequestDto(
         @Schema(description = "Opaque refresh token", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotBlank(message = "Refresh token is required")
+        @Pattern(regexp = "^[A-Za-z0-9_-]{43}$", message = "Invalid refresh token format")
         String refreshToken
 ) {
 }

--- a/src/main/java/com/bitbi/dfm/auth/presentation/dto/RefreshTokenResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/auth/presentation/dto/RefreshTokenResponseDto.java
@@ -1,0 +1,34 @@
+package com.bitbi.dfm.auth.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.Instant;
+
+/**
+ * Response DTO for token refresh.
+ *
+ * @param accessToken           new JWT access token
+ * @param refreshToken          new rotated refresh token
+ * @param accessTokenExpiresAt  access token expiration
+ * @param refreshTokenExpiresAt refresh token expiration
+ */
+@Schema(description = "Response with new access token and rotated refresh token")
+public record RefreshTokenResponseDto(
+        @Schema(description = "New JWT access token")
+        @JsonProperty("accessToken")
+        String accessToken,
+
+        @Schema(description = "New rotated refresh token (old token is now invalid)")
+        @JsonProperty("refreshToken")
+        String refreshToken,
+
+        @Schema(description = "Access token expiration timestamp")
+        @JsonProperty("accessTokenExpiresAt")
+        Instant accessTokenExpiresAt,
+
+        @Schema(description = "Refresh token expiration timestamp")
+        @JsonProperty("refreshTokenExpiresAt")
+        Instant refreshTokenExpiresAt
+) {
+}

--- a/src/main/java/com/bitbi/dfm/auth/presentation/dto/TokenResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/auth/presentation/dto/TokenResponseDto.java
@@ -6,30 +6,20 @@ import java.time.Instant;
 import java.util.UUID;
 
 /**
- * Response DTO for JWT token generation.
- *
- * Provides immutable representation of generated token with claims for API responses.
- *
- * FR-001: Structured response objects
- * FR-002: Consistent field naming and types
- * FR-003: Complete information preservation
+ * Response DTO for JWT token generation (Auth V2).
  *
  * @param token JWT token string
  * @param expiresAt Token expiration timestamp
  * @param siteId Site ID from token claims
- * @param domain Domain from token claims
  */
 public record TokenResponseDto(
     String token,
     Instant expiresAt,
-    UUID siteId,
-    String domain
+    UUID siteId
 ) {
 
     /**
      * Convert JwtToken value object to TokenResponseDto.
-     *
-     * Extracts relevant fields from JwtToken, excluding internal fields like issuedAt and accountId.
      *
      * @param jwtToken The JWT token value object to convert
      * @return TokenResponseDto with extracted claims
@@ -38,8 +28,7 @@ public record TokenResponseDto(
         return new TokenResponseDto(
             jwtToken.token(),
             jwtToken.expiresAt(),
-            jwtToken.siteId(),
-            jwtToken.domain()
+            jwtToken.siteId()
         );
     }
 }

--- a/src/main/java/com/bitbi/dfm/batch/application/BatchLifecycleService.java
+++ b/src/main/java/com/bitbi/dfm/batch/application/BatchLifecycleService.java
@@ -67,8 +67,8 @@ public class BatchLifecycleService {
      * @throws ActiveBatchExistsException   if site has active batch
      * @throws ConcurrentBatchLimitException if account exceeded concurrent batch limit
      */
-    public Batch startBatch(UUID accountId, UUID siteId, String domain) {
-        logger.info("Starting new batch: accountId={}, siteId={}, domain={}", accountId, siteId, domain);
+    public Batch startBatch(UUID accountId, UUID siteId) {
+        logger.info("Starting new batch: accountId={}, siteId={}", accountId, siteId);
 
         // Validate site is active
         Site site = siteRepository.findById(siteId)
@@ -93,7 +93,7 @@ public class BatchLifecycleService {
                     "Account exceeded concurrent batch limit: " + activeBatchCount + "/" + maxConcurrentBatches);
         }
 
-        Batch batch = Batch.start(accountId, siteId, domain);
+        Batch batch = Batch.start(accountId, siteId);
         Batch saved = batchRepository.save(batch);
 
         // Publish domain event

--- a/src/main/java/com/bitbi/dfm/batch/domain/Batch.java
+++ b/src/main/java/com/bitbi/dfm/batch/domain/Batch.java
@@ -86,25 +86,39 @@ public class Batch {
         // version is automatically managed by JPA
     }
 
-    public static Batch start(UUID accountId, UUID siteId, String domain) {
+    /**
+     * Start a new batch (Auth V2 - uses siteId in S3 path).
+     *
+     * @param accountId account identifier
+     * @param siteId    site identifier (used in S3 path)
+     * @return new batch in IN_PROGRESS status
+     */
+    public static Batch start(UUID accountId, UUID siteId) {
         Objects.requireNonNull(siteId, "SiteId cannot be null");
         Objects.requireNonNull(accountId, "AccountId cannot be null");
-        Objects.requireNonNull(domain, "Domain cannot be null");
 
         UUID id = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
-        String s3Path = generateS3Path(accountId, domain, now);
+        String s3Path = generateS3Path(accountId, siteId, now);
 
         return new Batch(id, accountId, siteId, BatchStatus.IN_PROGRESS, s3Path,
                 0, 0L, false, now, null, now);
     }
 
-    private static String generateS3Path(UUID accountId, String domain, LocalDateTime timestamp) {
+    /**
+     * @deprecated Use {@link #start(UUID, UUID)} instead
+     */
+    @Deprecated
+    public static Batch start(UUID accountId, UUID siteId, String domain) {
+        return start(accountId, siteId);
+    }
+
+    private static String generateS3Path(UUID accountId, UUID siteId, LocalDateTime timestamp) {
         DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH-mm");
         String date = timestamp.format(dateFormatter);
         String time = timestamp.format(timeFormatter);
-        return String.format("%s/%s/%s/%s/", accountId, domain, date, time);
+        return String.format("%s/%s/%s/%s/", accountId, siteId, date, time);
     }
 
     public void complete() {

--- a/src/main/java/com/bitbi/dfm/batch/presentation/BatchController.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/BatchController.java
@@ -55,14 +55,13 @@ public class BatchController {
     public ResponseEntity<?> startBatch() {
 
         try {
-            // Get authenticated site/account/domain from security context
+            // Get authenticated site/account from security context
             UUID siteId = authorizationHelper.getAuthenticatedSiteId();
             UUID accountId = authorizationHelper.getAuthenticatedAccountId();
-            String domain = authorizationHelper.getAuthenticatedDomain();
 
-            logger.info("Starting batch: siteId={}, domain={}", siteId, domain);
+            logger.info("Starting batch: siteId={}", siteId);
 
-            Batch batch = batchLifecycleService.startBatch(accountId, siteId, domain);
+            Batch batch = batchLifecycleService.startBatch(accountId, siteId);
 
             BatchResponseDto response = BatchResponseDto.fromEntity(batch);
             return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchDetailResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/batch/presentation/dto/BatchDetailResponseDto.java
@@ -87,7 +87,7 @@ public record BatchDetailResponseDto(
         return new BatchDetailResponseDto(
                 batch.getId(),
                 batch.getSiteId(),
-                site != null ? site.getDomain() : "unknown",
+                site != null ? site.getSiteName() : "unknown",
                 batch.getStatus().toString(),
                 batch.getS3Path(),
                 batch.getUploadedFilesCount(),

--- a/src/main/java/com/bitbi/dfm/device/presentation/DeviceAuthController.java
+++ b/src/main/java/com/bitbi/dfm/device/presentation/DeviceAuthController.java
@@ -1,8 +1,8 @@
 package com.bitbi.dfm.device.presentation;
 
-import com.bitbi.dfm.auth.application.TokenService;
-import com.bitbi.dfm.auth.domain.JwtToken;
-import com.bitbi.dfm.auth.presentation.dto.TokenResponseDto;
+import com.bitbi.dfm.auth.application.RefreshTokenService;
+import com.bitbi.dfm.auth.presentation.dto.RefreshTokenRequestDto;
+import com.bitbi.dfm.auth.presentation.dto.RefreshTokenResponseDto;
 import com.bitbi.dfm.shared.api.ApiRoutes;
 import com.bitbi.dfm.shared.presentation.DeviceControllerHelper;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,177 +10,122 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 /**
- * Device API Authentication Controller.
+ * Device API Authentication Controller (Auth V2).
  * <p>
- * Provides JWT token generation for device clients (IoT devices, mobile apps,
- * data collection clients) using Basic Authentication with site credentials.
- * </p>
- * <p>
- * <b>Authentication</b>: Basic Auth (domain:clientSecret)<br>
- * <b>Returns</b>: Custom JWT token for subsequent Device API requests
+ * Provides token refresh endpoint for device clients.
+ * Basic Auth token generation has been removed in Auth V2.
+ * Devices obtain initial tokens via Device Authorization Flow.
  * </p>
  *
  * @author Data Forge Team
- * @version 1.0.0
- * @see com.bitbi.dfm.auth.application.TokenService
- * @see <a href="specs/010-api-unification-goal/spec.md">API Unification Specification</a>
+ * @version 2.0.0
  */
 @RestController
 @RequestMapping(ApiRoutes.DEVICE_AUTH)
-@Tag(name = "Device API - Authentication", description = "JWT token generation for device clients using Basic Auth (domain:clientSecret)")
+@Tag(name = "Device API - Authentication", description = "Token refresh for device clients (Auth V2)")
 public class DeviceAuthController {
 
     private static final Logger logger = LoggerFactory.getLogger(DeviceAuthController.class);
 
-    private final TokenService tokenService;
+    private final RefreshTokenService refreshTokenService;
 
-    /**
-     * Constructor injection for TokenService.
-     *
-     * @param tokenService Service for generating JWT tokens
-     */
-    public DeviceAuthController(TokenService tokenService) {
-        this.tokenService = tokenService;
+    public DeviceAuthController(RefreshTokenService refreshTokenService) {
+        this.refreshTokenService = refreshTokenService;
     }
 
     /**
-     * Generate JWT token using Basic Auth credentials.
+     * Refresh access token using refresh token (Auth V2).
      * <p>
-     * <b>Authentication</b>: Basic Auth with site domain and clientSecret<br>
-     * <b>Format</b>: Authorization: Basic base64(domain:clientSecret)<br>
-     * <b>Returns</b>: Custom JWT token valid for 24 hours
+     * No authentication required - the refresh token itself is the credential.
+     * Implements token rotation: old refresh token is revoked, new one issued.
      * </p>
      *
-     * @param authHeader Authorization header with Basic Auth credentials
-     * @param request    HTTP servlet request for error reporting
-     * @return JWT token response or error response
+     * @param request refresh token request
+     * @return new access token and rotated refresh token
      */
-    @PostMapping("/token")
+    @PostMapping("/refresh")
     @Operation(
-            summary = "Generate JWT token for device authentication",
-            description = "Issues a Custom JWT token for device clients using Basic Authentication with site credentials. " +
-                    "The credentials format is 'domain:clientSecret' encoded in Base64."
+            summary = "Refresh access token",
+            description = "Issues a new JWT access token and rotated refresh token. " +
+                    "The provided refresh token is revoked after use (token rotation)."
     )
-    @SecurityRequirement(name = "basicAuth")
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "JWT token generated successfully",
+                    description = "Token refreshed successfully",
                     content = @Content(
                             mediaType = "application/json",
-                            schema = @Schema(implementation = TokenResponseDto.class)
+                            schema = @Schema(implementation = RefreshTokenResponseDto.class)
                     )
             ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "Bad Request - Invalid Authorization header encoding",
-                    content = @Content(mediaType = "application/json")
-            ),
-            @ApiResponse(
-                    responseCode = "401",
-                    description = "Unauthorized - Invalid credentials or inactive site",
-                    content = @Content(mediaType = "application/json")
-            ),
-            @ApiResponse(
-                    responseCode = "500",
-                    description = "Internal Server Error",
-                    content = @Content(mediaType = "application/json")
-            )
+            @ApiResponse(responseCode = "400", description = "Bad Request - Invalid refresh token format"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - Refresh token expired or revoked")
     })
-    public ResponseEntity<?> generateToken(
-            @RequestHeader(value = "Authorization", required = false) String authHeader,
-            HttpServletRequest request) {
+    public ResponseEntity<?> refreshToken(
+            @Valid @RequestBody RefreshTokenRequestDto request,
+            HttpServletRequest httpRequest) {
 
-        logger.debug("Device API token generation request received from {}", request.getRemoteAddr());
-
-        // Validate Authorization header presence
-        if (authHeader == null || !authHeader.startsWith("Basic ")) {
-            logger.warn("Missing or invalid Authorization header from {}", request.getRemoteAddr());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(DeviceControllerHelper.createErrorResponse(
-                            HttpStatus.UNAUTHORIZED,
-                            "Unauthorized",
-                            "Missing or invalid Authorization header",
-                            request.getRequestURI()));
-        }
+        logger.debug("Token refresh request received from {}", httpRequest.getRemoteAddr());
 
         try {
-            // Extract and decode Basic Auth credentials
-            String base64Credentials = authHeader.substring("Basic ".length());
-            byte[] decodedBytes = Base64.getDecoder().decode(base64Credentials);
-            String credentials = new String(decodedBytes, StandardCharsets.UTF_8);
+            RefreshTokenService.RefreshResult result =
+                    refreshTokenService.refreshAccessToken(request.refreshToken());
 
-            // Parse domain:clientSecret format
-            String[] parts = credentials.split(":", 2);
-            if (parts.length != 2) {
-                logger.warn("Invalid Basic Auth format from {}", request.getRemoteAddr());
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(DeviceControllerHelper.createErrorResponse(
-                                HttpStatus.UNAUTHORIZED,
-                                "Unauthorized",
-                                "Invalid credentials format",
-                                request.getRequestURI()));
-            }
+            RefreshTokenResponseDto response = new RefreshTokenResponseDto(
+                    result.accessToken().token(),
+                    result.refreshToken(),
+                    result.accessToken().expiresAt(),
+                    result.refreshTokenExpiresAt()
+            );
 
-            String domain = parts[0];
-            String clientSecret = parts[1];
-
-            // Generate JWT token via TokenService
-            JwtToken token = tokenService.generateToken(domain, clientSecret);
-
-            // Convert to DTO and return
-            TokenResponseDto response = TokenResponseDto.fromToken(token);
-
-            logger.info("Device API token generated successfully: domain={}, siteId={}",
-                    domain, token.siteId());
-
+            logger.info("Token refreshed successfully: siteId={}", result.accessToken().siteId());
             return ResponseEntity.ok(response);
 
-        } catch (TokenService.AuthenticationException e) {
-            // Invalid credentials, inactive site, or non-existent domain
-            logger.warn("Device API authentication failed from {}: {}",
-                    request.getRemoteAddr(), e.getMessage());
+        } catch (RefreshTokenService.RefreshTokenExpiredException e) {
+            logger.warn("Expired refresh token from {}: {}", httpRequest.getRemoteAddr(), e.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(DeviceControllerHelper.createErrorResponse(
                             HttpStatus.UNAUTHORIZED,
-                            "Unauthorized",
-                            "Invalid credentials",
-                            request.getRequestURI()));
+                            "refresh_token_expired",
+                            "Refresh token has expired. Re-authorize using Device Flow.",
+                            httpRequest.getRequestURI()));
 
-        } catch (IllegalArgumentException e) {
-            // Invalid Base64 encoding
-            logger.warn("Invalid Basic Auth encoding from {}: {}",
-                    request.getRemoteAddr(), e.getMessage());
+        } catch (RefreshTokenService.RefreshTokenRevokedException e) {
+            logger.warn("Revoked refresh token from {}: {}", httpRequest.getRemoteAddr(), e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(DeviceControllerHelper.createErrorResponse(
+                            HttpStatus.UNAUTHORIZED,
+                            "refresh_token_revoked",
+                            "Refresh token has been revoked. Re-authorize using Device Flow.",
+                            httpRequest.getRequestURI()));
+
+        } catch (RefreshTokenService.InvalidRefreshTokenException e) {
+            logger.warn("Invalid refresh token from {}: {}", httpRequest.getRemoteAddr(), e.getMessage());
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(DeviceControllerHelper.createErrorResponse(
                             HttpStatus.BAD_REQUEST,
-                            "Bad Request",
-                            "Invalid Authorization header encoding",
-                            request.getRequestURI()));
+                            "invalid_refresh_token",
+                            e.getMessage(),
+                            httpRequest.getRequestURI()));
 
         } catch (Exception e) {
-            // Unexpected error
-            logger.error("Unexpected error during Device API token generation from {}",
-                    request.getRemoteAddr(), e);
+            logger.error("Unexpected error during token refresh from {}", httpRequest.getRemoteAddr(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(DeviceControllerHelper.createErrorResponse(
                             HttpStatus.INTERNAL_SERVER_ERROR,
                             "Internal Server Error",
                             "Internal server error",
-                            request.getRequestURI()));
+                            httpRequest.getRequestURI()));
         }
     }
 }

--- a/src/main/java/com/bitbi/dfm/device/presentation/DeviceBatchController.java
+++ b/src/main/java/com/bitbi/dfm/device/presentation/DeviceBatchController.java
@@ -114,15 +114,14 @@ public class DeviceBatchController {
     })
     public ResponseEntity<?> startBatch() {
         try {
-            // Extract authenticated site/account/domain from JWT security context
+            // Extract authenticated site/account from JWT security context
             UUID siteId = authorizationHelper.getAuthenticatedSiteId();
             UUID accountId = authorizationHelper.getAuthenticatedAccountId();
-            String domain = authorizationHelper.getAuthenticatedDomain();
 
-            logger.info("Device API: Starting batch - siteId={}, domain={}", siteId, domain);
+            logger.info("Device API: Starting batch - siteId={}", siteId);
 
             // Delegate to service layer
-            Batch batch = batchLifecycleService.startBatch(accountId, siteId, domain);
+            Batch batch = batchLifecycleService.startBatch(accountId, siteId);
 
             BatchResponseDto response = BatchResponseDto.fromEntity(batch);
             return ResponseEntity.status(HttpStatus.CREATED).body(response);

--- a/src/main/java/com/bitbi/dfm/deviceauth/application/DeviceAuthorizationService.java
+++ b/src/main/java/com/bitbi/dfm/deviceauth/application/DeviceAuthorizationService.java
@@ -1,5 +1,8 @@
 package com.bitbi.dfm.deviceauth.application;
 
+import com.bitbi.dfm.auth.application.RefreshTokenService;
+import com.bitbi.dfm.auth.domain.JwtToken;
+import com.bitbi.dfm.auth.infrastructure.JwtTokenProvider;
 import com.bitbi.dfm.deviceauth.domain.DeviceAuthorization;
 import com.bitbi.dfm.deviceauth.domain.DeviceAuthorizationRepository;
 import com.bitbi.dfm.deviceauth.domain.DeviceAuthorizationStatus;
@@ -13,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.UUID;
 
@@ -38,6 +42,8 @@ public class DeviceAuthorizationService {
 
     private final DeviceAuthorizationRepository repository;
     private final SiteService siteService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
 
     @Value("${device-authorization.verification-uri:https://app.dataforge.com/device-verify}")
     private String verificationUri;
@@ -55,9 +61,13 @@ public class DeviceAuthorizationService {
     private String apiBaseUrl;
 
     public DeviceAuthorizationService(DeviceAuthorizationRepository repository,
-                                      SiteService siteService) {
+                                      SiteService siteService,
+                                      JwtTokenProvider jwtTokenProvider,
+                                      RefreshTokenService refreshTokenService) {
         this.repository = repository;
         this.siteService = siteService;
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
     }
 
     /**
@@ -115,15 +125,14 @@ public class DeviceAuthorizationService {
     }
 
     /**
-     * Poll for token (device side).
+     * Poll for token (device side) - Auth V2.
      * <p>
-     * Returns credentials if approved, or appropriate error status.
+     * Returns JWT access token + refresh token if approved, or appropriate error status.
      * </p>
      *
      * @param deviceCode the device code
      * @return token result
      */
-    @Transactional(readOnly = true)
     public TokenResult getToken(String deviceCode) {
         logger.debug("Token poll: deviceCode={}", deviceCode.substring(0, 8) + "...");
 
@@ -142,24 +151,46 @@ public class DeviceAuthorizationService {
         // Check status
         return switch (authorization.getStatus()) {
             case PENDING -> TokenResult.authorizationPending();
-            case APPROVED -> TokenResult.success(
-                    authorization.getSiteId(),
-                    authorization.getDomain(),
-                    // Note: We can't return plain secret here - it was hashed
-                    // The secret is stored in a separate field for one-time return
-                    getPlainSecretFromAuthorization(authorization),
-                    apiBaseUrl
-            );
+            case APPROVED -> {
+                UUID siteId = authorization.getSiteId();
+                UUID accountId = authorization.getAccountId();
+                String siteName = authorization.getSiteName();
+
+                // Generate JWT access token
+                JwtToken accessToken = jwtTokenProvider.generateToken(siteId, accountId);
+
+                // Generate refresh token
+                String refreshToken = refreshTokenService.generateRefreshToken(siteId);
+                Instant refreshTokenExpiresAt = Instant.now().plus(90, ChronoUnit.DAYS);
+
+                yield TokenResult.success(
+                        siteId,
+                        siteName,
+                        accessToken.token(),
+                        refreshToken,
+                        accessToken.expiresAt(),
+                        refreshTokenExpiresAt,
+                        apiBaseUrl
+                );
+            }
             case DENIED -> TokenResult.accessDenied();
             case EXPIRED -> TokenResult.expiredToken();
         };
     }
 
     /**
-     * Token polling result.
+     * Token polling result (Auth V2).
      */
     public sealed interface TokenResult {
-        record Success(UUID siteId, String domain, String clientSecret, String apiBaseUrl) implements TokenResult {
+        record Success(
+                UUID siteId,
+                String siteName,
+                String accessToken,
+                String refreshToken,
+                Instant accessTokenExpiresAt,
+                Instant refreshTokenExpiresAt,
+                String apiBaseUrl
+        ) implements TokenResult {
         }
 
         record Pending() implements TokenResult {
@@ -174,8 +205,9 @@ public class DeviceAuthorizationService {
         record InvalidGrant() implements TokenResult {
         }
 
-        static TokenResult success(UUID siteId, String domain, String clientSecret, String apiBaseUrl) {
-            return new Success(siteId, domain, clientSecret, apiBaseUrl);
+        static TokenResult success(UUID siteId, String siteName, String accessToken, String refreshToken,
+                                   Instant accessTokenExpiresAt, Instant refreshTokenExpiresAt, String apiBaseUrl) {
+            return new Success(siteId, siteName, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt, apiBaseUrl);
         }
 
         static TokenResult authorizationPending() {
@@ -260,8 +292,8 @@ public class DeviceAuthorizationService {
             throw new AuthorizationAlreadyProcessedException("Authorization already processed");
         }
 
-        // Get or create site with new credentials
-        SiteService.SiteCreationResult siteResult = siteService.getOrCreateSiteWithNewCredentials(
+        // Get or create site (Auth V2 - no credential generation)
+        SiteService.SiteCreationResult siteResult = siteService.getOrCreateSite(
                 accountId,
                 authorization.getSiteName(),
                 authorization.getSiteDescription() != null
@@ -269,19 +301,20 @@ public class DeviceAuthorizationService {
                         : authorization.getSiteName()
         );
 
+        // Revoke any existing refresh tokens for this site
+        refreshTokenService.revokeAllForSite(siteResult.site().getId());
+
         // Update authorization with site info
         authorization.setAccountId(accountId);
         authorization.setSiteId(siteResult.site().getId());
-        authorization.setDomain(siteResult.site().getDomain());
-        // Store the hashed secret (we'll use a workaround to return plain secret)
-        authorization.setClientSecretHash(encodeSecretForOneTimeReturn(siteResult.plaintextSecret()));
+        authorization.setDomain(siteResult.site().getSiteName());
         authorization.setStatus(DeviceAuthorizationStatus.APPROVED);
         authorization.setApprovedAt(Instant.now());
 
         repository.save(authorization);
 
-        logger.info("Authorization verified: userCode={}, siteId={}, domain={}",
-                userCode, siteResult.site().getId(), siteResult.site().getDomain());
+        logger.info("Authorization verified: userCode={}, siteId={}, siteName={}",
+                userCode, siteResult.site().getId(), siteResult.site().getSiteName());
 
         return new VerificationResult(
                 siteResult.site().getId(),
@@ -365,28 +398,6 @@ public class DeviceAuthorizationService {
             }
         }
         throw new RuntimeException("Failed to generate unique user code after 10 attempts");
-    }
-
-    /**
-     * Encode secret for one-time return (base64 encoded for storage).
-     * This is a workaround since we need to return the plain secret to the device.
-     */
-    private String encodeSecretForOneTimeReturn(String plainSecret) {
-        // Store base64 encoded for one-time retrieval
-        // In production, consider encrypting this
-        return "PLAIN:" + Base64.getEncoder().encodeToString(plainSecret.getBytes());
-    }
-
-    /**
-     * Get plain secret from authorization (one-time retrieval).
-     */
-    private String getPlainSecretFromAuthorization(DeviceAuthorization authorization) {
-        String stored = authorization.getClientSecretHash();
-        if (stored != null && stored.startsWith("PLAIN:")) {
-            return new String(Base64.getDecoder().decode(stored.substring(6)));
-        }
-        // Fallback - should not happen in normal flow
-        return null;
     }
 
     // --- Exceptions ---

--- a/src/main/java/com/bitbi/dfm/deviceauth/presentation/DeviceAuthorizationController.java
+++ b/src/main/java/com/bitbi/dfm/deviceauth/presentation/DeviceAuthorizationController.java
@@ -139,7 +139,7 @@ public class DeviceAuthorizationController {
 
         return switch (result) {
             case TokenResult.Success success -> {
-                logger.info("Token issued: siteId={}, domain={}", success.siteId(), success.domain());
+                logger.info("Token issued: siteId={}, siteName={}", success.siteId(), success.siteName());
                 yield ResponseEntity.ok(DeviceTokenResponseDto.fromResult(success));
             }
             case TokenResult.Pending pending -> {

--- a/src/main/java/com/bitbi/dfm/deviceauth/presentation/dto/DeviceTokenResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/deviceauth/presentation/dto/DeviceTokenResponseDto.java
@@ -3,32 +3,48 @@ package com.bitbi.dfm.deviceauth.presentation.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
- * Response DTO with site credentials after approval.
+ * Response DTO with tokens after approval (Auth V2).
  *
- * @param siteId       created site ID
- * @param domain       full domain for authentication
- * @param clientSecret plain client secret (returned only once!)
- * @param apiBaseUrl   API base URL for subsequent requests
+ * @param siteId                 created site ID
+ * @param siteName               site display name
+ * @param accessToken            JWT access token (1 hour TTL)
+ * @param refreshToken           opaque refresh token (90 days TTL)
+ * @param accessTokenExpiresAt   access token expiration
+ * @param refreshTokenExpiresAt  refresh token expiration
+ * @param apiBaseUrl             API base URL for subsequent requests
  * @author Data Forge Team
- * @version 1.0.0
+ * @version 2.0.0
  */
-@Schema(description = "Site credentials after successful authorization")
+@Schema(description = "Tokens after successful device authorization (Auth V2)")
 public record DeviceTokenResponseDto(
 
         @Schema(description = "Created site ID", example = "550e8400-e29b-41d4-a716-446655440000")
         @JsonProperty("siteId")
         UUID siteId,
 
-        @Schema(description = "Full domain for authentication", example = "acct123_warehouse-01")
-        @JsonProperty("domain")
-        String domain,
+        @Schema(description = "Site name", example = "warehouse-01")
+        @JsonProperty("siteName")
+        String siteName,
 
-        @Schema(description = "Client secret for Basic Auth (store securely!)", example = "dGhpcyBpcyBhIHNlY3JldCBrZXk=")
-        @JsonProperty("clientSecret")
-        String clientSecret,
+        @Schema(description = "JWT access token")
+        @JsonProperty("accessToken")
+        String accessToken,
+
+        @Schema(description = "Opaque refresh token (store securely!)")
+        @JsonProperty("refreshToken")
+        String refreshToken,
+
+        @Schema(description = "Access token expiration timestamp")
+        @JsonProperty("accessTokenExpiresAt")
+        Instant accessTokenExpiresAt,
+
+        @Schema(description = "Refresh token expiration timestamp")
+        @JsonProperty("refreshTokenExpiresAt")
+        Instant refreshTokenExpiresAt,
 
         @Schema(description = "API base URL", example = "https://api.dataforge.com")
         @JsonProperty("apiBaseUrl")
@@ -41,8 +57,11 @@ public record DeviceTokenResponseDto(
             com.bitbi.dfm.deviceauth.application.DeviceAuthorizationService.TokenResult.Success success) {
         return new DeviceTokenResponseDto(
                 success.siteId(),
-                success.domain(),
-                success.clientSecret(),
+                success.siteName(),
+                success.accessToken(),
+                success.refreshToken(),
+                success.accessTokenExpiresAt(),
+                success.refreshTokenExpiresAt(),
                 success.apiBaseUrl()
         );
     }

--- a/src/main/java/com/bitbi/dfm/error/infrastructure/JpaErrorLogRepository.java
+++ b/src/main/java/com/bitbi/dfm/error/infrastructure/JpaErrorLogRepository.java
@@ -181,7 +181,7 @@ public interface JpaErrorLogRepository extends JpaRepository<ErrorLog, UUID>, Er
      * @param pageable  pagination parameters
      * @return page of global error projections with site name
      */
-    @Query("SELECT e.id AS id, e.siteId AS siteId, s.domain AS siteName, " +
+    @Query("SELECT e.id AS id, e.siteId AS siteId, s.siteName AS siteName, " +
             "e.type AS type, e.title AS title, e.severity AS severity, " +
             "e.isRead AS isRead, e.occurredAt AS occurredAt " +
             "FROM ErrorLog e " +
@@ -196,7 +196,7 @@ public interface JpaErrorLogRepository extends JpaRepository<ErrorLog, UUID>, Er
      * @param pageable  pagination parameters
      * @return page of unread global error projections with site name
      */
-    @Query("SELECT e.id AS id, e.siteId AS siteId, s.domain AS siteName, " +
+    @Query("SELECT e.id AS id, e.siteId AS siteId, s.siteName AS siteName, " +
             "e.type AS type, e.title AS title, e.severity AS severity, " +
             "e.isRead AS isRead, e.occurredAt AS occurredAt " +
             "FROM ErrorLog e " +

--- a/src/main/java/com/bitbi/dfm/error/presentation/dto/GlobalErrorResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/error/presentation/dto/GlobalErrorResponseDto.java
@@ -78,7 +78,7 @@ public record GlobalErrorResponseDto(
         return new GlobalErrorResponseDto(
                 errorLog.getId(),
                 errorLog.getSiteId(),
-                site != null ? site.getDomain() : "Unknown",
+                site != null ? site.getSiteName() : "Unknown",
                 errorLog.getType(),
                 errorLog.getTitle(),
                 errorLog.getMessage(),

--- a/src/main/java/com/bitbi/dfm/error/presentation/dto/GlobalErrorSummaryDto.java
+++ b/src/main/java/com/bitbi/dfm/error/presentation/dto/GlobalErrorSummaryDto.java
@@ -61,7 +61,7 @@ public record GlobalErrorSummaryDto(
         return new GlobalErrorSummaryDto(
                 errorLog.getId(),
                 errorLog.getSiteId(),
-                site != null ? site.getDomain() : "Unknown",
+                site != null ? site.getSiteName() : "Unknown",
                 errorLog.getType(),
                 errorLog.getTitle(),
                 errorLog.getSeverity(),

--- a/src/main/java/com/bitbi/dfm/plugin/application/PluginAdminQueryService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/PluginAdminQueryService.java
@@ -388,7 +388,7 @@ public class PluginAdminQueryService {
 
                     // Get site domain from bulk-fetched map
                     String siteDomain = sitesById.containsKey(batch.getSiteId())
-                            ? sitesById.get(batch.getSiteId()).getDisplayDomain()
+                            ? sitesById.get(batch.getSiteId()).getSiteName()
                             : "unknown";
 
                     if (hasSql) {

--- a/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/application/SqlGenerationService.java
@@ -204,7 +204,7 @@ public class SqlGenerationService {
             // Phase 2b: Store SQL file in S3 (outside transaction)
             s3Key = s3SqlFileStorageService.storeSqlFile(
                     batchData.batch.getAccountId(),
-                    batchData.site.getDomain(),
+                    batchData.site.getId(),
                     result.sqlContent
             );
             long fileSize = s3SqlFileStorageService.getFileSize(s3Key);
@@ -654,7 +654,7 @@ public class SqlGenerationService {
             // Store SQL file in S3
             s3Key = s3SqlFileStorageService.storeSqlFile(
                     batchData.batch.getAccountId(),
-                    batchData.site.getDomain(),
+                    batchData.site.getId(),
                     result.sqlContent
             );
             long fileSize = s3SqlFileStorageService.getFileSize(s3Key);

--- a/src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java
+++ b/src/main/java/com/bitbi/dfm/plugin/infrastructure/storage/S3SqlFileStorageService.java
@@ -43,12 +43,12 @@ public class S3SqlFileStorageService {
      * Stores generated SQL content in S3.
      *
      * @param accountId The account ID
-     * @param siteName The site name (used in path)
+     * @param siteId    The site ID (used in path, Auth V2)
      * @param sqlContent The SQL content to store
      * @return The S3 key where the file was stored
      */
-    public String storeSqlFile(UUID accountId, String siteName, String sqlContent) {
-        String s3Key = generateS3Key(accountId, siteName);
+    public String storeSqlFile(UUID accountId, UUID siteId, String sqlContent) {
+        String s3Key = generateS3Key(accountId, siteId);
         byte[] contentBytes = sqlContent.getBytes(StandardCharsets.UTF_8);
 
         log.debug("Storing SQL file to S3: bucket={}, key={}, size={}",
@@ -222,24 +222,13 @@ public class S3SqlFileStorageService {
     }
 
     /**
-     * Generates S3 key for SQL file.
-     * Format: plugins/bit-bi/{accountId}/{siteName}/{datetime}.sql
+     * Generates S3 key for SQL file (Auth V2).
+     * Format: plugins/bit-bi/{accountId}/{siteId}/{datetime}.sql
      */
-    private String generateS3Key(UUID accountId, String siteName) {
+    private String generateS3Key(UUID accountId, UUID siteId) {
         String datetime = LocalDateTime.now().format(PATH_DATETIME_FORMATTER);
         return String.format("plugins/bit-bi/%s/%s/%s.sql",
-                accountId, sanitizeSiteName(siteName), datetime);
-    }
-
-    /**
-     * Sanitizes site name for use in S3 key.
-     * Replaces problematic characters with hyphens.
-     */
-    private String sanitizeSiteName(String siteName) {
-        if (siteName == null || siteName.isEmpty()) {
-            return "unknown-site";
-        }
-        return siteName.replaceAll("[^a-zA-Z0-9.-]", "-").toLowerCase();
+                accountId, siteId, datetime);
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/AccountPluginsController.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/AccountPluginsController.java
@@ -306,7 +306,7 @@ public class AccountPluginsController {
                     UUID logSiteId = extractSiteIdFromMetadata(auditLog.getMetadata());
                     String siteDomain = null;
                     if (logSiteId != null && sitesById.containsKey(logSiteId)) {
-                        siteDomain = sitesById.get(logSiteId).getDisplayDomain();
+                        siteDomain = sitesById.get(logSiteId).getSiteName();
                     }
                     return UserPluginLogDto.fromEntityWithSite(auditLog, siteDomain);
                 })

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/BitBiPluginApiController.java
@@ -187,7 +187,7 @@ public class BitBiPluginApiController {
             List<SiteDto> siteDtos = sites.stream()
                     .map(site -> new SiteDto(
                             site.getId(),
-                            site.getDomain(),
+                            site.getSiteName(),
                             site.getDisplayName()))
                     .toList();
 

--- a/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteDto.java
+++ b/src/main/java/com/bitbi/dfm/plugin/presentation/dto/SiteDto.java
@@ -8,7 +8,7 @@ import java.util.UUID;
  * DTO representing a site in the Plugin API response.
  *
  * @param id Unique site identifier
- * @param domain Site domain name
+ * @param siteName Site name
  * @param displayName Human-readable site name
  */
 @Schema(description = "Site information")
@@ -16,8 +16,8 @@ public record SiteDto(
     @Schema(description = "Unique site identifier", example = "550e8400-e29b-41d4-a716-446655440000")
     UUID id,
 
-    @Schema(description = "Site domain name", example = "example.com")
-    String domain,
+    @Schema(description = "Site name", example = "example.com")
+    String siteName,
 
     @Schema(description = "Human-readable site name", example = "Example Site")
     String displayName
@@ -25,7 +25,7 @@ public record SiteDto(
     /**
      * Creates a SiteDto from individual values.
      */
-    public static SiteDto of(UUID id, String domain, String displayName) {
-        return new SiteDto(id, domain, displayName);
+    public static SiteDto of(UUID id, String siteName, String displayName) {
+        return new SiteDto(id, siteName, displayName);
     }
 }

--- a/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
+++ b/src/main/java/com/bitbi/dfm/shared/api/ApiRoutes.java
@@ -47,6 +47,16 @@ public final class ApiRoutes {
      */
     public static final String DEVICE_AUTH_TOKEN = DEVICE_AUTH + "/token";
 
+    /**
+     * Device token refresh endpoint (Auth V2).
+     * <p>
+     * POST /api/v1/device/auth/refresh<br>
+     * Authentication: None (refresh token is the credential)<br>
+     * Returns: New JWT access token + rotated refresh token
+     * </p>
+     */
+    public static final String DEVICE_AUTH_REFRESH = DEVICE_AUTH + "/refresh";
+
     // Device Batches
     /**
      * Base path for device batch management endpoints.

--- a/src/main/java/com/bitbi/dfm/shared/auth/AuthorizationHelper.java
+++ b/src/main/java/com/bitbi/dfm/shared/auth/AuthorizationHelper.java
@@ -195,27 +195,6 @@ public class AuthorizationHelper {
     }
 
     /**
-     * Get the authenticated domain from security context.
-     *
-     * @return domain from JWT token
-     * @throws UnauthorizedException if not authenticated or not a JWT token
-     */
-    public String getAuthenticatedDomain() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new UnauthorizedException("Not authenticated");
-        }
-
-        if (!(authentication instanceof JwtAuthenticationToken)) {
-            throw new UnauthorizedException("Invalid authentication type");
-        }
-
-        JwtAuthenticationToken jwtAuth = (JwtAuthenticationToken) authentication;
-        return jwtAuth.getDomain();
-    }
-
-    /**
      * Verify that the authenticated site matches the expected site ID.
      *
      * @param expectedSiteId expected site ID

--- a/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
+++ b/src/main/java/com/bitbi/dfm/shared/config/SecurityConfiguration.java
@@ -147,7 +147,8 @@ public class SecurityConfiguration {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/v1/device/auth/token").permitAll() // Public token endpoint with Basic Auth
+                .requestMatchers("/api/v1/device/auth/token").permitAll() // Public token endpoint with Basic Auth (deprecated)
+                .requestMatchers("/api/v1/device/auth/refresh").permitAll() // Auth V2: refresh token endpoint
                 .requestMatchers(HttpMethod.POST, "/api/v1/device/authorize").permitAll() // Device Authorization Flow - initiate
                 .requestMatchers(HttpMethod.POST, "/api/v1/device/token").permitAll() // Device Authorization Flow - poll
                 .anyRequest().authenticated()

--- a/src/main/java/com/bitbi/dfm/site/application/SiteService.java
+++ b/src/main/java/com/bitbi/dfm/site/application/SiteService.java
@@ -67,26 +67,24 @@ public class SiteService {
      * @return SiteCreationResult with site and plaintext clientSecret (only shown once)
      * @throws SiteAlreadyExistsException if domain already exists
      */
-    public SiteCreationResult createSite(UUID accountId, String domain, String displayName) {
-        logger.info("Creating new site: accountId={}, domain={}, displayName={}", accountId, domain, displayName);
+    public SiteCreationResult createSite(UUID accountId, String siteName, String displayName) {
+        logger.info("Creating new site: accountId={}, siteName={}, displayName={}", accountId, siteName, displayName);
 
-        // Create composite domain: accountId_domain (FR-019)
-        String compositeDomain = accountId.toString() + "_" + domain.toLowerCase().trim();
+        String cleanSiteName = siteName.toLowerCase().trim();
 
-        if (siteRepository.findByDomain(compositeDomain).isPresent()) {
-            throw new SiteAlreadyExistsException("Site with domain already exists: " + domain);
+        // Check uniqueness by (accountId, siteName)
+        if (siteRepository.findByAccountIdAndSiteName(accountId, cleanSiteName).isPresent()) {
+            throw new SiteAlreadyExistsException("Site with name already exists: " + siteName);
         }
 
-        // Generate plaintext secret and bcrypt hash
-        String[] secretPair = SiteCredentials.generateWithHash(compositeDomain);
-        String plaintextSecret = secretPair[0];
-        String hashedSecret = secretPair[1];
+        // Create composite domain for backward compatibility
+        String compositeDomain = accountId.toString() + "_" + cleanSiteName;
 
-        Site site = Site.create(accountId, compositeDomain, displayName, hashedSecret);
+        Site site = Site.create(accountId, compositeDomain, cleanSiteName, displayName, null);
         Site saved = siteRepository.save(site);
 
-        logger.info("Site created successfully: id={}, compositeDomain={}", saved.getId(), saved.getDomain());
-        return new SiteCreationResult(saved, plaintextSecret);
+        logger.info("Site created successfully: id={}, siteName={}", saved.getId(), saved.getSiteName());
+        return new SiteCreationResult(saved, null);
     }
 
     /**
@@ -100,31 +98,33 @@ public class SiteService {
      * @throws SiteAlreadyExistsException if domain already exists
      * @throws IllegalArgumentException if password is invalid
      */
-    public SiteCreationResult createSite(UUID accountId, String domain, String displayName, String password) {
-        logger.info("Creating new site with custom password: accountId={}, domain={}, displayName={}",
-                    accountId, domain, displayName);
+    public SiteCreationResult createSite(UUID accountId, String siteName, String displayName, String password) {
+        logger.info("Creating new site with custom password: accountId={}, siteName={}, displayName={}",
+                    accountId, siteName, displayName);
 
         if (password == null || password.length() < 8) {
             throw new IllegalArgumentException("Password must be at least 8 characters");
         }
 
-        // Create composite domain: accountId_domain (FR-019)
-        String compositeDomain = accountId.toString() + "_" + domain.toLowerCase().trim();
+        String cleanSiteName = siteName.toLowerCase().trim();
 
-        if (siteRepository.findByDomain(compositeDomain).isPresent()) {
-            throw new SiteAlreadyExistsException("Site with domain already exists: " + domain);
+        if (siteRepository.findByAccountIdAndSiteName(accountId, cleanSiteName).isPresent()) {
+            throw new SiteAlreadyExistsException("Site with name already exists: " + siteName);
         }
 
         // Hash the provided password
         String[] secretPair = SiteCredentials.hashPassword(password);
         String hashedSecret = secretPair[1];
 
-        Site site = Site.create(accountId, compositeDomain, displayName, hashedSecret);
+        // Create composite domain for backward compatibility
+        String compositeDomain = accountId.toString() + "_" + cleanSiteName;
+
+        Site site = Site.create(accountId, compositeDomain, cleanSiteName, displayName, hashedSecret);
         Site saved = siteRepository.save(site);
 
-        logger.info("Site created successfully with custom password: id={}, compositeDomain={}",
-                    saved.getId(), saved.getDomain());
-        return new SiteCreationResult(saved, password); // Return original password
+        logger.info("Site created successfully with custom password: id={}, siteName={}",
+                    saved.getId(), saved.getSiteName());
+        return new SiteCreationResult(saved, password);
     }
 
     /**
@@ -149,13 +149,20 @@ public class SiteService {
      * @param displayName site display name
      * @return SiteCreationResult with site and new plaintext clientSecret
      */
-    public SiteCreationResult getOrCreateSiteWithNewCredentials(UUID accountId, String domain, String displayName) {
-        logger.info("GetOrCreate site with new credentials: accountId={}, domain={}", accountId, domain);
+    /**
+     * Get existing site or create new one (Auth V2 - no credential generation).
+     * <p>
+     * Used by Device Flow when user approves authorization:
+     * - If site exists: Reactivate if needed, return existing site
+     * - If site doesn't exist: Create new site
+     * </p>
+     */
+    public SiteCreationResult getOrCreateSite(UUID accountId, String siteName, String displayName) {
+        logger.info("GetOrCreate site: accountId={}, siteName={}", accountId, siteName);
 
-        // Create composite domain: accountId_domain (FR-019)
-        String compositeDomain = accountId.toString() + "_" + domain.toLowerCase().trim();
+        String cleanSiteName = siteName.toLowerCase().trim();
 
-        java.util.Optional<Site> existingSite = siteRepository.findByDomain(compositeDomain);
+        java.util.Optional<Site> existingSite = siteRepository.findByAccountIdAndSiteName(accountId, cleanSiteName);
 
         if (existingSite.isPresent()) {
             Site site = existingSite.get();
@@ -166,21 +173,22 @@ public class SiteService {
                 logger.info("Reactivated deactivated site: siteId={}", site.getId());
             }
 
-            // Generate new credentials
-            String[] secretPair = SiteCredentials.generateWithHash(compositeDomain);
-            String plaintextSecret = secretPair[0];
-            String hashedSecret = secretPair[1];
-
-            site.updateClientSecretHash(hashedSecret);
             Site saved = siteRepository.save(site);
 
-            logger.info("Regenerated credentials for existing site: siteId={}, domain={}",
-                        saved.getId(), saved.getDomain());
-            return new SiteCreationResult(saved, plaintextSecret);
+            logger.info("Found existing site: siteId={}, siteName={}", saved.getId(), saved.getSiteName());
+            return new SiteCreationResult(saved, null);
         }
 
         // Site doesn't exist - create new one
-        return createSite(accountId, domain, displayName);
+        return createSite(accountId, siteName, displayName);
+    }
+
+    /**
+     * @deprecated Use {@link #getOrCreateSite(UUID, String, String)} instead
+     */
+    @Deprecated
+    public SiteCreationResult getOrCreateSiteWithNewCredentials(UUID accountId, String domain, String displayName) {
+        return getOrCreateSite(accountId, domain, displayName);
     }
 
     /**
@@ -415,7 +423,7 @@ public class SiteService {
         logger.info("Deleting site record: id={}", siteId);
         siteRepository.deleteById(siteId);
 
-        logger.warn("Site and all associated data permanently deleted: id={}, domain={}", siteId, site.getDomain());
+        logger.warn("Site and all associated data permanently deleted: id={}, siteName={}", siteId, site.getSiteName());
     }
 
     /**

--- a/src/main/java/com/bitbi/dfm/site/application/SiteService.java
+++ b/src/main/java/com/bitbi/dfm/site/application/SiteService.java
@@ -1,5 +1,6 @@
 package com.bitbi.dfm.site.application;
 
+import com.bitbi.dfm.auth.application.RefreshTokenService;
 import com.bitbi.dfm.batch.domain.Batch;
 import com.bitbi.dfm.batch.domain.BatchRepository;
 import com.bitbi.dfm.deviceauth.domain.DeviceAuthorizationRepository;
@@ -43,19 +44,22 @@ public class SiteService {
     private final UploadedFileRepository uploadedFileRepository;
     private final S3FileStorageService s3FileStorageService;
     private final DeviceAuthorizationRepository deviceAuthorizationRepository;
+    private final RefreshTokenService refreshTokenService;
 
     public SiteService(SiteRepository siteRepository,
                        BatchRepository batchRepository,
                        ErrorLogRepository errorLogRepository,
                        UploadedFileRepository uploadedFileRepository,
                        S3FileStorageService s3FileStorageService,
-                       DeviceAuthorizationRepository deviceAuthorizationRepository) {
+                       DeviceAuthorizationRepository deviceAuthorizationRepository,
+                       RefreshTokenService refreshTokenService) {
         this.siteRepository = siteRepository;
         this.batchRepository = batchRepository;
         this.errorLogRepository = errorLogRepository;
         this.uploadedFileRepository = uploadedFileRepository;
         this.s3FileStorageService = s3FileStorageService;
         this.deviceAuthorizationRepository = deviceAuthorizationRepository;
+        this.refreshTokenService = refreshTokenService;
     }
 
     /**
@@ -317,6 +321,9 @@ public class SiteService {
 
         site.deactivate();
         siteRepository.save(site);
+
+        // Revoke all refresh tokens for this site (Auth V2)
+        refreshTokenService.revokeAllForSite(siteId);
 
         logger.info("Site deactivated successfully: id={}", siteId);
     }

--- a/src/main/java/com/bitbi/dfm/site/domain/Site.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/Site.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.time.LocalDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -103,10 +105,13 @@ public class Site {
             throw new IllegalArgumentException("DisplayName cannot be blank");
         }
 
+        // Normalize and validate site name
+        String normalizedSiteName = validateAndNormalizeSiteName(siteName);
+
         UUID id = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
-        return new Site(id, accountId, domain.toLowerCase().trim(), siteName.trim(), clientSecretHash,
+        return new Site(id, accountId, domain.toLowerCase().trim(), normalizedSiteName, clientSecretHash,
                 displayName.trim(), true, DEFAULT_RETENTION_DAYS, now, now);
     }
 
@@ -140,6 +145,36 @@ public class Site {
             siteName = domain.substring(COMPOSITE_DOMAIN_PREFIX_LENGTH);
         }
         return create(accountId, domain, siteName, displayName, hashedSecret);
+    }
+
+    /**
+     * Validate and normalize a site name.
+     * <ul>
+     *   <li>Applies Unicode NFC normalization</li>
+     *   <li>Rejects null bytes and path traversal sequences</li>
+     *   <li>Validates UTF-8 byte length fits VARCHAR(255)</li>
+     * </ul>
+     */
+    private static String validateAndNormalizeSiteName(String siteName) {
+        // NFC normalization (é vs e + combining accent → canonical form)
+        String normalized = Normalizer.normalize(siteName.trim(), Normalizer.Form.NFC);
+
+        // Reject null bytes
+        if (normalized.indexOf('\0') >= 0) {
+            throw new IllegalArgumentException("Site name must not contain null bytes");
+        }
+
+        // Reject path traversal
+        if (normalized.contains("..") || normalized.contains("/") || normalized.contains("\\")) {
+            throw new IllegalArgumentException("Site name must not contain path traversal characters");
+        }
+
+        // Validate UTF-8 byte length (VARCHAR(255) = 255 bytes)
+        if (normalized.getBytes(StandardCharsets.UTF_8).length > 255) {
+            throw new IllegalArgumentException("Site name exceeds 255 bytes");
+        }
+
+        return normalized;
     }
 
     public void updateDisplayName(String newDisplayName) {

--- a/src/main/java/com/bitbi/dfm/site/domain/Site.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/Site.java
@@ -217,6 +217,9 @@ public class Site {
     }
 
     public boolean verifySecret(String providedSecret) {
+        if (clientSecretHash == null) {
+            return false; // Auth V2 sites have no client secret
+        }
         return new SiteCredentials(domain, clientSecretHash).verifySecret(providedSecret);
     }
 

--- a/src/main/java/com/bitbi/dfm/site/domain/Site.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/Site.java
@@ -41,7 +41,10 @@ public class Site {
     @Column(name = "domain", nullable = false, unique = true, length = 255)
     private String domain;
 
-    @Column(name = "client_secret_hash", nullable = false, length = 60)
+    @Column(name = "site_name", nullable = false, length = 255)
+    private String siteName;
+
+    @Column(name = "client_secret_hash", length = 60)
     private String clientSecretHash;
 
     @Column(name = "display_name", nullable = false, length = 255)
@@ -59,12 +62,13 @@ public class Site {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
-    protected Site(UUID id, UUID accountId, String domain, String clientSecretHash,
+    protected Site(UUID id, UUID accountId, String domain, String siteName, String clientSecretHash,
                    String displayName, Boolean isActive, Integer retentionDays,
                    LocalDateTime createdAt, LocalDateTime updatedAt) {
         this.id = id;
         this.accountId = accountId;
         this.domain = domain;
+        this.siteName = siteName;
         this.clientSecretHash = clientSecretHash;
         this.displayName = displayName;
         this.isActive = isActive;
@@ -73,27 +77,50 @@ public class Site {
         this.updatedAt = updatedAt;
     }
 
-    public static Site create(UUID accountId, String domain, String displayName, String clientSecretHash) {
+    /**
+     * Create a new site with composite domain (legacy) and siteName.
+     *
+     * @param accountId        account identifier
+     * @param domain           composite domain (accountId_siteName)
+     * @param siteName         clean site name (Unicode allowed)
+     * @param displayName      human-readable display name
+     * @param clientSecretHash bcrypt-hashed client secret (nullable for Auth V2)
+     * @return new Site entity
+     */
+    public static Site create(UUID accountId, String domain, String siteName, String displayName, String clientSecretHash) {
         Objects.requireNonNull(accountId, "AccountId cannot be null");
         Objects.requireNonNull(domain, "Domain cannot be null");
+        Objects.requireNonNull(siteName, "SiteName cannot be null");
         Objects.requireNonNull(displayName, "DisplayName cannot be null");
-        Objects.requireNonNull(clientSecretHash, "ClientSecretHash cannot be null");
 
         if (domain.isBlank()) {
             throw new IllegalArgumentException("Domain cannot be blank");
         }
+        if (siteName.isBlank()) {
+            throw new IllegalArgumentException("SiteName cannot be blank");
+        }
         if (displayName.isBlank()) {
             throw new IllegalArgumentException("DisplayName cannot be blank");
-        }
-        if (clientSecretHash.isBlank()) {
-            throw new IllegalArgumentException("ClientSecretHash cannot be blank");
         }
 
         UUID id = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
-        return new Site(id, accountId, domain.toLowerCase().trim(), clientSecretHash,
+        return new Site(id, accountId, domain.toLowerCase().trim(), siteName.trim(), clientSecretHash,
                 displayName.trim(), true, DEFAULT_RETENTION_DAYS, now, now);
+    }
+
+    /**
+     * @deprecated Use {@link #create(UUID, String, String, String, String)} instead.
+     */
+    @Deprecated
+    public static Site create(UUID accountId, String domain, String displayName, String clientSecretHash) {
+        // Extract siteName from composite domain for backward compatibility
+        String siteName = domain;
+        if (domain.length() > COMPOSITE_DOMAIN_PREFIX_LENGTH) {
+            siteName = domain.substring(COMPOSITE_DOMAIN_PREFIX_LENGTH);
+        }
+        return create(accountId, domain, siteName, displayName, clientSecretHash);
     }
 
     /**
@@ -108,7 +135,11 @@ public class Site {
     public static Site createForTesting(UUID accountId, String domain, String displayName) {
         String[] secretPair = SiteCredentials.generateWithHash(domain);
         String hashedSecret = secretPair[1]; // Use only hash, discard plaintext
-        return create(accountId, domain, displayName, hashedSecret);
+        String siteName = domain;
+        if (domain.length() > COMPOSITE_DOMAIN_PREFIX_LENGTH) {
+            siteName = domain.substring(COMPOSITE_DOMAIN_PREFIX_LENGTH);
+        }
+        return create(accountId, domain, siteName, displayName, hashedSecret);
     }
 
     public void updateDisplayName(String newDisplayName) {
@@ -167,10 +198,16 @@ public class Site {
      * Domain is stored as "uuid_domain" per FR-019.
      *
      * @return display domain without accountId prefix
+     * @deprecated Use {@link #getSiteName()} instead
      */
+    @Deprecated
     public String getDisplayDomain() {
+        if (siteName != null) {
+            return siteName;
+        }
+        // Fallback for legacy data
         if (domain == null || domain.length() <= COMPOSITE_DOMAIN_PREFIX_LENGTH) {
-            return domain; // Fallback for invalid format
+            return domain;
         }
         return domain.substring(COMPOSITE_DOMAIN_PREFIX_LENGTH);
     }

--- a/src/main/java/com/bitbi/dfm/site/domain/SiteRepository.java
+++ b/src/main/java/com/bitbi/dfm/site/domain/SiteRepository.java
@@ -21,6 +21,8 @@ public interface SiteRepository {
 
     Optional<Site> findByDomain(String domain);
 
+    Optional<Site> findByAccountIdAndSiteName(UUID accountId, String siteName);
+
     List<Site> findByAccountId(UUID accountId);
 
     List<Site> findActiveByAccountId(UUID accountId);

--- a/src/main/java/com/bitbi/dfm/site/infrastructure/JpaSiteRepository.java
+++ b/src/main/java/com/bitbi/dfm/site/infrastructure/JpaSiteRepository.java
@@ -33,6 +33,16 @@ public interface JpaSiteRepository extends JpaRepository<Site, UUID>, SiteReposi
     Optional<Site> findByDomain(String domain);
 
     /**
+     * Find site by account ID and site name (Auth V2 composite key).
+     *
+     * @param accountId account identifier
+     * @param siteName  clean site name
+     * @return site if found
+     */
+    @Query("SELECT s FROM Site s WHERE s.accountId = :accountId AND LOWER(s.siteName) = LOWER(:siteName)")
+    Optional<Site> findByAccountIdAndSiteName(UUID accountId, String siteName);
+
+    /**
      * Find all sites for given account.
      *
      * @param accountId account identifier

--- a/src/main/java/com/bitbi/dfm/site/presentation/SiteAdminController.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/SiteAdminController.java
@@ -106,10 +106,10 @@ public class SiteAdminController {
             Authentication authentication,
             HttpServletRequest httpRequest) {
 
-        logger.info("Creating site: accountId={}, domain={}, displayName={}", accountId, request.domain(), request.displayName());
+        logger.info("Creating site: accountId={}, siteName={}, displayName={}", accountId, request.siteName(), request.displayName());
 
         try {
-            SiteService.SiteCreationResult result = siteService.createSite(accountId, request.domain(), request.displayName());
+            SiteService.SiteCreationResult result = siteService.createSite(accountId, request.siteName(), request.displayName());
 
             // Log successful site creation
             logAdminAction(

--- a/src/main/java/com/bitbi/dfm/site/presentation/SiteUserController.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/SiteUserController.java
@@ -90,7 +90,7 @@ public class SiteUserController {
         try {
             // Get authenticated account ID from JWT
             UUID accountId = authorizationHelper.getAuthenticatedAccountId();
-            logger.info("Creating site for account: accountId={}, domain={}", accountId, request.domain());
+            logger.info("Creating site for account: accountId={}, siteName={}", accountId, request.siteName());
 
             // Use provided password or generate if null/empty
             String password = (request.password() == null || request.password().isBlank())
@@ -100,7 +100,7 @@ public class SiteUserController {
             // Create site with password
             SiteService.SiteCreationResult result = siteService.createSite(
                     accountId,
-                    request.domain(),
+                    request.siteName(),
                     request.displayName(),
                     password
             );
@@ -108,7 +108,7 @@ public class SiteUserController {
             // Build response with site and plaintext password
             UserSiteCreationResponseDto response = UserSiteCreationResponseDto.fromCreationResult(result);
 
-            logger.info("Site created successfully: siteId={}, domain={}", result.site().getId(), request.domain());
+            logger.info("Site created successfully: siteId={}, siteName={}", result.site().getId(), request.siteName());
             return ResponseEntity.status(HttpStatus.CREATED).body(response);
 
         } catch (AuthorizationHelper.UnauthorizedException e) {

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/CreateSiteRequestDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/CreateSiteRequestDto.java
@@ -2,35 +2,34 @@ package com.bitbi.dfm.site.presentation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 /**
  * Request DTO for creating a new site.
  * <p>
- * Replaces Map<String, Object> input for site creation endpoint.
  * Provides type safety and automatic validation via Jakarta Bean Validation.
- * Domain is case-insensitive (accepts uppercase but stored as lowercase).
+ * Site name is case-insensitive (accepts uppercase but stored as lowercase).
+ * Unicode characters are allowed in site names.
  * </p>
  *
- * @param domain      Site domain (unique within account, case-insensitive, 3-255 characters)
+ * @param siteName    Site name (unique within account, case-insensitive, 1-255 characters)
  * @param displayName Site display name (2-100 characters, required)
+ * @param password    Site password (optional, will be generated if not provided)
  * @author Data Forge Team
- * @version 1.0.0
+ * @version 2.0.0
  * @see com.bitbi.dfm.site.presentation.SiteAdminController
  */
 @Schema(description = "Request body for creating a new site")
 public record CreateSiteRequestDto(
 
         @Schema(
-                description = "Site domain (unique within account, case-insensitive)",
+                description = "Site name (unique within account, case-insensitive, unicode allowed)",
                 example = "example.com",
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotBlank(message = "Domain is required")
-        @Size(min = 3, max = 255, message = "Domain must be 3-255 characters")
-        @Pattern(regexp = "^[a-zA-Z0-9.-]+$", message = "Domain must contain only letters, numbers, dots, and hyphens")
-        String domain,
+        @NotBlank(message = "Site name is required")
+        @Size(min = 1, max = 255, message = "Site name must be 1-255 characters")
+        String siteName,
 
         @Schema(
                 description = "Site display name",
@@ -47,7 +46,6 @@ public record CreateSiteRequestDto(
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
         @Size(min = 8, message = "Password must be at least 8 characters if provided")
-        @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "Password must contain only letters and numbers")
         String password
 ) {
 }

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteCreationResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteCreationResponseDto.java
@@ -8,26 +8,24 @@ import java.time.ZoneOffset;
 import java.util.UUID;
 
 /**
- * Response DTO for site creation.
+ * Response DTO for site creation (Auth V2).
  * <p>
- * Includes the plaintext client secret and site identifier (FR-019).
- * Secret is ONLY shown at creation time and cannot be retrieved later.
+ * Auth V2: No clientSecret or siteIdentifier returned.
+ * Authentication is handled via Device Flow (JWT + refresh token).
  * </p>
  *
  * @param id             Site unique identifier
  * @param accountId      Parent account identifier
- * @param domain         Site domain (display format)
+ * @param siteName       Site name (unique within account)
  * @param name           Site display name
  * @param isActive       Whether site is active
  * @param retentionDays  Retention period in days for batch cleanup
  * @param createdAt      Site creation timestamp
- * @param clientSecret   Plaintext client secret (ONLY shown at creation)
- * @param siteIdentifier Full identifier for Basic Auth (accountId_domain)
  * @author Data Forge Team
- * @version 1.0.0
+ * @version 2.0.0
  * @see com.bitbi.dfm.site.presentation.SiteAdminController
  */
-@Schema(description = "Site creation response with client secret and auth identifier")
+@Schema(description = "Site creation response")
 public record SiteCreationResponseDto(
         @Schema(description = "Site unique identifier", example = "123e4567-e89b-12d3-a456-426614174000")
         UUID id,
@@ -35,8 +33,8 @@ public record SiteCreationResponseDto(
         @Schema(description = "Parent account identifier", example = "987fcdeb-51a2-43f7-9c3d-123456789abc")
         UUID accountId,
 
-        @Schema(description = "Site domain (display format)", example = "example.com")
-        String domain,
+        @Schema(description = "Site name (unique within account)", example = "example.com")
+        String siteName,
 
         @Schema(description = "Site display name", example = "Example Website")
         String name,
@@ -48,32 +46,23 @@ public record SiteCreationResponseDto(
         int retentionDays,
 
         @Schema(description = "Site creation timestamp (ISO-8601)", example = "2025-01-15T10:30:00Z")
-        Instant createdAt,
-
-        @Schema(description = "Plaintext client secret (only shown at creation)", example = "secret_abc123xyz")
-        String clientSecret,
-
-        @Schema(description = "Site identifier for Basic Auth (accountId_domain)",
-                example = "987fcdeb-51a2-43f7-9c3d-123456789abc_example.com")
-        String siteIdentifier
+        Instant createdAt
 ) {
     /**
      * Create DTO from SiteCreationResult.
      *
      * @param result Site creation result from service
-     * @return SiteCreationResponseDto with site identifier
+     * @return SiteCreationResponseDto
      */
     public static SiteCreationResponseDto fromCreationResult(SiteService.SiteCreationResult result) {
         return new SiteCreationResponseDto(
                 result.site().getId(),
                 result.site().getAccountId(),
-                result.site().getDisplayDomain(), // Display domain without accountId prefix
+                result.site().getSiteName(),
                 result.site().getDisplayName(),
                 result.site().getIsActive(),
                 result.site().getRetentionDays(),
-                result.site().getCreatedAt().toInstant(ZoneOffset.UTC),
-                result.plaintextSecret(),
-                result.site().getDomain() // Full composite domain for auth
+                result.site().getCreatedAt().toInstant(ZoneOffset.UTC)
         );
     }
 }

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDto.java
@@ -11,16 +11,10 @@ import java.util.UUID;
  *
  * Provides immutable representation of site data for API responses.
  * Excludes clientSecretHash for security.
- * Returns display domain without accountId prefix (FR-019).
- *
- * FR-001: Structured response objects
- * FR-002: Consistent field naming and types
- * FR-003: Complete information preservation (non-sensitive)
- * FR-019: Composite domain stored as accountId_domain, displayed as domain only
  *
  * @param id Unique site identifier
  * @param accountId Account this site belongs to
- * @param domain Site domain name (display format, without accountId prefix)
+ * @param siteName Site name (unique within account)
  * @param name Site display name
  * @param isActive Active status
  * @param retentionDays Retention period in days for batch cleanup
@@ -29,7 +23,7 @@ import java.util.UUID;
 public record SiteResponseDto(
     UUID id,
     UUID accountId,
-    String domain,
+    String siteName,
     String name,
     Boolean isActive,
     Integer retentionDays,
@@ -39,12 +33,6 @@ public record SiteResponseDto(
     /**
      * Convert Site domain entity to SiteResponseDto.
      *
-     * Maps all non-sensitive fields from entity to DTO, converting:
-     * - domain using getDisplayDomain() to strip accountId prefix
-     * - displayName to name
-     * - LocalDateTime timestamp to Instant (UTC)
-     * - Excludes clientSecretHash for security
-     *
      * @param site The domain entity to convert
      * @return SiteResponseDto with all fields mapped
      */
@@ -52,7 +40,7 @@ public record SiteResponseDto(
         return new SiteResponseDto(
             site.getId(),
             site.getAccountId(),
-            site.getDisplayDomain(), // Use display domain without accountId prefix
+            site.getSiteName(),
             site.getDisplayName(),
             site.getIsActive(),
             site.getRetentionDays(),

--- a/src/main/java/com/bitbi/dfm/site/presentation/dto/UserSiteCreationResponseDto.java
+++ b/src/main/java/com/bitbi/dfm/site/presentation/dto/UserSiteCreationResponseDto.java
@@ -4,43 +4,36 @@ import com.bitbi.dfm.site.application.SiteService;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * Response DTO for user site creation.
+ * Response DTO for user site creation (Auth V2).
  * <p>
- * Returns site details in a nested structure with the plaintext password
- * and site identifier for Basic Auth (FR-019).
- * This is specifically for user-facing endpoints where the password
- * is displayed only once at creation time.
+ * Returns site details with the plaintext password.
+ * Auth V2: No siteIdentifier (composite domain) returned.
+ * Authentication is handled via Device Flow (JWT + refresh token).
  * </p>
  *
- * @param site           Site details (domain is display format)
- * @param password       Plaintext password (ONLY shown at creation)
- * @param siteIdentifier Full identifier for Basic Auth (accountId_domain)
+ * @param site     Site details
+ * @param password Plaintext password (ONLY shown at creation)
  * @author Data Forge Team
- * @version 1.0.0
+ * @version 2.0.0
  */
-@Schema(description = "User site creation response with site details, password, and auth identifier")
+@Schema(description = "User site creation response with site details and password")
 public record UserSiteCreationResponseDto(
         @Schema(description = "Created site details")
         SiteResponseDto site,
 
         @Schema(description = "Plaintext password (only shown at creation)", example = "Pass1234")
-        String password,
-
-        @Schema(description = "Site identifier for Basic Auth (accountId_domain)",
-                example = "a1b2c3d4-e5f6-7890-abcd-ef1234567890_example.com")
-        String siteIdentifier
+        String password
 ) {
     /**
      * Create DTO from SiteCreationResult.
      *
      * @param result Site creation result from service
-     * @return UserSiteCreationResponseDto with site identifier
+     * @return UserSiteCreationResponseDto
      */
     public static UserSiteCreationResponseDto fromCreationResult(SiteService.SiteCreationResult result) {
         return new UserSiteCreationResponseDto(
                 SiteResponseDto.fromEntity(result.site()),
-                result.plaintextSecret(),
-                result.site().getDomain() // Full composite domain for auth
+                result.plaintextSecret()
         );
     }
 }

--- a/src/main/resources/db/migration/V27__auth_v2_site_name_and_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V27__auth_v2_site_name_and_refresh_tokens.sql
@@ -10,6 +10,32 @@
 -- 4. Keeps existing domain and client_secret_hash for backward compatibility
 
 -- ============================================================
+-- 0. Pre-migration validation: verify all domains match expected composite format
+-- ============================================================
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM sites
+    WHERE domain IS NULL
+       OR domain = ''
+       OR length(domain) <= 37
+       OR domain !~ '^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}_'
+  ) THEN
+    RAISE EXCEPTION 'V27 pre-check failed: found domains that do not match composite format (UUID_siteName). Fix data before migrating.';
+  END IF;
+
+  -- Check for duplicate (account_id, site_name) that would violate the new unique constraint
+  IF EXISTS (
+    SELECT account_id, SUBSTRING(domain FROM 38) AS site_name
+    FROM sites
+    GROUP BY account_id, SUBSTRING(domain FROM 38)
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'V27 pre-check failed: duplicate (account_id, site_name) pairs detected. Resolve duplicates before migrating.';
+  END IF;
+END $$;
+
+-- ============================================================
 -- 1. Add site_name column to sites
 -- ============================================================
 ALTER TABLE sites ADD COLUMN site_name VARCHAR(255);
@@ -45,6 +71,7 @@ CREATE TABLE refresh_tokens (
 CREATE INDEX idx_refresh_tokens_site_id ON refresh_tokens(site_id);
 CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
 CREATE INDEX idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
+CREATE INDEX idx_refresh_tokens_cleanup ON refresh_tokens(expires_at, revoked_at);
 
 COMMENT ON TABLE refresh_tokens IS 'JWT refresh tokens for device authentication (Auth V2)';
 COMMENT ON COLUMN refresh_tokens.token_hash IS 'SHA-256 hash of the opaque refresh token';

--- a/src/main/resources/db/migration/V27__auth_v2_site_name_and_refresh_tokens.sql
+++ b/src/main/resources/db/migration/V27__auth_v2_site_name_and_refresh_tokens.sql
@@ -1,0 +1,57 @@
+-- Migration: V27__auth_v2_site_name_and_refresh_tokens.sql
+-- Description: Auth V2 - Add site_name to sites, create refresh_tokens table
+-- Author: Data Forge Team
+-- Date: 2026-02-10
+--
+-- This migration supports the Auth V2 changes:
+-- 1. Adds site_name column (extracted from composite domain)
+-- 2. Creates composite unique key (account_id, site_name)
+-- 3. Creates refresh_tokens table for JWT refresh token rotation
+-- 4. Keeps existing domain and client_secret_hash for backward compatibility
+
+-- ============================================================
+-- 1. Add site_name column to sites
+-- ============================================================
+ALTER TABLE sites ADD COLUMN site_name VARCHAR(255);
+
+-- 2. Populate site_name from composite domain (skip UUID prefix + underscore = 37 chars)
+UPDATE sites SET site_name = SUBSTRING(domain FROM 38);
+
+-- 3. Make site_name NOT NULL
+ALTER TABLE sites ALTER COLUMN site_name SET NOT NULL;
+
+-- 4. Create composite unique constraint (account_id, site_name)
+ALTER TABLE sites ADD CONSTRAINT uk_sites_account_site_name
+    UNIQUE (account_id, site_name);
+
+-- 5. Index for site_name lookups
+CREATE INDEX idx_sites_site_name ON sites(site_name);
+
+COMMENT ON COLUMN sites.site_name IS 'Clean site name without account prefix (Unicode allowed)';
+
+-- ============================================================
+-- 6. Create refresh_tokens table
+-- ============================================================
+CREATE TABLE refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    site_id UUID NOT NULL REFERENCES sites(id) ON DELETE CASCADE,
+    token_hash VARCHAR(64) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    revoked_at TIMESTAMP,
+    CONSTRAINT uk_refresh_tokens_hash UNIQUE (token_hash)
+);
+
+CREATE INDEX idx_refresh_tokens_site_id ON refresh_tokens(site_id);
+CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);
+CREATE INDEX idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
+
+COMMENT ON TABLE refresh_tokens IS 'JWT refresh tokens for device authentication (Auth V2)';
+COMMENT ON COLUMN refresh_tokens.token_hash IS 'SHA-256 hash of the opaque refresh token';
+COMMENT ON COLUMN refresh_tokens.expires_at IS 'Token expiration (90 days from creation)';
+COMMENT ON COLUMN refresh_tokens.revoked_at IS 'When token was revoked (NULL if active)';
+
+-- ============================================================
+-- 7. Make client_secret_hash nullable (no longer required for new sites)
+-- ============================================================
+ALTER TABLE sites ALTER COLUMN client_secret_hash DROP NOT NULL;

--- a/src/test/java/com/bitbi/dfm/auth/application/RefreshTokenServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/auth/application/RefreshTokenServiceTest.java
@@ -1,0 +1,353 @@
+package com.bitbi.dfm.auth.application;
+
+import com.bitbi.dfm.account.domain.Account;
+import com.bitbi.dfm.account.domain.AccountRepository;
+import com.bitbi.dfm.auth.domain.JwtToken;
+import com.bitbi.dfm.auth.domain.RefreshToken;
+import com.bitbi.dfm.auth.domain.RefreshTokenRepository;
+import com.bitbi.dfm.auth.infrastructure.JwtTokenProvider;
+import com.bitbi.dfm.site.domain.Site;
+import com.bitbi.dfm.site.domain.SiteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for RefreshTokenService.
+ * <p>
+ * Tests refresh token lifecycle: generation, rotation, revocation, cleanup.
+ * </p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefreshTokenService")
+class RefreshTokenServiceTest {
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private SiteRepository siteRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    private RefreshTokenService refreshTokenService;
+
+    private UUID siteId;
+    private UUID accountId;
+
+    @BeforeEach
+    void setUp() {
+        siteId = UUID.randomUUID();
+        accountId = UUID.randomUUID();
+        refreshTokenService = new RefreshTokenService(
+                refreshTokenRepository, siteRepository, accountRepository, jwtTokenProvider);
+    }
+
+    @Nested
+    @DisplayName("generateRefreshToken")
+    class GenerateRefreshToken {
+
+        @Test
+        @DisplayName("Should generate opaque token and store SHA-256 hash")
+        void shouldGenerateOpaqueTokenAndStoreHash() {
+            when(refreshTokenRepository.save(any(RefreshToken.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            String opaqueToken = refreshTokenService.generateRefreshToken(siteId);
+
+            assertThat(opaqueToken).isNotBlank();
+            // URL-safe Base64 encoded 32 bytes = 43 chars
+            assertThat(opaqueToken).hasSize(43);
+
+            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+            verify(refreshTokenRepository).save(captor.capture());
+
+            RefreshToken saved = captor.getValue();
+            assertThat(saved.getSiteId()).isEqualTo(siteId);
+            assertThat(saved.getTokenHash()).isNotBlank();
+            assertThat(saved.getTokenHash()).hasSize(64); // SHA-256 hex = 64 chars
+            assertThat(saved.isExpired()).isFalse();
+            assertThat(saved.isRevoked()).isFalse();
+        }
+
+        @Test
+        @DisplayName("Should generate unique tokens on successive calls")
+        void shouldGenerateUniqueTokens() {
+            when(refreshTokenRepository.save(any(RefreshToken.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            String token1 = refreshTokenService.generateRefreshToken(siteId);
+            String token2 = refreshTokenService.generateRefreshToken(siteId);
+
+            assertThat(token1).isNotEqualTo(token2);
+        }
+    }
+
+    @Nested
+    @DisplayName("refreshAccessToken")
+    class RefreshAccessToken {
+
+        @Test
+        @DisplayName("Should refresh token successfully with rotation")
+        void shouldRefreshTokenSuccessfully() {
+            String opaqueToken = "test-opaque-token";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            RefreshToken existingToken = RefreshToken.create(siteId, tokenHash);
+            Site mockSite = mock(Site.class);
+            Account mockAccount = mock(Account.class);
+            JwtToken mockJwt = mock(JwtToken.class);
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(existingToken));
+            when(siteRepository.findById(siteId)).thenReturn(Optional.of(mockSite));
+            when(mockSite.getIsActive()).thenReturn(true);
+            when(mockSite.getAccountId()).thenReturn(accountId);
+            when(accountRepository.findById(accountId)).thenReturn(Optional.of(mockAccount));
+            when(mockAccount.getIsActive()).thenReturn(true);
+            when(jwtTokenProvider.generateToken(siteId, accountId)).thenReturn(mockJwt);
+            when(refreshTokenRepository.save(any(RefreshToken.class)))
+                    .thenAnswer(inv -> inv.getArgument(0));
+
+            RefreshTokenService.RefreshResult result =
+                    refreshTokenService.refreshAccessToken(opaqueToken);
+
+            assertThat(result.accessToken()).isEqualTo(mockJwt);
+            assertThat(result.refreshToken()).isNotBlank();
+            assertThat(result.refreshTokenExpiresAt()).isAfter(Instant.now());
+
+            // Verify old token was revoked
+            assertThat(existingToken.isRevoked()).isTrue();
+
+            // Verify new token saved (revoked old + new)
+            verify(refreshTokenRepository, times(2)).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("Should throw InvalidRefreshTokenException for unknown token")
+        void shouldThrowForUnknownToken() {
+            String unknownToken = "unknown-token";
+            String tokenHash = RefreshTokenService.sha256(unknownToken);
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(unknownToken))
+                    .isInstanceOf(RefreshTokenService.InvalidRefreshTokenException.class)
+                    .hasMessageContaining("Invalid refresh token");
+        }
+
+        @Test
+        @DisplayName("Should throw RefreshTokenRevokedException for revoked token")
+        void shouldThrowForRevokedToken() {
+            String opaqueToken = "revoked-token";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            RefreshToken revokedToken = RefreshToken.create(siteId, tokenHash);
+            revokedToken.revoke();
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(revokedToken));
+
+            assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(opaqueToken))
+                    .isInstanceOf(RefreshTokenService.RefreshTokenRevokedException.class)
+                    .hasMessageContaining("revoked");
+        }
+
+        @Test
+        @DisplayName("Should throw RefreshTokenExpiredException for expired token")
+        void shouldThrowForExpiredToken() throws Exception {
+            String opaqueToken = "expired-token";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            // Create token then make it expired via reflection
+            RefreshToken expiredToken = RefreshToken.create(siteId, tokenHash);
+            java.lang.reflect.Field expiresAtField = RefreshToken.class.getDeclaredField("expiresAt");
+            expiresAtField.setAccessible(true);
+            expiresAtField.set(expiredToken, Instant.now().minus(1, ChronoUnit.DAYS));
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(expiredToken));
+
+            assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(opaqueToken))
+                    .isInstanceOf(RefreshTokenService.RefreshTokenExpiredException.class)
+                    .hasMessageContaining("expired");
+        }
+
+        @Test
+        @DisplayName("Should throw when site not found")
+        void shouldThrowWhenSiteNotFound() {
+            String opaqueToken = "orphan-token";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            RefreshToken token = RefreshToken.create(siteId, tokenHash);
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(token));
+            when(siteRepository.findById(siteId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(opaqueToken))
+                    .isInstanceOf(RefreshTokenService.InvalidRefreshTokenException.class)
+                    .hasMessageContaining("Site not found");
+        }
+
+        @Test
+        @DisplayName("Should throw when site is inactive")
+        void shouldThrowWhenSiteInactive() {
+            String opaqueToken = "inactive-site-token";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            RefreshToken token = RefreshToken.create(siteId, tokenHash);
+            Site mockSite = mock(Site.class);
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(token));
+            when(siteRepository.findById(siteId)).thenReturn(Optional.of(mockSite));
+            when(mockSite.getIsActive()).thenReturn(false);
+
+            assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(opaqueToken))
+                    .isInstanceOf(RefreshTokenService.InvalidRefreshTokenException.class)
+                    .hasMessageContaining("not active");
+        }
+
+        @Test
+        @DisplayName("Should throw when account is inactive")
+        void shouldThrowWhenAccountInactive() {
+            String opaqueToken = "inactive-account-token";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            RefreshToken token = RefreshToken.create(siteId, tokenHash);
+            Site mockSite = mock(Site.class);
+            Account mockAccount = mock(Account.class);
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(token));
+            when(siteRepository.findById(siteId)).thenReturn(Optional.of(mockSite));
+            when(mockSite.getIsActive()).thenReturn(true);
+            when(mockSite.getAccountId()).thenReturn(accountId);
+            when(accountRepository.findById(accountId)).thenReturn(Optional.of(mockAccount));
+            when(mockAccount.getIsActive()).thenReturn(false);
+
+            assertThatThrownBy(() -> refreshTokenService.refreshAccessToken(opaqueToken))
+                    .isInstanceOf(RefreshTokenService.InvalidRefreshTokenException.class)
+                    .hasMessageContaining("Account is not active");
+        }
+    }
+
+    @Nested
+    @DisplayName("revokeRefreshToken")
+    class RevokeRefreshToken {
+
+        @Test
+        @DisplayName("Should revoke existing token")
+        void shouldRevokeExistingToken() {
+            String opaqueToken = "to-revoke";
+            String tokenHash = RefreshTokenService.sha256(opaqueToken);
+
+            RefreshToken token = RefreshToken.create(siteId, tokenHash);
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.of(token));
+
+            refreshTokenService.revokeRefreshToken(opaqueToken);
+
+            assertThat(token.isRevoked()).isTrue();
+            verify(refreshTokenRepository).save(token);
+        }
+
+        @Test
+        @DisplayName("Should silently ignore unknown token")
+        void shouldIgnoreUnknownToken() {
+            String unknownToken = "unknown";
+            String tokenHash = RefreshTokenService.sha256(unknownToken);
+
+            when(refreshTokenRepository.findByTokenHash(tokenHash))
+                    .thenReturn(Optional.empty());
+
+            refreshTokenService.revokeRefreshToken(unknownToken);
+
+            verify(refreshTokenRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("revokeAllForSite")
+    class RevokeAllForSite {
+
+        @Test
+        @DisplayName("Should delegate to repository")
+        void shouldDelegateToRepository() {
+            when(refreshTokenRepository.revokeAllBySiteId(siteId)).thenReturn(3);
+
+            refreshTokenService.revokeAllForSite(siteId);
+
+            verify(refreshTokenRepository).revokeAllBySiteId(siteId);
+        }
+    }
+
+    @Nested
+    @DisplayName("cleanupExpiredTokens")
+    class CleanupExpiredTokens {
+
+        @Test
+        @DisplayName("Should delete tokens older than 7 days past expiration")
+        void shouldDeleteOldTokens() {
+            when(refreshTokenRepository.deleteExpiredBefore(any(Instant.class))).thenReturn(5);
+
+            refreshTokenService.cleanupExpiredTokens();
+
+            ArgumentCaptor<Instant> captor = ArgumentCaptor.forClass(Instant.class);
+            verify(refreshTokenRepository).deleteExpiredBefore(captor.capture());
+
+            Instant cutoff = captor.getValue();
+            // Cutoff should be ~7 days ago
+            assertThat(cutoff).isBetween(
+                    Instant.now().minus(7, ChronoUnit.DAYS).minus(1, ChronoUnit.MINUTES),
+                    Instant.now().minus(7, ChronoUnit.DAYS).plus(1, ChronoUnit.MINUTES)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("sha256")
+    class Sha256 {
+
+        @Test
+        @DisplayName("Should produce consistent 64-char hex hash")
+        void shouldProduceConsistentHash() {
+            String hash1 = RefreshTokenService.sha256("test-input");
+            String hash2 = RefreshTokenService.sha256("test-input");
+
+            assertThat(hash1).isEqualTo(hash2);
+            assertThat(hash1).hasSize(64);
+            assertThat(hash1).matches("[0-9a-f]{64}");
+        }
+
+        @Test
+        @DisplayName("Should produce different hashes for different inputs")
+        void shouldProduceDifferentHashes() {
+            String hash1 = RefreshTokenService.sha256("input-1");
+            String hash2 = RefreshTokenService.sha256("input-2");
+
+            assertThat(hash1).isNotEqualTo(hash2);
+        }
+    }
+}

--- a/src/test/java/com/bitbi/dfm/auth/domain/JwtTokenTest.java
+++ b/src/test/java/com/bitbi/dfm/auth/domain/JwtTokenTest.java
@@ -185,16 +185,19 @@ class JwtTokenTest {
     }
 
     @Test
-    @DisplayName("Should throw exception when domain is null")
-    void shouldThrowExceptionWhenDomainIsNull() {
-        // Given
+    @DisplayName("Should accept null domain (Auth V2)")
+    void shouldAcceptNullDomain() {
+        // Given - Auth V2 tokens do not have domain
         Instant now = Instant.now();
         Instant expires = now.plus(3600, ChronoUnit.SECONDS);
 
-        // When & Then
-        assertThrows(NullPointerException.class, () ->
-                new JwtToken(TEST_TOKEN, now, expires, TEST_SITE_ID, TEST_ACCOUNT_ID, null)
-        );
+        // When
+        JwtToken token = new JwtToken(TEST_TOKEN, now, expires, TEST_SITE_ID, TEST_ACCOUNT_ID, null);
+
+        // Then
+        assertNull(token.domain());
+        assertEquals(TEST_SITE_ID, token.siteId());
+        assertEquals(TEST_ACCOUNT_ID, token.accountId());
     }
 
     @Test

--- a/src/test/java/com/bitbi/dfm/auth/infrastructure/JwtTokenProviderTest.java
+++ b/src/test/java/com/bitbi/dfm/auth/infrastructure/JwtTokenProviderTest.java
@@ -38,14 +38,14 @@ class JwtTokenProviderTest {
     @DisplayName("Should generate valid JWT token with correct claims")
     void shouldGenerateValidJwtTokenWithCorrectClaims() {
         // When
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // Then
         assertNotNull(token);
         assertNotNull(token.token());
         assertEquals(testSiteId, token.siteId());
         assertEquals(testAccountId, token.accountId());
-        assertEquals(testDomain, token.domain());
+        assertNull(token.domain()); // Auth V2: domain is not included
         assertEquals(TEST_EXPIRATION, token.getExpirationDuration());
     }
 
@@ -53,7 +53,7 @@ class JwtTokenProviderTest {
     @DisplayName("Should validate token and extract claims")
     void shouldValidateTokenAndExtractClaims() {
         // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // When
         Claims claims = jwtTokenProvider.validateToken(token.token());
@@ -63,14 +63,14 @@ class JwtTokenProviderTest {
         assertEquals(testSiteId.toString(), claims.getSubject());
         assertEquals(testSiteId.toString(), claims.get("siteId", String.class));
         assertEquals(testAccountId.toString(), claims.get("accountId", String.class));
-        assertEquals(testDomain, claims.get("domain", String.class));
+        assertNull(claims.get("domain", String.class)); // Auth V2: domain not in token
     }
 
     @Test
     @DisplayName("Should extract site ID from valid token")
     void shouldExtractSiteIdFromValidToken() {
         // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // When
         UUID extractedSiteId = jwtTokenProvider.extractSiteId(token.token());
@@ -83,7 +83,7 @@ class JwtTokenProviderTest {
     @DisplayName("Should extract account ID from valid token")
     void shouldExtractAccountIdFromValidToken() {
         // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // When
         UUID extractedAccountId = jwtTokenProvider.extractAccountId(token.token());
@@ -93,10 +93,10 @@ class JwtTokenProviderTest {
     }
 
     @Test
-    @DisplayName("Should extract domain from valid token")
-    void shouldExtractDomainFromValidToken() {
-        // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+    @DisplayName("Should extract domain from legacy token with domain")
+    void shouldExtractDomainFromLegacyToken() {
+        // Given - use deprecated method that includes domain in token
+        JwtToken token = jwtTokenProvider.generateTokenWithDomain(testSiteId, testAccountId, testDomain);
 
         // When
         String extractedDomain = jwtTokenProvider.extractDomain(token.token());
@@ -145,7 +145,7 @@ class JwtTokenProviderTest {
     @DisplayName("Should return false for non-expired token")
     void shouldReturnFalseForNonExpiredToken() {
         // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // When
         boolean isExpired = jwtTokenProvider.isExpired(token.token());
@@ -174,8 +174,8 @@ class JwtTokenProviderTest {
         UUID siteId2 = UUID.randomUUID();
 
         // When
-        JwtToken token1 = jwtTokenProvider.generateToken(siteId1, testAccountId, testDomain);
-        JwtToken token2 = jwtTokenProvider.generateToken(siteId2, testAccountId, testDomain);
+        JwtToken token1 = jwtTokenProvider.generateToken(siteId1, testAccountId);
+        JwtToken token2 = jwtTokenProvider.generateToken(siteId2, testAccountId);
 
         // Then
         assertNotEquals(token1.token(), token2.token());
@@ -185,7 +185,7 @@ class JwtTokenProviderTest {
     @DisplayName("Should include issued at timestamp in token")
     void shouldIncludeIssuedAtTimestampInToken() {
         // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // When
         Claims claims = jwtTokenProvider.validateToken(token.token());
@@ -198,7 +198,7 @@ class JwtTokenProviderTest {
     @DisplayName("Should include expiration timestamp in token")
     void shouldIncludeExpirationTimestampInToken() {
         // Given
-        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = jwtTokenProvider.generateToken(testSiteId, testAccountId);
 
         // When
         Claims claims = jwtTokenProvider.validateToken(token.token());
@@ -231,7 +231,7 @@ class JwtTokenProviderTest {
         JwtTokenProvider customProvider = new JwtTokenProvider(TEST_SECRET, customExpiration);
 
         // When
-        JwtToken token = customProvider.generateToken(testSiteId, testAccountId, testDomain);
+        JwtToken token = customProvider.generateToken(testSiteId, testAccountId);
 
         // Then
         assertEquals(customExpiration, token.getExpirationDuration());

--- a/src/test/java/com/bitbi/dfm/auth/presentation/dto/TokenResponseDtoTest.java
+++ b/src/test/java/com/bitbi/dfm/auth/presentation/dto/TokenResponseDtoTest.java
@@ -24,13 +24,11 @@ class TokenResponseDtoTest {
         UUID siteId = UUID.randomUUID();
         Instant expiresAt = Instant.now().plusSeconds(3600);
         String tokenString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...";
-        String domain = "example.com";
 
         JwtToken jwtToken = mock(JwtToken.class);
         when(jwtToken.token()).thenReturn(tokenString);
         when(jwtToken.expiresAt()).thenReturn(expiresAt);
         when(jwtToken.siteId()).thenReturn(siteId);
-        when(jwtToken.domain()).thenReturn(domain);
 
         // When
         TokenResponseDto dto = TokenResponseDto.fromToken(jwtToken);
@@ -40,6 +38,5 @@ class TokenResponseDtoTest {
         assertEquals(tokenString, dto.token());
         assertEquals(expiresAt, dto.expiresAt());
         assertEquals(siteId, dto.siteId());
-        assertEquals(domain, dto.domain());
     }
 }

--- a/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
+++ b/src/test/java/com/bitbi/dfm/config/TestSecurityConfig.java
@@ -233,6 +233,9 @@ public class TestSecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/v1/device/auth/token").permitAll() // Public token endpoint
+                .requestMatchers("/api/v1/device/auth/refresh").permitAll() // Auth V2: refresh token endpoint
+                .requestMatchers("/api/v1/device/authorize").permitAll() // Device authorization
+                .requestMatchers("/api/v1/device/token").permitAll() // Device token polling
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/test/java/com/bitbi/dfm/contract/AuthContractTest.java
+++ b/src/test/java/com/bitbi/dfm/contract/AuthContractTest.java
@@ -2,6 +2,7 @@ package com.bitbi.dfm.contract;
 
 import com.bitbi.dfm.integration.BaseIntegrationTest;
 import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @see <a href="specs/001-technical-specification-data/contracts/auth-api.md">Authentication API Contract</a>
  */
+@Disabled("Auth V2: Basic Auth endpoint removed. See auth-v2-migration-guide.md")
 @DisplayName("Authentication API Contract Tests")
 class AuthContractTest extends BaseIntegrationTest {
 
@@ -51,8 +53,7 @@ class AuthContractTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.token").exists())
                 .andExpect(jsonPath("$.token").isString())
                 .andExpect(jsonPath("$.expiresAt").exists())
-                .andExpect(jsonPath("$.siteId").exists())
-                .andExpect(jsonPath("$.domain").exists());
+                .andExpect(jsonPath("$.siteId").exists());
     }
 
     /**

--- a/src/test/java/com/bitbi/dfm/device/presentation/DeviceAuthContractTest.java
+++ b/src/test/java/com/bitbi/dfm/device/presentation/DeviceAuthContractTest.java
@@ -2,6 +2,7 @@ package com.bitbi.dfm.device.presentation;
 
 import com.bitbi.dfm.integration.BaseIntegrationTest;
 import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @see com.bitbi.dfm.device.presentation.DeviceAuthController
  * @see <a href="specs/010-api-unification-goal/tasks.md">Task T007</a>
  */
+@Disabled("Auth V2: Basic Auth endpoint removed. See auth-v2-migration-guide.md")
 @DisplayName("Device API - Authentication Contract Tests")
 class DeviceAuthContractTest extends BaseIntegrationTest {
 
@@ -63,9 +65,7 @@ class DeviceAuthContractTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.token").isString())
                 .andExpect(jsonPath("$.expiresAt").exists())
                 .andExpect(jsonPath("$.siteId").exists())
-                .andExpect(jsonPath("$.siteId").value("0199baac-f852-753f-6fc3-7c994fc38654"))
-                .andExpect(jsonPath("$.domain").exists())
-                .andExpect(jsonPath("$.domain").value("store-01.example.com"));
+                .andExpect(jsonPath("$.siteId").value("0199baac-f852-753f-6fc3-7c994fc38654"));
     }
 
     /**

--- a/src/test/java/com/bitbi/dfm/device/presentation/DeviceAuthRefreshContractTest.java
+++ b/src/test/java/com/bitbi/dfm/device/presentation/DeviceAuthRefreshContractTest.java
@@ -1,0 +1,142 @@
+package com.bitbi.dfm.device.presentation;
+
+import com.bitbi.dfm.auth.application.RefreshTokenService;
+import com.bitbi.dfm.integration.BaseIntegrationTest;
+import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Contract tests for POST /api/v1/device/auth/refresh (Auth V2).
+ * <p>
+ * Verifies the refresh token endpoint returns correct HTTP statuses
+ * and response structures for various scenarios.
+ * </p>
+ */
+@DisplayName("Device API - Token Refresh Contract Tests")
+class DeviceAuthRefreshContractTest extends BaseIntegrationTest {
+
+    /**
+     * Site ID for store-03 from test-data.sql (used in Device API tests).
+     */
+    private static final UUID STORE_03_SITE_ID =
+            UUID.fromString("0199bab0-ca3b-e41c-5521-2f4b33fda8b6");
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Test
+    @DisplayName("Should refresh token successfully and return new access + refresh tokens")
+    void shouldRefreshTokenSuccessfully() throws Exception {
+        // Given: A valid refresh token for an active site
+        String refreshToken = refreshTokenService.generateRefreshToken(STORE_03_SITE_ID);
+
+        String requestBody = """
+                {"refreshToken": "%s"}
+                """.formatted(refreshToken);
+
+        // When/Then: POST /api/v1/device/auth/refresh → 200 with new tokens
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").exists())
+                .andExpect(jsonPath("$.refreshToken").exists())
+                .andExpect(jsonPath("$.accessTokenExpiresAt").exists())
+                .andExpect(jsonPath("$.refreshTokenExpiresAt").exists());
+    }
+
+    @Test
+    @DisplayName("Should return 400 for invalid/unknown refresh token")
+    void shouldReturn400ForInvalidRefreshToken() throws Exception {
+        String requestBody = """
+                {"refreshToken": "completely-invalid-token"}
+                """;
+
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("invalid_refresh_token"));
+    }
+
+    @Test
+    @DisplayName("Should return 401 for revoked refresh token")
+    void shouldReturn401ForRevokedRefreshToken() throws Exception {
+        // Given: Generate and then revoke a token
+        String refreshToken = refreshTokenService.generateRefreshToken(STORE_03_SITE_ID);
+        refreshTokenService.revokeRefreshToken(refreshToken);
+
+        String requestBody = """
+                {"refreshToken": "%s"}
+                """.formatted(refreshToken);
+
+        // When/Then: 401 with refresh_token_revoked error
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("refresh_token_revoked"));
+    }
+
+    @Test
+    @DisplayName("Should return 400 for empty refresh token")
+    void shouldReturn400ForEmptyRefreshToken() throws Exception {
+        String requestBody = """
+                {"refreshToken": ""}
+                """;
+
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should rotate token - old token invalid after refresh")
+    void shouldRotateTokenOldTokenInvalidAfterRefresh() throws Exception {
+        // Given: A valid refresh token
+        String originalToken = refreshTokenService.generateRefreshToken(STORE_03_SITE_ID);
+
+        // When: Use it to refresh (consumes the token)
+        String requestBody = """
+                {"refreshToken": "%s"}
+                """.formatted(originalToken);
+
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+
+        // Then: Reusing the same token should fail (revoked after rotation)
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("refresh_token_revoked"));
+    }
+
+    @Test
+    @DisplayName("Should not require Bearer token (endpoint is public)")
+    void shouldNotRequireBearerToken() throws Exception {
+        // Given: A valid refresh token, no Authorization header
+        String refreshToken = refreshTokenService.generateRefreshToken(STORE_03_SITE_ID);
+
+        String requestBody = """
+                {"refreshToken": "%s"}
+                """.formatted(refreshToken);
+
+        // When/Then: Should succeed without Authorization header
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/bitbi/dfm/device/presentation/DeviceAuthRefreshContractTest.java
+++ b/src/test/java/com/bitbi/dfm/device/presentation/DeviceAuthRefreshContractTest.java
@@ -54,11 +54,27 @@ class DeviceAuthRefreshContractTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("Should return 400 for invalid/unknown refresh token")
-    void shouldReturn400ForInvalidRefreshToken() throws Exception {
+    @DisplayName("Should return 400 for malformed refresh token (wrong format)")
+    void shouldReturn400ForMalformedRefreshToken() throws Exception {
         String requestBody = """
                 {"refreshToken": "completely-invalid-token"}
                 """;
+
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Should return 400 for unknown but well-formed refresh token")
+    void shouldReturn400ForUnknownRefreshToken() throws Exception {
+        // A valid 43-char Base64url token that doesn't exist in the database
+        String fakeToken = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopq";
+
+        String requestBody = """
+                {"refreshToken": "%s"}
+                """.formatted(fakeToken);
 
         mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/bitbi/dfm/integration/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/AuthenticationIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.bitbi.dfm.integration;
 
 import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *
  * @see <a href="specs/001-technical-specification-data/quickstart.md">Quickstart Scenario 1</a>
  */
+@Disabled("Auth V2: Basic Auth endpoint removed. See auth-v2-migration-guide.md")
 @DisplayName("Scenario 1: Client Authentication Integration Test")
 class AuthenticationIntegrationTest extends BaseIntegrationTest {
 
@@ -46,8 +48,7 @@ class AuthenticationIntegrationTest extends BaseIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").exists())
                 .andExpect(jsonPath("$.expiresAt").exists())
-                .andExpect(jsonPath("$.siteId").exists())
-                .andExpect(jsonPath("$.domain").exists());
+                .andExpect(jsonPath("$.siteId").exists());
 
         // Verify: JWT token contains expected claims (siteId, accountId, domain)
         // Note: Full JWT validation will be done in domain layer tests

--- a/src/test/java/com/bitbi/dfm/integration/BatchRetentionIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/BatchRetentionIntegrationTest.java
@@ -58,14 +58,15 @@ class BatchRetentionIntegrationTest extends AbstractIntegrationTest {
         );
 
         jdbcTemplate.update(
-                "INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, retention_days, created_at, updated_at) VALUES (?,?,?,?,?,?,?,NOW(),NOW())",
+                "INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, retention_days, created_at, updated_at, site_name) VALUES (?,?,?,?,?,?,?,NOW(),NOW(),?)",
                 siteId,
                 accountId,
                 compositeDomain,
                 secretHash,
                 "Retention Site",
                 true,
-                45
+                45,
+                "example.com"
         );
 
         LocalDateTime oldStartedAt = LocalDateTime.now().minusDays(60);
@@ -173,14 +174,15 @@ class BatchRetentionIntegrationTest extends AbstractIntegrationTest {
         );
 
         jdbcTemplate.update(
-                "INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, retention_days, created_at, updated_at) VALUES (?,?,?,?,?,?,?,NOW(),NOW())",
+                "INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, retention_days, created_at, updated_at, site_name) VALUES (?,?,?,?,?,?,?,NOW(),NOW(),?)",
                 siteId,
                 accountId,
                 compositeDomain,
                 secretHash,
                 "Baseline Site",
                 true,
-                45
+                45,
+                "baseline.example.com"
         );
 
         LocalDateTime oldStartedAt = LocalDateTime.now().minusDays(60);

--- a/src/test/java/com/bitbi/dfm/integration/DeviceApiIntegrationTest.java
+++ b/src/test/java/com/bitbi/dfm/integration/DeviceApiIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.bitbi.dfm.integration;
 
+import com.bitbi.dfm.auth.domain.JwtToken;
 import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -45,23 +47,9 @@ class DeviceApiIntegrationTest extends BaseIntegrationTest {
     @Test
     @DisplayName("Should complete full device workflow: auth → start → upload → log error → complete")
     void shouldCompleteFullDeviceWorkflow() throws Exception {
-        // STEP 1: Generate JWT token via Device Auth endpoint
-        String credentials = Base64.getEncoder()
-                .encodeToString("store-03.example.com:batch-test-secret".getBytes());
-
-        MvcResult authResult = mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_TOKEN)
-                        .header("Authorization", "Basic " + credentials)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.token").exists())
-                .andExpect(jsonPath("$.siteId").exists())
-                .andExpect(jsonPath("$.domain").value("store-03.example.com"))
-                .andReturn();
-
-        // Extract JWT token from response
-        String tokenJson = authResult.getResponse().getContentAsString();
-        String jwtToken = com.jayway.jsonpath.JsonPath.read(tokenJson, "$.token");
-        String bearerToken = "Bearer " + jwtToken;
+        // STEP 1: Generate JWT token directly (Basic Auth endpoint removed in Auth V2)
+        JwtToken jwtTokenObj = tokenService.generateToken("store-03.example.com", "batch-test-secret");
+        String bearerToken = "Bearer " + jwtTokenObj.token();
 
         // STEP 2: Start new batch
         MvcResult batchResult = mockMvc.perform(post(ApiRoutes.DEVICE_BATCHES_START)
@@ -197,6 +185,7 @@ class DeviceApiIntegrationTest extends BaseIntegrationTest {
      * Tests that authentication endpoint properly validates credentials.
      * </p>
      */
+    @Disabled("Auth V2: Basic Auth endpoint removed")
     @Test
     @DisplayName("Should reject invalid credentials at Device Auth endpoint")
     void shouldRejectInvalidCredentialsAtDeviceAuthEndpoint() throws Exception {

--- a/src/test/java/com/bitbi/dfm/plugin/unit/SqlGenerationServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/plugin/unit/SqlGenerationServiceTest.java
@@ -295,7 +295,7 @@ class SqlGenerationServiceTest {
             when(sqlStatementGenerator.generate(any(), anyString(), any()))
                     .thenReturn("INSERT INTO good_data (id, name) VALUES ('1', 'Alice');\n");
 
-            when(s3SqlFileStorageService.storeSqlFile(any(), anyString(), anyString()))
+            when(s3SqlFileStorageService.storeSqlFile(any(), any(), anyString()))
                     .thenReturn("plugins/bit-bi/test.sql");
             when(s3SqlFileStorageService.getFileSize(anyString())).thenReturn(100L);
 
@@ -309,7 +309,7 @@ class SqlGenerationServiceTest {
             // Then - should succeed with the good file, skipping the bad one
             assertThat(result).isPresent();
             // The good file should still be processed
-            verify(s3SqlFileStorageService).storeSqlFile(any(), anyString(), anyString());
+            verify(s3SqlFileStorageService).storeSqlFile(any(), any(), anyString());
             // Verify the skipped file metric was incremented
             assertThat(realRegistry.counter("sql.generation.files.skipped.invalid_headers").count()).isEqualTo(1.0);
         }

--- a/src/test/java/com/bitbi/dfm/security/SecurityFilterChainTest.java
+++ b/src/test/java/com/bitbi/dfm/security/SecurityFilterChainTest.java
@@ -204,6 +204,23 @@ class SecurityFilterChainTest extends BaseIntegrationTest {
     }
 
     /**
+     * TC07b: Device auth refresh endpoint should be accessible without authentication.
+     * <p>
+     * <b>Given</b>: No Authorization header<br>
+     * <b>When</b>: POST /api/v1/device/auth/refresh with invalid body<br>
+     * <b>Then</b>: 400 Bad Request (not 401 — endpoint is public)
+     * </p>
+     */
+    @Test
+    @DisplayName("TC07b: Device auth refresh endpoint should be public (no auth required)")
+    void deviceAuthRefreshEndpointShouldBePublic() throws Exception {
+        mockMvc.perform(post(ApiRoutes.DEVICE_AUTH_REFRESH)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"refreshToken\": \"invalid-token\"}"))
+                .andExpect(status().isBadRequest()); // 400 not 401 → endpoint is reachable
+    }
+
+    /**
      * TC08: User History API with Auth0 user token → 200 OK (authorized)
      * <p>
      * <b>Given</b>: A valid Auth0 OAuth2 token (any authenticated user, not just admin)<br>

--- a/src/test/java/com/bitbi/dfm/security/SecurityFilterChainTest.java
+++ b/src/test/java/com/bitbi/dfm/security/SecurityFilterChainTest.java
@@ -2,6 +2,7 @@ package com.bitbi.dfm.security;
 
 import com.bitbi.dfm.integration.BaseIntegrationTest;
 import com.bitbi.dfm.shared.api.ApiRoutes;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -186,6 +187,7 @@ class SecurityFilterChainTest extends BaseIntegrationTest {
      * <b>Note</b>: This endpoint should allow Basic Auth (not Bearer) for initial token generation.
      * </p>
      */
+    @Disabled("Auth V2: Basic Auth endpoint removed")
     @Test
     @DisplayName("TC07: Device auth token endpoint with Basic Auth should return 200 OK")
     void deviceAuthTokenEndpointWithBasicAuthShouldBeAuthorized() throws Exception {

--- a/src/test/java/com/bitbi/dfm/site/application/SiteServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/site/application/SiteServiceTest.java
@@ -1,5 +1,6 @@
 package com.bitbi.dfm.site.application;
 
+import com.bitbi.dfm.auth.application.RefreshTokenService;
 import com.bitbi.dfm.batch.domain.Batch;
 import com.bitbi.dfm.batch.domain.BatchRepository;
 import com.bitbi.dfm.deviceauth.domain.DeviceAuthorizationRepository;
@@ -60,6 +61,9 @@ class SiteServiceTest {
     @Mock
     private DeviceAuthorizationRepository deviceAuthorizationRepository;
 
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
     private SiteService siteService;
 
     private UUID accountId;
@@ -70,7 +74,8 @@ class SiteServiceTest {
         accountId = UUID.randomUUID();
         siteId = UUID.randomUUID();
         siteService = new SiteService(siteRepository, batchRepository, errorLogRepository,
-                                      uploadedFileRepository, s3FileStorageService, deviceAuthorizationRepository);
+                                      uploadedFileRepository, s3FileStorageService, deviceAuthorizationRepository,
+                                      refreshTokenService);
     }
 
     @Test
@@ -109,7 +114,7 @@ class SiteServiceTest {
     }
 
     @Test
-    @DisplayName("deactivateSite - Should deactivate active site")
+    @DisplayName("deactivateSite - Should deactivate active site and revoke refresh tokens")
     void deactivateSite_ShouldDeactivateActiveSite() {
         // Given
         Site mockSite = mock(Site.class);
@@ -123,6 +128,7 @@ class SiteServiceTest {
         verify(siteRepository).findById(siteId);
         verify(mockSite).deactivate();
         verify(siteRepository).save(mockSite);
+        verify(refreshTokenService).revokeAllForSite(siteId);
     }
 
     @Test

--- a/src/test/java/com/bitbi/dfm/site/application/SiteServiceTest.java
+++ b/src/test/java/com/bitbi/dfm/site/application/SiteServiceTest.java
@@ -232,7 +232,7 @@ class SiteServiceTest {
     void deleteSite_ShouldHardDeleteWithCascade() {
         // Given
         Site mockSite = mock(Site.class);
-        when(mockSite.getDomain()).thenReturn("test.example.com");
+        when(mockSite.getSiteName()).thenReturn("test.example.com");
         when(siteRepository.findById(siteId)).thenReturn(Optional.of(mockSite));
 
         // Mock batches
@@ -274,49 +274,46 @@ class SiteServiceTest {
     @DisplayName("getOrCreateSiteWithNewCredentials - Should create new site when not exists")
     void getOrCreateSiteWithNewCredentials_ShouldCreateNewSiteWhenNotExists() {
         // Given
-        String domain = "test-site";
+        String siteName = "test-site";
         String displayName = "Test Site";
-        String compositeDomain = accountId + "_" + domain;
 
-        when(siteRepository.findByDomain(compositeDomain)).thenReturn(Optional.empty());
+        when(siteRepository.findByAccountIdAndSiteName(accountId, siteName)).thenReturn(Optional.empty());
         when(siteRepository.save(any(Site.class))).thenAnswer(inv -> inv.getArgument(0));
 
         // When
         SiteService.SiteCreationResult result = siteService.getOrCreateSiteWithNewCredentials(
-                accountId, domain, displayName);
+                accountId, siteName, displayName);
 
         // Then
         assertThat(result.site()).isNotNull();
-        assertThat(result.plaintextSecret()).isNotNull();
-        assertThat(result.plaintextSecret()).isNotBlank();
-        // findByDomain is called twice: once in getOrCreateSiteWithNewCredentials, once in createSite
-        verify(siteRepository, times(2)).findByDomain(compositeDomain);
+        // Auth V2: no credentials generated
+        assertThat(result.plaintextSecret()).isNull();
+        // findByAccountIdAndSiteName is called twice: once in getOrCreateSite, once in createSite
+        verify(siteRepository, times(2)).findByAccountIdAndSiteName(accountId, siteName);
         verify(siteRepository).save(any(Site.class));
     }
 
     @Test
-    @DisplayName("getOrCreateSiteWithNewCredentials - Should regenerate credentials for existing active site")
-    void getOrCreateSiteWithNewCredentials_ShouldRegenerateCredentialsForExistingSite() {
+    @DisplayName("getOrCreateSiteWithNewCredentials - Should return existing active site without credential regeneration")
+    void getOrCreateSiteWithNewCredentials_ShouldReturnExistingActiveSite() {
         // Given
-        String domain = "existing-site";
+        String siteName = "existing-site";
         String displayName = "Existing Site";
-        String compositeDomain = accountId + "_" + domain;
 
         Site existingSite = mock(Site.class);
         when(existingSite.getIsActive()).thenReturn(true);
 
-        when(siteRepository.findByDomain(compositeDomain)).thenReturn(Optional.of(existingSite));
+        when(siteRepository.findByAccountIdAndSiteName(accountId, siteName)).thenReturn(Optional.of(existingSite));
         when(siteRepository.save(existingSite)).thenReturn(existingSite);
 
         // When
         SiteService.SiteCreationResult result = siteService.getOrCreateSiteWithNewCredentials(
-                accountId, domain, displayName);
+                accountId, siteName, displayName);
 
         // Then
         assertThat(result.site()).isEqualTo(existingSite);
-        assertThat(result.plaintextSecret()).isNotNull();
-        assertThat(result.plaintextSecret()).isNotBlank();
-        verify(existingSite).updateClientSecretHash(anyString());
+        // Auth V2: no credentials generated
+        assertThat(result.plaintextSecret()).isNull();
         verify(existingSite, never()).activate(); // Already active
         verify(siteRepository).save(existingSite);
     }
@@ -325,25 +322,24 @@ class SiteServiceTest {
     @DisplayName("getOrCreateSiteWithNewCredentials - Should reactivate deactivated site")
     void getOrCreateSiteWithNewCredentials_ShouldReactivateDeactivatedSite() {
         // Given
-        String domain = "deactivated-site";
+        String siteName = "deactivated-site";
         String displayName = "Deactivated Site";
-        String compositeDomain = accountId + "_" + domain;
 
         Site existingSite = mock(Site.class);
         when(existingSite.getIsActive()).thenReturn(false); // Deactivated
 
-        when(siteRepository.findByDomain(compositeDomain)).thenReturn(Optional.of(existingSite));
+        when(siteRepository.findByAccountIdAndSiteName(accountId, siteName)).thenReturn(Optional.of(existingSite));
         when(siteRepository.save(existingSite)).thenReturn(existingSite);
 
         // When
         SiteService.SiteCreationResult result = siteService.getOrCreateSiteWithNewCredentials(
-                accountId, domain, displayName);
+                accountId, siteName, displayName);
 
         // Then
         assertThat(result.site()).isEqualTo(existingSite);
-        assertThat(result.plaintextSecret()).isNotNull();
+        // Auth V2: no credentials generated
+        assertThat(result.plaintextSecret()).isNull();
         verify(existingSite).activate();
-        verify(existingSite).updateClientSecretHash(anyString());
         verify(siteRepository).save(existingSite);
     }
 }

--- a/src/test/java/com/bitbi/dfm/site/domain/SiteTest.java
+++ b/src/test/java/com/bitbi/dfm/site/domain/SiteTest.java
@@ -157,21 +157,31 @@ class SiteTest {
     /**
      * Helper method to create a Site with a specific domain for testing.
      * Uses reflection to set the domain field since Site.create() validates domain format.
+     * <p>
+     * Sets siteName by extracting from composite domain (stripping UUID prefix),
+     * matching the behavior of getDisplayDomain() which returns siteName first.
+     * </p>
      */
     private Site createSiteWithDomain(String domain) {
         UUID id = UUID.randomUUID();
         UUID accountId = UUID.randomUUID();
         LocalDateTime now = LocalDateTime.now();
 
+        // Derive siteName the same way the production code does
+        String siteName = domain;
+        if (domain != null && domain.length() > 37) {
+            siteName = domain.substring(37);
+        }
+
         // Use reflection to create Site with specific domain
         try {
             java.lang.reflect.Constructor<Site> constructor = Site.class.getDeclaredConstructor(
-                    UUID.class, UUID.class, String.class, String.class,
+                    UUID.class, UUID.class, String.class, String.class, String.class,
                     String.class, Boolean.class, Integer.class, LocalDateTime.class, LocalDateTime.class
             );
             constructor.setAccessible(true);
             return constructor.newInstance(
-                    id, accountId, domain, "$2a$10$dummyHash",
+                    id, accountId, domain, siteName, "$2a$10$dummyHash",
                     "Test Site", true, 45, now, now
             );
         } catch (Exception e) {

--- a/src/test/java/com/bitbi/dfm/site/presentation/SiteAdminControllerTest.java
+++ b/src/test/java/com/bitbi/dfm/site/presentation/SiteAdminControllerTest.java
@@ -83,10 +83,8 @@ class SiteAdminControllerTest {
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertNotNull(response.getBody());
         SiteCreationResponseDto body = response.getBody();
-        assertEquals(testSite.getDomain(), body.domain());
+        assertEquals(testSite.getSiteName(), body.siteName());
         assertEquals(testSite.getDisplayName(), body.name());
-        assertNotNull(body.clientSecret());
-        assertEquals("test-secret-plaintext", body.clientSecret());
         verify(siteService, times(1)).createSite(eq(testAccountId), eq("test.example.com"), eq("Test Site"));
         verify(adminActionLogRepository, times(1)).save(any());
     }
@@ -107,7 +105,7 @@ class SiteAdminControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertNotNull(response.getBody());
         SiteResponseDto body = response.getBody();
-        assertEquals(testSite.getDomain(), body.domain());
+        assertEquals(testSite.getSiteName(), body.siteName());
         assertEquals(testSite.getDisplayName(), body.name());
         verify(siteService, times(1)).getSite(testSiteId);
     }
@@ -133,8 +131,8 @@ class SiteAdminControllerTest {
         assertNotNull(response.getBody());
         List<SiteResponseDto> siteList = response.getBody();
         assertEquals(2, siteList.size());
-        assertEquals("site1.example.com", siteList.get(0).domain());
-        assertEquals("site2.example.com", siteList.get(1).domain());
+        assertEquals("site1.example.com", siteList.get(0).siteName());
+        assertEquals("site2.example.com", siteList.get(1).siteName());
         verify(siteService, times(1)).listSitesByAccount(testAccountId);
     }
 

--- a/src/test/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDtoTest.java
+++ b/src/test/java/com/bitbi/dfm/site/presentation/dto/SiteResponseDtoTest.java
@@ -29,7 +29,7 @@ class SiteResponseDtoTest {
         Site site = mock(Site.class);
         when(site.getId()).thenReturn(id);
         when(site.getAccountId()).thenReturn(accountId);
-        when(site.getDisplayDomain()).thenReturn("example.com"); // Use getDisplayDomain() per FR-019
+        when(site.getSiteName()).thenReturn("example.com");
         when(site.getDisplayName()).thenReturn("Example Site");
         when(site.getIsActive()).thenReturn(true);
         when(site.getRetentionDays()).thenReturn(45);
@@ -42,7 +42,7 @@ class SiteResponseDtoTest {
         assertNotNull(dto);
         assertEquals(id, dto.id());
         assertEquals(accountId, dto.accountId());
-        assertEquals("example.com", dto.domain()); // domain field shows display format only
+        assertEquals("example.com", dto.siteName());
         assertEquals("Example Site", dto.name());
         assertEquals(true, dto.isActive());
         assertEquals(45, dto.retentionDays());
@@ -56,7 +56,7 @@ class SiteResponseDtoTest {
         Site site = mock(Site.class);
         when(site.getId()).thenReturn(UUID.randomUUID());
         when(site.getAccountId()).thenReturn(UUID.randomUUID());
-        when(site.getDisplayDomain()).thenReturn("secure.example.com"); // Use getDisplayDomain() per FR-019
+        when(site.getSiteName()).thenReturn("secure.example.com");
         when(site.getDisplayName()).thenReturn("Secure Site");
         when(site.getIsActive()).thenReturn(true);
         when(site.getRetentionDays()).thenReturn(30);
@@ -74,7 +74,7 @@ class SiteResponseDtoTest {
         assertDoesNotThrow(() -> {
             dto.id();
             dto.accountId();
-            dto.domain();
+            dto.siteName();
             dto.name();
             dto.isActive();
             dto.retentionDays();

--- a/src/test/resources/test-data.sql
+++ b/src/test/resources/test-data.sql
@@ -43,33 +43,33 @@ VALUES ('0199baac-f851-7ed9-5963-00dbaf07b233', 'plugin-test@example.com', 'Plug
 
 -- Test sites (with BCrypt hashed client_secret_hash)
 -- NOTE: After migration V7, column renamed from client_secret to client_secret_hash
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('b2c3d4e5-f6a7-8901-bcde-f12345678901', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'admin-site.example.com', '$2a$10$zOS1.KWMj6b2crXsM1hsh.hssSJghfUH1Wdxx3RMQzzNfK5zzPhBK', 'Admin Test Site', true, '2025-09-11 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('b2c3d4e5-f6a7-8901-bcde-f12345678901', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'admin-site.example.com', '$2a$10$zOS1.KWMj6b2crXsM1hsh.hssSJghfUH1Wdxx3RMQzzNfK5zzPhBK', 'Admin Test Site', true, '2025-09-11 00:00:00', CURRENT_TIMESTAMP, 'admin-site.example.com');
 -- Plaintext: admin-site-secret
 
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('0199baac-f852-753f-6fc3-7c994fc38654', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'store-01.example.com', '$2a$10$w4ybRJqsZPH4IWHXHaN1rukDAfZc6Ri4P45Hpk3mlfbZpHIHYYyBm', 'Store 01', true, '2025-09-21 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('0199baac-f852-753f-6fc3-7c994fc38654', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'store-01.example.com', '$2a$10$w4ybRJqsZPH4IWHXHaN1rukDAfZc6Ri4P45Hpk3mlfbZpHIHYYyBm', 'Store 01', true, '2025-09-21 00:00:00', CURRENT_TIMESTAMP, 'store-01.example.com');
 -- Plaintext: valid-secret-uuid
 
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('0199baaf-ea7a-bd1f-6f6c-8610b9ddc4d7', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'store-02.example.com', '$2a$10$R2zm98c/.YXxfrR3dDvj6uYfGv7ITs7cyqpWwpImC1n/tTq20bQqG', 'Store 02', true, '2025-09-26 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('0199baaf-ea7a-bd1f-6f6c-8610b9ddc4d7', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'store-02.example.com', '$2a$10$R2zm98c/.YXxfrR3dDvj6uYfGv7ITs7cyqpWwpImC1n/tTq20bQqG', 'Store 02', true, '2025-09-26 00:00:00', CURRENT_TIMESTAMP, 'store-02.example.com');
 -- Plaintext: inactive-secret-uuid
 
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('0199bab0-ca3b-e41c-5521-2f4b33fda8b6', '0199bab1-fad2-bf76-c478-eae1f61e1c17', 'store-03.example.com', '$2a$10$8KGp8l7VXbUwby9yQACEEuOYuBApd8uWzSy4hGppksFbIC07MdnB2', 'Store 03', true, '2025-10-01 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('0199bab0-ca3b-e41c-5521-2f4b33fda8b6', '0199bab1-fad2-bf76-c478-eae1f61e1c17', 'store-03.example.com', '$2a$10$8KGp8l7VXbUwby9yQACEEuOYuBApd8uWzSy4hGppksFbIC07MdnB2', 'Store 03', true, '2025-10-01 00:00:00', CURRENT_TIMESTAMP, 'store-03.example.com');
 -- Plaintext: batch-test-secret
 
 -- Sites for AuthenticationIntegrationTest
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('0199bab0-1111-1111-1111-111111111111', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'test-store.example.com', '$2a$10$gMwFxteMaHb0kkSu3vaK7.z1PD7tXwSxtwZz.Ib.tzITdaFg.nbRy', 'Test Store', true, '2025-10-01 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('0199bab0-1111-1111-1111-111111111111', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'test-store.example.com', '$2a$10$gMwFxteMaHb0kkSu3vaK7.z1PD7tXwSxtwZz.Ib.tzITdaFg.nbRy', 'Test Store', true, '2025-10-01 00:00:00', CURRENT_TIMESTAMP, 'test-store.example.com');
 -- Plaintext: test-client-secret-uuid
 
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('0199bab0-2222-2222-2222-222222222222', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'inactive-store.example.com', '$2a$10$H.wcapH9pLI0XcM6Sz1EHeECA2axttsYPjE90GObxmOEkDvgYDEgi', 'Inactive Store', false, '2025-10-01 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('0199bab0-2222-2222-2222-222222222222', 'a1b2c3d4-e5f6-7890-abcd-ef1234567890', 'inactive-store.example.com', '$2a$10$H.wcapH9pLI0XcM6Sz1EHeECA2axttsYPjE90GObxmOEkDvgYDEgi', 'Inactive Store', false, '2025-10-01 00:00:00', CURRENT_TIMESTAMP, 'inactive-store.example.com');
 -- Plaintext: inactive-secret
 
-INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at)
-VALUES ('0199bab0-3333-3333-3333-333333333333', '0199bab2-3cbd-cc95-a989-57ba51d258c8', 'orphaned-store.example.com', '$2a$10$t.QXSUqKLALkr4yq6F5PLuX78.Zl1WDYCKF.ZAXW3oym4XNxMv8aO', 'Orphaned Store (inactive parent)', true, '2025-10-01 00:00:00', CURRENT_TIMESTAMP);
+INSERT INTO sites (id, account_id, domain, client_secret_hash, display_name, is_active, created_at, updated_at, site_name)
+VALUES ('0199bab0-3333-3333-3333-333333333333', '0199bab2-3cbd-cc95-a989-57ba51d258c8', 'orphaned-store.example.com', '$2a$10$t.QXSUqKLALkr4yq6F5PLuX78.Zl1WDYCKF.ZAXW3oym4XNxMv8aO', 'Orphaned Store (inactive parent)', true, '2025-10-01 00:00:00', CURRENT_TIMESTAMP, 'orphaned-store.example.com');
 -- Plaintext: orphaned-secret
 
 -- Test batches


### PR DESCRIPTION
## Summary

- **Refresh token infrastructure**: `RefreshToken` entity + `RefreshTokenService` with SHA-256 hashing, token rotation, and `POST /api/v1/device/auth/refresh` endpoint
- **Remove composite domain**: Add `site_name` column (V27 migration), replace `{accountId}_{siteName}` pattern with `(account_id, site_name)` composite key, allow unicode site names
- **Remove Basic Auth**: Device Flow now returns JWT (1h) + refresh token (90d) directly — no more credential storage on sites
- **Update JWT claims**: Remove `domain` claim, use `siteId` + `accountId` only
- **Update S3 paths**: Use `siteId` instead of composite domain for new batches (dual-path: old data unaffected)
- **Frontend**: Update types, forms, and components for new site model (no domain field, unicode support)
- **Migration guide**: `docs/auth-v2-migration-guide.md` for client migration

## BREAKING CHANGES

| Before | After |
|--------|-------|
| `POST /api/v1/device/auth/token` (Basic Auth) | Removed — use Device Flow |
| Device Flow returns `{domain, clientSecret}` | Returns `{accessToken, refreshToken, siteId, siteName}` |
| JWT contains `domain` claim | JWT contains `siteId` + `accountId` only |
| Site names restricted to `[a-zA-Z0-9.-]` | Unicode allowed |
| S3 path: `{accountId}/{compositeDomain}/...` | `{accountId}/{siteId}/...` |

## Test plan

- [x] All 1070 unit/integration tests pass (0 failures)
- [x] 44 tests skipped (deprecated Basic Auth endpoints, properly annotated with `@Disabled`)
- [ ] Manual test: Device Flow → JWT + refresh token → batch upload → token refresh rotation
- [ ] Verify V27 migration on staging DB (site_name populated from composite domain)
- [ ] Verify S3 dual-path: old batches readable, new batches use siteId paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)