### PR TITLE
ci: pin LocalStack image to 3.8 (fix backend-test)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -72,7 +72,9 @@ jobs:
           --health-retries 5
 
       localstack:
-        image: localstack/localstack:latest
+        # Pinned to the community edition used by Testcontainers (TestContainersManager).
+        # `:latest` now requires LOCALSTACK_AUTH_TOKEN and fails container init.
+        image: localstack/localstack:3.8
         env:
           SERVICES: s3
           DEFAULT_REGION: us-east-1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -41,7 +41,7 @@ services:
       - dfm-network
 
   localstack:
-    image: localstack/localstack:stable
+    image: localstack/localstack:3.8
     container_name: dfm-localstack
     environment:
       SERVICES: s3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - dfm-network
 
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:3.8
     container_name: dfm-localstack
     environment:
       SERVICES: s3


### PR DESCRIPTION
## Problem

`backend-test` fails on every PR at the **Initialize containers** step:

> LocalStack returning with exit code 55. License activation failed! 🔑❌ — No credentials were found in the environment. Please set the LOCALSTACK_AUTH_TOKEN variable...

The CI `localstack` service used `localstack/localstack:latest`, whose recent builds (2026.5.x) require a license token and exit unhealthy, aborting the job before tests run. This is pre-existing infra breakage, surfaced now that `backend-test` is a required check on `develop`.

## Fix

Pin LocalStack to **`3.8`** — the community edition already used by the test suite via Testcontainers (`TestContainersManager`). Applied to `ci-cd.yml` and both `docker-compose*.yml` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)